### PR TITLE
stage6: deploy metadata agent

### DIFF
--- a/validated_arch_1/stage6/openstackdataplanedeployment.yaml
+++ b/validated_arch_1/stage6/openstackdataplanedeployment.yaml
@@ -9,5 +9,6 @@ spec:
   servicesOverride:
     - ceph-client
     - ovn
+    - neutron-metadata
     - libvirt
     - nova-custom-ceph


### PR DESCRIPTION
Since [1], ovn service no longer deploys metadata agent. We should select it explicitly.

[1] https://github.com/openstack-k8s-operators/dataplane-operator/pull/445