### PR TITLE
Revert "Configure glanceAPI with no replicas at stage 4"

### DIFF
--- a/va/hci/stage4/openstackcontrolplane.yaml
+++ b/va/hci/stage4/openstackcontrolplane.yaml
@@ -76,7 +76,6 @@ spec:
     template:
       databaseInstance: openstack
       glanceAPI:
-        replicas: 0
         networkAttachments:
           - storage
         override:

--- a/va/hci/stage6/openstackcontrolplane.yaml
+++ b/va/hci/stage6/openstackcontrolplane.yaml
@@ -94,7 +94,6 @@ spec:
     template:
       databaseInstance: openstack
       glanceAPI:
-        replicas: 1
         networkAttachments:
           - storage
         override:


### PR DESCRIPTION
Reverts openstack-k8s-operators/architecture#33

We currently have issues with network isolation because the ensureNAD code is still not skipped in the glance-operator, causing the OpenStackControlPlane to not converge. 
This happens because [1] set the `NetworkReady` to false, and we might need some logic to skip that part before changing this value here.
Hopefully this will be addressed by [2], but we're going to double check if extra logic is needed to manage `replicas=0`.

[1] https://github.com/openstack-k8s-operators/lib-common/blob/f7a552f208e7981290c98b7f08c4ae078eadd4a3/modules/common/networkattachment/networkattachment.go#L127-L134
[2] https://github.com/openstack-k8s-operators/glance-operator/pull/384