### PR TITLE
Use vanity names for L2 advertisement

### DIFF
--- a/examples/va/hci/values.yaml
+++ b/examples/va/hci/values.yaml
@@ -71,7 +71,7 @@ data:
         vlan: 20
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.20
+    iface: internalapi
     vlan: 20
     base_iface: enp7s0
     lb_addresses:
@@ -104,7 +104,7 @@ data:
         vlan: 21
     mtu: 9000
     prefix-length: 24
-    iface: enp7s0.21
+    iface: storage
     vlan: 21
     base_iface: enp7s0
     lb_addresses:
@@ -143,7 +143,7 @@ data:
         vlan: 22
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.22
+    iface: tenant
     vlan: 22
     base_iface: enp7s0
     lb_addresses:


### PR DESCRIPTION
Use the interface vanity names referenced by NNCP within the L2 advertisement configuration.