### PR TITLE
Move VA1 to the new GlanceAPI definition

### DIFF
--- a/validated_arch_1/stage4/openstackcontrolplane.yaml
+++ b/validated_arch_1/stage4/openstackcontrolplane.yaml
@@ -75,10 +75,7 @@ spec:
       route: {}
     template:
       databaseInstance: openstack
-      glanceAPIExternal:
-        networkAttachments:
-          - storage
-      glanceAPIInternal:
+      glanceAPI:
         networkAttachments:
           - storage
         override:

--- a/validated_arch_1/stage6/openstackcontrolplane.yaml
+++ b/validated_arch_1/stage6/openstackcontrolplane.yaml
@@ -93,10 +93,7 @@ spec:
       route: {}
     template:
       databaseInstance: openstack
-      glanceAPIExternal:
-        networkAttachments:
-          - storage
-      glanceAPIInternal:
+      glanceAPI:
         networkAttachments:
           - storage
         override:


### PR DESCRIPTION
Glance moved to a new API definition via [1][2] and this patch aligns VA1 to the current changes.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/514

[1] https://github.com/openstack-k8s-operators/glance-operator/pull/329
[2] https://github.com/openstack-k8s-operators/openstack-operator/pull/514