### PR TITLE
Fix Glance internal service network override

### DIFF
--- a/va/hci/stage4/openstackcontrolplane.yaml
+++ b/va/hci/stage4/openstackcontrolplane.yaml
@@ -83,13 +83,14 @@ spec:
             - storage
           override:
             service:
-              metadata:
-                annotations:
-                  metallb.universe.tf/address-pool: internalapi
-                  metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-              spec:
-                type: LoadBalancer
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                spec:
+                  type: LoadBalancer
       storageClass: ""
       storageRequest: 10G
   heat:

--- a/va/hci/stage6/openstackcontrolplane.yaml
+++ b/va/hci/stage6/openstackcontrolplane.yaml
@@ -101,13 +101,14 @@ spec:
             - storage
           override:
             service:
-              metadata:
-                annotations:
-                  metallb.universe.tf/address-pool: internalapi
-                  metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-              spec:
-                type: LoadBalancer
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                spec:
+                  type: LoadBalancer
       storageClass: ""
       storageRequest: 10G
       customServiceConfig: |


### PR DESCRIPTION
We have changed the network override structure for Glance, which we need to reflect in our `OpenStackControlPlane` CRs.