### PR TITLE
Clarify use of pre-provisioned computes

### DIFF
--- a/va/hci/stage1/README.md
+++ b/va/hci/stage1/README.md
@@ -4,7 +4,7 @@ Install the dependencies for Red Hat OpenStack Services on OpenShift operators
 
 ## Notes
 
-Requires an OpenShift 4.12+ cluster with 3 master/worker combo-nodes, with Metal3 and a provisioning network available
+Requires an OpenShift 4.12+ cluster with 3 master/worker combo-nodes
 
 ## Steps
 

--- a/va/hci/stage5/README.md
+++ b/va/hci/stage5/README.md
@@ -2,6 +2,12 @@
 
 Deploy the initial data plane to prepare for CephHCI installation
 
+## Notes
+
+Requires 3 pre-provisioned compute nodes that are accessible via the control plane IPs
+enumerated in step 2's `OpenStackDataPlaneNodeSet` using the SSH credentials provided
+in step 1's `Secret`.
+
 ## Steps
 
 1. Create SSH Secret


### PR DESCRIPTION
Removes a reference to Metal3 provisioning and directly notes the use of pre-provisioned computes instead