### PR TITLE
Rename OpenStackDataPlaneDeployment so it's not deleted

### DIFF
--- a/validated_arch_1/stage5/README.md
+++ b/validated_arch_1/stage5/README.md
@@ -12,8 +12,8 @@ oc apply -f dataplanesshsecret.yaml
 ```bash
 oc apply -f openstackdataplanenodeset.yaml
 ```
-3. Create OpenStackDataPlaneDeployment and wait for it to finish
+3. Create pre-Ceph OpenStackDataPlaneDeployment and wait for it to finish
 ```bash
 oc apply -f openstackdataplanedeployment.yaml
-oc wait osdpd openstack-edpm-ipam --for condition=Ready --timeout=720s
+oc wait osdpd deployment-pre-ceph --for condition=Ready --timeout=720s
 ```

--- a/validated_arch_1/stage5/openstackdataplanedeployment.yaml
+++ b/validated_arch_1/stage5/openstackdataplanedeployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: openstack-edpm-ipam
+  name: deployment-pre-ceph
   namespace: openstack
 spec:
   nodeSets:

--- a/validated_arch_1/stage6/README.md
+++ b/validated_arch_1/stage6/README.md
@@ -25,11 +25,10 @@ oc wait osctlplane openstack-galera-network-isolation-3replicas --for condition=
 ```bash
 oc apply -f openstackdataplanenodeset.yaml
 ```
-5. Recreate OpenStackDataPlaneDeployment and wait for it to finish
+5. Create a post-Ceph OpenStackDataPlaneDeployment and wait for it to finish
 ```bash
-oc delete -f openstackdataplanedeployment.yaml
 oc apply -f openstackdataplanedeployment.yaml
-oc wait osdpd openstack-edpm-ipam --for condition=Ready --timeout=720s
+oc wait osdpd deployment-post-ceph --for condition=Ready --timeout=720s
 ```
 6. Force Nova to discover all compute hosts
 ```bash

--- a/validated_arch_1/stage6/openstackdataplanedeployment.yaml
+++ b/validated_arch_1/stage6/openstackdataplanedeployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: openstack-edpm-ipam
+  name: deployment-post-ceph
   namespace: openstack
 spec:
   nodeSets:


### PR DESCRIPTION
Rename stage5 deloyment from openstack-edpm-ipam to deployment-pre-ceph 
Rename stage6 deloyment from openstack-edpm-ipam to deployment-post-ceph

Do not instruct user to delete their pre-ceph deployment as the logs will be removed. Instead have them create a second deployment. Both can continue to exist after Ansible runs as a record of what deployments have happened.