### PR TITLE
Explain why storage mgmt has no NetAttach

### DIFF
--- a/validated_arch_1/stage3/README.md
+++ b/validated_arch_1/stage3/README.md
@@ -15,6 +15,11 @@ oc wait nncp -l osp/interface=enp7s0 --for condition=available --timeout=300s
 oc apply -f netattach_ctlplane.yaml -f netattach_internalapi.yaml -f netattach_storage.yaml -f netattach_tenant.yaml
 ```
 3. Create MetalLB resources
+
 ```bash
 oc apply -f metallb_ipaddresspools.yaml -f metallb_l2advertisement.yaml
 ```
+
+A NetworkAttachmentDefinition is not required for storage management
+network since that network is used by OpenStackDataPlane nodes but not
+OpenStack pods hosted on OpenShift in this architecture.


### PR DESCRIPTION
NetworkAttachmentDefinition files exist for all
networks except for storage management by design.
Add statement about why this is the case so it is
not thought to be a mistake.