### PR TITLE
Simplify HCI deployment with servicesOverride

### DIFF
--- a/validated_arch_1/stage5/openstackdataplanedeployment.yaml
+++ b/validated_arch_1/stage5/openstackdataplanedeployment.yaml
@@ -6,3 +6,10 @@ metadata:
 spec:
   nodeSets:
   - openstack-edpm-ipam
+  servicesOverride:
+    - configure-network
+    - validate-network
+    - install-os
+    - ceph-hci-pre
+    - configure-os
+    - run-os

--- a/validated_arch_1/stage5/openstackdataplanenodeset.yaml
+++ b/validated_arch_1/stage5/openstackdataplanenodeset.yaml
@@ -162,11 +162,6 @@ spec:
       hostName: edpm-compute-1
     edpm-compute-2:
       hostName: edpm-compute-2
-  services:
-    - configure-network
-    - validate-network
-    - download-cache
-    - install-os
-    - ceph-hci-pre
-    - configure-os
-    - run-os
+  # Each OpenStackDataPlaneDeployment will override
+  # the services list so it is empty.
+  services: []

--- a/validated_arch_1/stage6/openstackdataplanedeployment.yaml
+++ b/validated_arch_1/stage6/openstackdataplanedeployment.yaml
@@ -6,3 +6,8 @@ metadata:
 spec:
   nodeSets:
   - openstack-edpm-ipam
+  servicesOverride:
+    - ceph-client
+    - ovn
+    - libvirt
+    - nova-custom-ceph

--- a/validated_arch_1/stage6/openstackdataplanenodeset.yaml
+++ b/validated_arch_1/stage6/openstackdataplanenodeset.yaml
@@ -147,15 +147,6 @@ spec:
       hostName: edpm-compute-1
     edpm-compute-2:
       hostName: edpm-compute-2
-  services:
-    - configure-network
-    - validate-network
-    - download-cache
-    - install-os
-    - ceph-hci-pre
-    - configure-os
-    - run-os
-    - ceph-client
-    - ovn
-    - libvirt
-    - nova-custom-ceph
+  # Each OpenStackDataPlaneDeployment will override
+  # the services list so it is empty.
+  services: []


### PR DESCRIPTION
Use servicesOverride feature of OpenStackDataPlaneDeployment to make HCI example more clear. Instead of having human operator edit the services list before creating a second deployment, provide two deployment examples which can be run before and after Ceph is deployed.

Jira: OSP-29040