### PR TITLE
Drop certain network Ansible vars and rename metadata agent key

### DIFF
--- a/validated_arch_1/stage5/openstackdataplanenodeset.yaml
+++ b/validated_arch_1/stage5/openstackdataplanenodeset.yaml
@@ -98,12 +98,12 @@ spec:
                   {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
               routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
           {% endfor %}
+        edpm_neutron_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}'
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
         edpm_nova_compute_container_image: '{{ registry_url }}/openstack-nova-compute:{{ image_tag }}'
         edpm_nova_libvirt_container_image: '{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}'
         edpm_ovn_controller_agent_image: '{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}'
-        edpm_ovn_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}'
         edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24 # CHANGEME
@@ -111,20 +111,9 @@ spec:
         enable_debug: false
         gather_facts: false
         image_tag: current-podified
-        networks_lower:
-          External: external
-          InternalApi: internal_api
-          Storage: storage
-          Tenant: tenant
-          StorageMgmt: storage_mgmt
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth0
         registry_url: quay.io/podified-antelope-centos9
-        role_networks:
-          - InternalApi
-          - Storage
-          - Tenant
-          - StorageMgmt
         service_net_map:
           nova_api_network: internal_api
           nova_libvirt_network: internal_api

--- a/validated_arch_1/stage6/openstackdataplanenodeset.yaml
+++ b/validated_arch_1/stage6/openstackdataplanenodeset.yaml
@@ -73,12 +73,12 @@ spec:
                   {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
               routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
           {% endfor %}
+        edpm_neutron_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}'
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
         edpm_nova_compute_container_image: '{{ registry_url }}/openstack-nova-compute:{{ image_tag }}'
         edpm_nova_libvirt_container_image: '{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}'
         edpm_ovn_controller_agent_image: '{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}'
-        edpm_ovn_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}'
         edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
@@ -86,20 +86,9 @@ spec:
         enable_debug: false
         gather_facts: false
         image_tag: current-podified
-        networks_lower:
-          External: external
-          InternalApi: internal_api
-          Storage: storage
-          Tenant: tenant
-          StorageMgmt: storage_mgmt
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth0
         registry_url: quay.io/podified-antelope-centos9
-        role_networks:
-          - InternalApi
-          - Storage
-          - Tenant
-          - StorageMgmt
         service_net_map:
           nova_api_network: internal_api
           nova_libvirt_network: internal_api


### PR DESCRIPTION
The network vars are automatically calculated now by the data plane operator and the metadata agent key was simply renamed