### PR TITLE
Add missing links now that the SRIOV VA has merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ It may also be used to create deployed topologies
 The following VAs are available.
 
 - [Hyperconverged OpenStack and Ceph](examples/va/hci/)
-- [Network Function Virtualization with SRIOV](examples/va/nfv/sriov/)
+- [Network Functions Virtualization with SRIOV](examples/va/nfv/sriov/)

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ It may also be used to create deployed topologies
 The following VAs are available.
 
 - [Hyperconverged OpenStack and Ceph](examples/va/hci/)
+- [Network Function Virtualization with SRIOV](examples/va/nfv/sriov/)

--- a/docs/wa/missing_nncp.md
+++ b/docs/wa/missing_nncp.md
@@ -1,0 +1,72 @@
+# Missing NNCPs
+
+The following command defines the OpenStack control plane and its
+dependent CRs.
+```bash
+kustomize build architecture/examples/va/hci > control-plane.yaml
+```
+The `control-plane.yaml` file contains CRs for both `NMState` and
+`NodeNetworkConfigurationPolicy` (NNCP). When `oc apply -f` is passed
+this file, OpenShift might try to create the NNCPs while `NMState`
+CRDs are still installing and produce the following message.
+```
+nmstate.nmstate.io/nmstate created
+[resource mapping not found for name:
+"ostest-master-0" namespace: "openstack" from "control-plane.yaml":
+no matches for kind "NodeNetworkConfigurationPolicy" in version "nmstate.io/v1"
+ensure CRDs are installed first,
+resource mapping not found for name: "ostest-master-1" namespace: "openstack"
+from "control-plane.yaml": no matches for kind "NodeNetworkConfigurationPolicy"
+in version "nmstate.io/v1"
+```
+Retrying `oc apply -f contol-plane.yaml` a few seconds later should
+resolve the problem however.
+
+## Alternative Approach
+
+It's also possible to create CR files with less components and wait
+before applying each CR file. E.g. the file `nncp.yaml` would contain
+only `NodeNetworkConfigurationPolicy` CRs and `NMState` and other
+deployment related CRs could exist in another file like
+`deploy.yaml`. The following process may be used to do generate these
+files using kustomize.
+
+- Edit
+[va/hci/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/va/hci/kustomization.yaml)
+so that the last two lines contain only the following:
+```yaml
+components:
+- ../../lib/deploy
+```
+- Generate a file with only `MetalLB` and `NMState` CRs:
+```bash
+kustomize build architecture/examples/va/hci > deploy.yaml
+```
+- Edit
+[va/hci/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/va/hci/kustomization.yaml)
+so that the last two lines contain only the following:
+```yaml
+components:
+- ../../lib/nncp
+```
+- Generate a file with only `NNCP` CRs:
+```bash
+kustomize build architecture/examples/va/hci > nncp.yaml
+```
+The above process may be continued for each component.
+
+Note that [va/hci/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/va/hci/kustomization.yaml)
+is not the same file as
+[examples/va/hci/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/examples/va/hci/kustomization.yaml).
+`/example/va/hci` is a specific example of a given VA where as
+`/va/hci` is a generic HCI VA that may be customised and shared in
+multiple examples or composed to make a larger VA.
+
+This process will work for VAs (and DTs) besides HCI, but the paths
+may be different. E.g.
+[examples/va/nfv/sriov/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/examples/va/nfv/sriov/kustomization.yaml)
+differs from
+[va/nfv/sriov/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/va/nfv/sriov/kustomization.yaml)
+and the later is in an `nfv` subdirectory
+so each component is referred to using
+`- ../../../lib/` instead of `- ../../lib/`.

--- a/docs/wa/missing_nncp.md
+++ b/docs/wa/missing_nncp.md
@@ -23,12 +23,11 @@ resolve the problem.
 
 ## Alternative Approach
 
-It's also possible to create CR files with less components and wait
-before applying each CR file. E.g. the file `nncp.yaml` would contain
-only `NodeNetworkConfigurationPolicy` CRs and `NMState` and other
-deployment related CRs could exist in another file like
-`deploy.yaml`. The following process may be used to do generate these
-files using kustomize.
+You can create Custom Resource (CR) files with less components and wait
+before applying each CR file. For example, the file `nncp.yaml` could contain
+only `NodeNetworkConfigurationPolicy` CRs and `NMState` definitions. Other
+deployment related CRs could exist in another file such as
+`deploy.yaml`. You can generate these files using kustomize.
 
 - Edit
 [va/hci/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/va/hci/kustomization.yaml)

--- a/docs/wa/missing_nncp.md
+++ b/docs/wa/missing_nncp.md
@@ -29,42 +29,8 @@ only `NodeNetworkConfigurationPolicy` CRs and `NMState` definitions. Other
 deployment related CRs could exist in another file such as
 `deploy.yaml`. You can generate these files using kustomize.
 
-- Edit
-[va/hci/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/va/hci/kustomization.yaml)
-so that the last two lines contain only the following:
+- Modify the [va/hci/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/va/hci/kustomization.yaml) file for your environment
+so that the last two lines contain the deploy component configuration:
 ```yaml
 components:
 - ../../lib/deploy
-```
-- Generate a file with only `MetalLB` and `NMState` CRs:
-```bash
-kustomize build architecture/examples/va/hci > deploy.yaml
-```
-- Edit
-[va/hci/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/va/hci/kustomization.yaml)
-so that the last two lines contain only the following:
-```yaml
-components:
-- ../../lib/nncp
-```
-- Generate a file with only `NNCP` CRs:
-```bash
-kustomize build architecture/examples/va/hci > nncp.yaml
-```
-The above process may be continued for each component.
-
-Note that [va/hci/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/va/hci/kustomization.yaml)
-is not the same file as
-[examples/va/hci/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/examples/va/hci/kustomization.yaml).
-`/example/va/hci` is a specific example of a given VA where as
-`/va/hci` is a generic HCI VA that may be customised and shared in
-multiple examples or composed to make a larger VA.
-
-This process will work for VAs (and DTs) besides HCI, but the paths
-may be different. E.g.
-[examples/va/nfv/sriov/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/examples/va/nfv/sriov/kustomization.yaml)
-differs from
-[va/nfv/sriov/kustomization.yaml](https://github.com/openstack-k8s-operators/architecture/blob/main/va/nfv/sriov/kustomization.yaml)
-and the later is in an `nfv` subdirectory
-so each component is referred to using
-`- ../../../lib/` instead of `- ../../lib/`.

--- a/docs/wa/missing_nncp.md
+++ b/docs/wa/missing_nncp.md
@@ -1,7 +1,7 @@
 # Missing NNCPs
 
-The following command defines the OpenStack control plane and its
-dependent CRs.
+The kustomize command builds and results in the OpenStack control plane definitions and its
+dependent Custom Resources (CR).
 ```bash
 kustomize build architecture/examples/va/hci > control-plane.yaml
 ```

--- a/docs/wa/missing_nncp.md
+++ b/docs/wa/missing_nncp.md
@@ -18,8 +18,8 @@ resource mapping not found for name: "ostest-master-1" namespace: "openstack"
 from "control-plane.yaml": no matches for kind "NodeNetworkConfigurationPolicy"
 in version "nmstate.io/v1"
 ```
-Retrying `oc apply -f contol-plane.yaml` a few seconds later should
-resolve the problem however.
+Retrying `oc apply -f contol-plane.yaml` a few seconds later is likely to
+resolve the problem.
 
 ## Alternative Approach
 

--- a/docs/wa/missing_nncp.md
+++ b/docs/wa/missing_nncp.md
@@ -6,9 +6,8 @@ dependent Custom Resources (CR).
 kustomize build architecture/examples/va/hci > control-plane.yaml
 ```
 The `control-plane.yaml` file contains CRs for both `NMState` and
-`NodeNetworkConfigurationPolicy` (NNCP). When `oc apply -f` is passed
-this file, OpenShift might try to create the NNCPs while `NMState`
-CRDs are still installing and produce the following message.
+`NodeNetworkConfigurationPolicy` (NNCP). When  `oc apply -f control-plane.yaml` is read, OpenShift will try to create the NNCPs while `NMState`
+Custom Resource Definitions (CRD) are still installing and produce a message noting that the resource mappings are not found:
 ```
 nmstate.nmstate.io/nmstate created
 [resource mapping not found for name:

--- a/examples/va/hci/control-plane.md
+++ b/examples/va/hci/control-plane.md
@@ -34,8 +34,8 @@ kustomize build > control-plane.yaml
 ```
 oc apply -f control-plane.yaml
 ```
-If the above produces a `no matches for kind
-NodeNetworkConfigurationPolicy` error, then see the
+If the `oc apply` command produces a `no matches for kind
+NodeNetworkConfigurationPolicy` error, then see,
 [Missing NNCPs Workaround](../../docs/wa/missing_nncp.md).
 
 Wait for NNCPs to be available

--- a/examples/va/hci/control-plane.md
+++ b/examples/va/hci/control-plane.md
@@ -34,6 +34,9 @@ kustomize build > control-plane.yaml
 ```
 oc apply -f control-plane.yaml
 ```
+If the above produces a `no matches for kind
+NodeNetworkConfigurationPolicy` error, then see the
+[Missing NNCPs Workaround](../../docs/wa/missing_nncp.md).
 
 Wait for NNCPs to be available
 ```
@@ -44,23 +47,3 @@ Wait for control plane to be available
 ```
 oc wait osctlplane controlplane --for condition=Ready --timeout=600s
 ```
-
-## Workaround
-
-The `control-plane.yaml` file contains CRs for both `NMState` and
-`NodeNetworkConfigurationPolicy` (NNCP). When `oc apply -f` is
-passed this file, OpenShift might try to create the NNCPs while
-`NMState` CRDs are still installing and produce the following message.
-
-```
-nmstate.nmstate.io/nmstate created
-[resource mapping not found for name:
-"ostest-master-0" namespace: "openstack" from "control-plane.yaml":
-no matches for kind "NodeNetworkConfigurationPolicy" in version "nmstate.io/v1"
-ensure CRDs are installed first,
-resource mapping not found for name: "ostest-master-1" namespace: "openstack"
-from "control-plane.yaml": no matches for kind "NodeNetworkConfigurationPolicy"
-in version "nmstate.io/v1"
-```
-Retrying `oc apply -f contol-plane.yaml` a few seconds later should
-resolve the problem however.

--- a/examples/va/nfv/sriov/control-plane.md
+++ b/examples/va/nfv/sriov/control-plane.md
@@ -38,8 +38,8 @@ kustomize build > control-plane.yaml
 ```
 oc apply -f control-plane.yaml
 ```
-If the above produces a `no matches for kind
-NodeNetworkConfigurationPolicy` error, then see the
+If the `oc apply` command  produces a `no matches for kind
+NodeNetworkConfigurationPolicy` error, then see, 
 [Missing NNCPs Workaround](../../../docs/wa/missing_nncp.md).
 
 Wait for NNCPs to be available

--- a/examples/va/nfv/sriov/control-plane.md
+++ b/examples/va/nfv/sriov/control-plane.md
@@ -38,6 +38,9 @@ kustomize build > control-plane.yaml
 ```
 oc apply -f control-plane.yaml
 ```
+If the above produces a `no matches for kind
+NodeNetworkConfigurationPolicy` error, then see the
+[Missing NNCPs Workaround](../../../docs/wa/missing_nncp.md).
 
 Wait for NNCPs to be available
 ```
@@ -48,23 +51,3 @@ Wait for control plane to be available
 ```
 oc wait osctlplane controlplane --for condition=Ready --timeout=600s
 ```
-
-## Workaround
-
-The `control-plane.yaml` file contains CRs for both `NMState` and
-`NodeNetworkConfigurationPolicy` (NNCP). When `oc apply -f` is
-passed this file, OpenShift might try to create the NNCPs while
-`NMState` CRDs are still installing and produce the following message.
-
-```
-nmstate.nmstate.io/nmstate created
-[resource mapping not found for name:
-"ostest-master-0" namespace: "openstack" from "control-plane.yaml":
-no matches for kind "NodeNetworkConfigurationPolicy" in version "nmstate.io/v1"
-ensure CRDs are installed first,
-resource mapping not found for name: "ostest-master-1" namespace: "openstack"
-from "control-plane.yaml": no matches for kind "NodeNetworkConfigurationPolicy"
-in version "nmstate.io/v1"
-```
-Retrying `oc apply -f contol-plane.yaml` a few seconds later should
-resolve the problem however.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,8 +28,11 @@ nav:
   - Overview: index.md
   - Validated Architectures:
     - HCI: https://github.com/openstack-k8s-operators/architecture/tree/main/examples/va/hci/README.md
+    - SRIOV: https://github.com/openstack-k8s-operators/architecture/blob/main/examples/va/nfv/sriov/README.md
   - Deployed Topologies:
     - None
+  - Workarounds:
+    - Missing NNCPs: wa/missing_nncp.md
   - Contributing:
     - contributing/documentation.md
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ nav:
   - Overview: index.md
   - Validated Architectures:
     - HCI: https://github.com/openstack-k8s-operators/architecture/tree/main/examples/va/hci/README.md
-    - SRIOV: https://github.com/openstack-k8s-operators/architecture/blob/main/examples/va/nfv/sriov/README.md
+    - NFV SRIOV: https://github.com/openstack-k8s-operators/architecture/blob/main/examples/va/nfv/sriov/README.md
   - Deployed Topologies:
     - None
   - Workarounds:

--- a/va/hci/README.md
+++ b/va/hci/README.md
@@ -6,6 +6,6 @@ please see the
 
 This directory, `architecture/va/hci/`, exists so that the
 [kustomization.yaml](../../examples/va/hci/kustomization.yaml)
-in the examples directory for the HCI VA, reference it by URL as a
+in the examples directory for the HCI VA, reference it by path as a
 component. Its contents are likely uninteresting unless you want to
 understand how kustomize was implemented in this repository.

--- a/va/nfv/sriov/README.md
+++ b/va/nfv/sriov/README.md
@@ -2,10 +2,10 @@
 
 If you are looking for information on how to deploy the SRIOV VA, then
 please see the
-[SRIOV README in the examples directory](../../examples/va/nfv/sriov/README.md).
+[SRIOV README in the examples directory](../../../examples/va/nfv/sriov/README.md).
 
 This directory, `architecture/va/nfv/sriov/`, exists so that the
-[kustomization.yaml](../../examples/va/nfv/sriov/kustomization.yaml)
-in the examples directory for the SRIOV VA, reference it by URL as a
+[kustomization.yaml](../../../examples/va/nfv/sriov/kustomization.yaml)
+in the examples directory for the SRIOV VA, reference it by path as a
 component. Its contents are likely uninteresting unless you want to
 understand how kustomize was implemented in this repository.


### PR DESCRIPTION
Add links to SRIOV VA from docs `mkdocs.yml` and top level README.md.

Create a generic workarounds section in the docs
directory for a the NNCP workaround. Link to it
from both the HCI and SRIOV docs to deduplicate
content. Add an alternative method to resolve the
NNCP workaround.

Some links 404'd so the paths have been corrected.