### PR TITLE
Configure glanceAPI with no replicas at stage 4

### DIFF
--- a/validated_arch_1/stage4/openstackcontrolplane.yaml
+++ b/validated_arch_1/stage4/openstackcontrolplane.yaml
@@ -76,6 +76,7 @@ spec:
     template:
       databaseInstance: openstack
       glanceAPI:
+        replicas: 0
         networkAttachments:
           - storage
         override:

--- a/validated_arch_1/stage6/openstackcontrolplane.yaml
+++ b/validated_arch_1/stage6/openstackcontrolplane.yaml
@@ -94,6 +94,7 @@ spec:
     template:
       databaseInstance: openstack
       glanceAPI:
+        replicas: 1
         networkAttachments:
           - storage
         override:


### PR DESCRIPTION
During `stage 4` we stand up the `openstackcontrolplane`, including `glanceAPI`, but no backend is set. `Ceph` and the `Glance` configuration come with `stage 6`, and in that case it makes sense to increase the number of replicas.
This avoid situations where people try to upload an image using `file` as a `backend` (which is the default for development reasons), and then try to get the image after `stage 6` and expect to find it in the `Ceph` backend.
In this case the image exists as an entry in the database, but it's no longer available.
Moving `GlanceAPI` to `replicas: 0` at `stage 4` is a safe default to reduce the amount of issues between the `stage 4` and `stage 6` timeframe.