### PR TITLE
ovn: remove external-ids from the spec

### DIFF
--- a/validated_arch_1/stage4/openstackcontrolplane.yaml
+++ b/validated_arch_1/stage4/openstackcontrolplane.yaml
@@ -253,10 +253,6 @@ spec:
   ovn:
     template:
       ovnController:
-        external-ids:
-          ovn-bridge: br-int
-          ovn-encap-type: geneve
-          system-id: random
         networkAttachment: tenant
       ovnDBCluster:
         ovndbcluster-nb:

--- a/validated_arch_1/stage6/openstackcontrolplane.yaml
+++ b/validated_arch_1/stage6/openstackcontrolplane.yaml
@@ -302,10 +302,6 @@ spec:
   ovn:
     template:
       ovnController:
-        external-ids:
-          ovn-bridge: br-int
-          ovn-encap-type: geneve
-          system-id: random
         networkAttachment: tenant
       ovnDBCluster:
         ovndbcluster-nb:


### PR DESCRIPTION
These are default values and should apply implicitly since [1].

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/64

Draft for now since I'd like to first make sure myself this works (if applied via openstackCP, not directly through ovnController CRD.)