### PR TITLE
ARCH1: Add cinder backups

### DIFF
--- a/validated_arch_1/stage6/openstackcontrolplane.yaml
+++ b/validated_arch_1/stage6/openstackcontrolplane.yaml
@@ -29,6 +29,11 @@ spec:
         networkAttachments:
           - storage
         replicas: 1
+        customServiceConfig: |
+          [DEFAULT]
+          backup_driver=cinder.backup.drivers.ceph.CephBackupDriver
+          backup_ceph_pool=backups
+          backup_ceph_user=openstack
       cinderScheduler:
         replicas: 1
       cinderVolumes:


### PR DESCRIPTION
This patch adds the cinder backup using Ceph configuration to stage 6.

The documentation gdoc has new suggestions to create the "backups" pool and provide access to it.