### PR TITLE
Update VA1 to use Glance image conversion

### DIFF
--- a/validated_arch_1/stage6/README.md
+++ b/validated_arch_1/stage6/README.md
@@ -12,22 +12,26 @@ Assumes that a Ceph cluster is available
 ```bash
 oc apply -f ceph_secret.yaml -f nova_ceph.yaml
 ```
-2. Update OpenStackControlPlane and wait for it to finish
+2. Create image conversion PVC
+```bash
+oc apply -f image_conversion_pvc.yaml
+```
+3. Update OpenStackControlPlane and wait for it to finish
 ```bash
 oc apply -f openstackcontrolplane.yaml
 oc wait osctlplane openstack-galera-network-isolation-3replicas --for condition=Ready --timeout=300s
 ```
-3. Update OpenStackDataPlaneNodeSet
+4. Update OpenStackDataPlaneNodeSet
 ```bash
 oc apply -f openstackdataplanenodeset.yaml
 ```
-4. Recreate OpenStackDataPlaneDeployment and wait for it to finish
+5. Recreate OpenStackDataPlaneDeployment and wait for it to finish
 ```bash
 oc delete -f openstackdataplanedeployment.yaml
 oc apply -f openstackdataplanedeployment.yaml
 oc wait osdpd openstack-edpm-ipam --for condition=Ready --timeout=720s
 ```
-5. Force Nova to discover all compute hosts
+6. Force Nova to discover all compute hosts
 ```bash
 oc rsh nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
 ```

--- a/validated_arch_1/stage6/image_conversion_pvc.yaml
+++ b/validated_arch_1/stage6/image_conversion_pvc.yaml
@@ -1,0 +1,19 @@
+# CHANGEME:
+#
+# - Change the storage size of the requested PVC to be as large as your largest
+#   expected image after it has been converted into RAW format with a command
+#   like `qemu-img convert -f qcow2 -O raw cirros.img cirros.raw`. When an image
+#   is uploaded, Glance will use this space to convert it to RAW so that Ceph
+#   can create volumes and VMs from the image efficiently using COW references.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: image-import-staging
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi  # CHANGEME
+  storageClassName: local-storage

--- a/validated_arch_1/stage6/openstackcontrolplane.yaml
+++ b/validated_arch_1/stage6/openstackcontrolplane.yaml
@@ -113,6 +113,7 @@ spec:
       customServiceConfig: |
         [DEFAULT]
         enabled_backends = default_backend:rbd
+        enabled_import_methods=[web-download,glance-direct]
         [glance_store]
         default_backend = default_backend
         [default_backend]
@@ -120,6 +121,10 @@ spec:
         store_description = "RBD backend"
         rbd_store_pool = images
         rbd_store_user = openstack
+        [image_import_opts]
+        image_import_plugins = ['image_conversion']
+        [image_conversion]
+        output_format = raw
   heat:
     apiOverride:
       route: {}
@@ -392,7 +397,14 @@ spec:
                 sources:
                   - secret:
                       name: ceph-conf-files
+            - name: image-import-staging
+              persistentVolumeClaim:
+                claimName: image-import-staging
+                readOnly: false
           mounts:
             - name: ceph
               mountPath: /etc/ceph
               readOnly: true
+            - name: image-import-staging
+              mountPath: /var/lib/glance/os_glance_staging_store/
+              readOnly: false


### PR DESCRIPTION
Add a CR for a PVC where Glance can convert images. Upadate OpenStackControlPlane CR to use the PVC. Also add `enabled_import_methods` with `glance-direct` to `customServiceConfig` sample because a popular way to import an image when conversion is used is with `openstack image create --import` since it forces the use of the import plugin instead of a direct upload.

A qcow2 image which is made into a bootable volume by running:
```
IMG=cirros-0.5.2-x86_64-disk.img
openstack image create my_img --disk-format raw --file $IMG --import
openstack volume create --size 8 my_vol --image $(openstack image show my_img -f value -c id)
```
should show up in the Ceph volumes pool with a reference to its parent in the images pool:
```
[ceph: root@edpm-compute-1 /]# rbd -p volumes ls -l
NAME                                         SIZE   PARENT                                            FMT  PROT  LOCK
volume-5ec39434-9674-4fa8-8ebf-ef0ce8dc22e2  8 GiB  images/d0285227-739d-424c-b4f2-938ee49eb0cc@snap    2
[ceph: root@edpm-compute-1 /]#
```
The above will happen because after the qcow2 file is uploaded, Glance will use the staging area to convert it to a RAW format before import into Ceph. If a volume created from image does not have a parent, then the image was not converted and a full copy was made in the volumes pool.

Jira: OSP-29527