### PR TITLE
Align the existing va/hci stages to the new Glance CRD

### DIFF
--- a/va/hci/stage4/openstackcontrolplane.yaml
+++ b/va/hci/stage4/openstackcontrolplane.yaml
@@ -71,22 +71,25 @@ spec:
         secret: osp-secret
         storageRequest: 500M
   glance:
-    apiOverride:
-      route: {}
+    apiOverrides:
+      default:
+        route: {}
     template:
       databaseInstance: openstack
-      glanceAPI:
-        networkAttachments:
-          - storage
-        override:
-          service:
-            metadata:
-              annotations:
-                metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/allow-shared-ip: internalapi
-                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-            spec:
-              type: LoadBalancer
+      glanceAPIs:
+        default:
+          replicas: 1
+          networkAttachments:
+            - storage
+          override:
+            service:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
       storageClass: ""
       storageRequest: 10G
   heat:

--- a/va/hci/stage6/openstackcontrolplane.yaml
+++ b/va/hci/stage6/openstackcontrolplane.yaml
@@ -89,22 +89,25 @@ spec:
         secret: osp-secret
         storageRequest: 500M
   glance:
-    apiOverride:
-      route: {}
+    apiOverrides:
+      default:
+        route: {}
     template:
       databaseInstance: openstack
-      glanceAPI:
-        networkAttachments:
-          - storage
-        override:
-          service:
-            metadata:
-              annotations:
-                metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/allow-shared-ip: internalapi
-                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-            spec:
-              type: LoadBalancer
+      glanceAPIs:
+        default:
+          replicas: 1
+          networkAttachments:
+            - storage
+          override:
+            service:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
       storageClass: ""
       storageRequest: 10G
       customServiceConfig: |


### PR DESCRIPTION
We recently updated the `Glance` service and it's now able to deploy a list of `glanceAPI` to cover several use cases. As part of this effort this patch updates the existing `va/hci` `openstackcontrolplane` `CRs` to match the new `CRD`.