### PR TITLE
Define full service list in OpenStackDataPlaneNodeSet

### DIFF
--- a/validated_arch_1/stage5/openstackdataplanenodeset.yaml
+++ b/validated_arch_1/stage5/openstackdataplanenodeset.yaml
@@ -152,7 +152,19 @@ spec:
     edpm-compute-2:
       hostName: edpm-compute-2
   # Each OpenStackDataPlaneDeployment will override
-  # the services list. When the services list is
-  # omitted from OpenStackDataPlaneNodeSet the default
-  # service list defined in the operator will be used
-  # and created.
+  # the services list so that only a subset of them
+  # are deployed during different phases. The full
+  # service list is defined here so that each service
+  # will be created by the dataplane-operator.
+  services:
+    - configure-network
+    - validate-network
+    - install-os
+    - ceph-hci-pre
+    - configure-os
+    - run-os
+    - ceph-client
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova-custom-ceph

--- a/validated_arch_1/stage6/openstackdataplanenodeset.yaml
+++ b/validated_arch_1/stage6/openstackdataplanenodeset.yaml
@@ -137,7 +137,19 @@ spec:
     edpm-compute-2:
       hostName: edpm-compute-2
   # Each OpenStackDataPlaneDeployment will override
-  # the services list. When the services list is
-  # omitted from OpenStackDataPlaneNodeSet the default
-  # service list defined in the operator will be used
-  # and created.
+  # the services list so that only a subset of them
+  # are deployed during different phases. The full
+  # service list is defined here so that each service
+  # will be created by the dataplane-operator.
+  services:
+    - configure-network
+    - validate-network
+    - install-os
+    - ceph-hci-pre
+    - configure-os
+    - run-os
+    - ceph-client
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova-custom-ceph


### PR DESCRIPTION
Follow up to ab1a80a0e75e6c555a235d39e1ebf29dd6daa60f

The ceph-hci-pre and ceph-client services will not be created by default so the services list cannot be empty if we want the dataplane operator to define these services for the user. Thus, put all services which will be used in the OpenStackDataPlaneNodeSet so they will be created. We still rely on the servicesOverride in each deployment however to identify which subset of services are deployed when.