### PR TITLE
Add reboot-os service to SRIOV VA

### DIFF
--- a/examples/va/nfv/sriov/edpm/openstackdataplanenodeset.yaml
+++ b/examples/va/nfv/sriov/edpm/openstackdataplanenodeset.yaml
@@ -41,6 +41,7 @@ spec:
     - install-os
     - configure-os
     - run-os
+    - reboot-os
     - libvirt
     - ovn
     - neutron-sriov


### PR DESCRIPTION
The `reboot-os` service was introduced to the codebase recently and needs to be included in the SRIOV VA in order to properly apply needed kernel args.