### PR TITLE
Do not put empty services list in OpenStackDataPlaneNodeSet

### DIFF
--- a/validated_arch_1/stage5/openstackdataplanenodeset.yaml
+++ b/validated_arch_1/stage5/openstackdataplanenodeset.yaml
@@ -152,5 +152,7 @@ spec:
     edpm-compute-2:
       hostName: edpm-compute-2
   # Each OpenStackDataPlaneDeployment will override
-  # the services list so it is empty.
-  services: []
+  # the services list. When the services list is
+  # omitted from OpenStackDataPlaneNodeSet the default
+  # service list defined in the operator will be used
+  # and created.

--- a/validated_arch_1/stage6/openstackdataplanenodeset.yaml
+++ b/validated_arch_1/stage6/openstackdataplanenodeset.yaml
@@ -137,5 +137,7 @@ spec:
     edpm-compute-2:
       hostName: edpm-compute-2
   # Each OpenStackDataPlaneDeployment will override
-  # the services list so it is empty.
-  services: []
+  # the services list. When the services list is
+  # omitted from OpenStackDataPlaneNodeSet the default
+  # service list defined in the operator will be used
+  # and created.


### PR DESCRIPTION
If the services field is omitted from the spec in OpenStackDataPlaneNodeSet, then the default services list in the dataplane-operator will be created.

The problem with having a services list in NodeSet but setting it to an empty list is that the services will not be created. By omitting the field we can get the services created but also have a clear interface where the user can define their services in the deployment for pre and post ceph as originally introduced by eaf0392b1bd1a52d0728be8d1aef54b4360dcd3c