### PR TITLE
Add comment about MTU 9000 setting

### DIFF
--- a/validated_arch_1/stage3/ocp_node_0_nncp.yaml
+++ b/validated_arch_1/stage3/ocp_node_0_nncp.yaml
@@ -76,6 +76,9 @@ spec:
         dhcp: false
       ipv6:
         enabled: false
+      # MTU 9000 is used to access Ceph via the storage network
+      # If storage network is on its own NIC adjust accordingly
+      # Using >1 NIC is not currently represented in these CRs
       mtu: 9000
       name: enp7s0 # CHANGEME
       state: up


### PR DESCRIPTION
Red Hat Ceph documentation recommends MTU 9000 (see the end of section 2.4 of [1]). Since enp7s0 is hosting Ceph traffic this setting of 9000 is correct.

Add a comment next to the setting stating that in our case there's one NIC, enp7s0 so we used that MTU. But if an environment has >1 NIC and the storage traffic is only on a particular NIC, then we could use a different MTU for other NICs.

[1] https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/6/html/hardware_guide/general-principles-for-selecting-hardware#network-considerations-for-red-hat-ceph-storage_hw