### PR TITLE
Fix data plane services

### DIFF
--- a/validated_arch_1/stage5/openstackdataplanedeployment.yaml
+++ b/validated_arch_1/stage5/openstackdataplanedeployment.yaml
@@ -6,10 +6,6 @@ metadata:
 spec:
   nodeSets:
   - openstack-edpm-ipam
-  servicesOverride:
-    - configure-network
-    - validate-network
-    - install-os
-    - ceph-hci-pre
-    - configure-os
-    - run-os
+  # Listing the OpenStackDataPlaneServices here does work unless they
+  # have been pre-created manually by the user
+  servicesOverride: []

--- a/validated_arch_1/stage5/openstackdataplanenodeset.yaml
+++ b/validated_arch_1/stage5/openstackdataplanenodeset.yaml
@@ -151,6 +151,12 @@ spec:
       hostName: edpm-compute-1
     edpm-compute-2:
       hostName: edpm-compute-2
-  # Each OpenStackDataPlaneDeployment will override
-  # the services list so it is empty.
-  services: []
+  # The OpenStackDataPlaneServices must be declared here, otherwise the
+  # data plane controller will not create them
+  services:
+    - configure-network
+    - validate-network
+    - install-os
+    - ceph-hci-pre
+    - configure-os
+    - run-os

--- a/validated_arch_1/stage6/openstackdataplanedeployment.yaml
+++ b/validated_arch_1/stage6/openstackdataplanedeployment.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   nodeSets:
   - openstack-edpm-ipam
-  servicesOverride:
-    - ceph-client
-    - ovn
-    - neutron-metadata
-    - libvirt
-    - nova-custom-ceph
+  # Listing the OpenStackDataPlaneServices here does work unless they
+  # have been pre-created manually by the user
+  servicesOverride: []

--- a/validated_arch_1/stage6/openstackdataplanenodeset.yaml
+++ b/validated_arch_1/stage6/openstackdataplanenodeset.yaml
@@ -136,6 +136,11 @@ spec:
       hostName: edpm-compute-1
     edpm-compute-2:
       hostName: edpm-compute-2
-  # Each OpenStackDataPlaneDeployment will override
-  # the services list so it is empty.
-  services: []
+  # The OpenStackDataPlaneServices must be declared here, otherwise the
+  # data plane controller will not create them
+  services:
+    - ceph-client
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova-custom-ceph


### PR DESCRIPTION
Unfortunately, using the `OpenStackDataPlaneDeployment.spec.servicesOverride` assumes that the actual `OpenStackDataPlaneService` CRs have been created beforehand.  On the other hand, any services include in the `OpenStackDataPlaneNodeSet.spec.services` list are automatically created by the data plane controller itself.  Since we don't want to burden the user with manually creating these, let's switch back to using `OpenStackDataPlaneNodeSet.spec.services` for now.