### PR TITLE
Change image-import-staging PVC to WRO

### DIFF
--- a/validated_arch_1/stage6/image_conversion_pvc.yaml
+++ b/validated_arch_1/stage6/image_conversion_pvc.yaml
@@ -12,7 +12,7 @@ metadata:
   name: image-import-staging
 spec:
   accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
   resources:
     requests:
       storage: 5Gi  # CHANGEME


### PR DESCRIPTION
The PVC for Glance import does not need to be ReadWriteMany. ReadWriteOnce is sufficient even if there are >1 replicas since Glance can support distributed-image-import.

https://opendev.org/openstack/glance/commit/41e1cecbe63c778ce8e92519993c61588ea1f0cb