### PR TITLE
Do not deploy GlanceAPI pods by default

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -45,7 +45,7 @@ spec:
       databaseInstance: openstack
       glanceAPIs:
         default:
-          replicas: 1
+          replicas: 0
           networkAttachments:
             - storage
       storageClass: _replaced_


### PR DESCRIPTION
While we still apply the `Glance` `CR` during the first ctlplane deployment, this patch sets both `internal` and `external` instances to `replicas: 0`. By doing this we prevent a scenario where `Glance` is run without a supported backend, causing issues as long as `RWX` is not supported but we still apply a `split` layout by default.

We should still `split` the deployment between `internal` and `external` by default at this stage for at least two reasons:

1. the `layout` can't be change, so if `file` is used and a single instance is deployed, it's then not possible to patch the `default` glance instance and change its `layout` (the webhooks prevent it and the only solution is to entirely delete and recreate it);

2. in the next phase (`stage5`) we're going to patch the `ctlplane` and apply a backend (e.g., `ceph`)

For any other VA/DT that is not planning to use Ceph, it's still possible to `kustomize` at this stage the `ctlplane` and apply a backend for Glance (different than Ceph, for instance  `swift`).

Finally, as per [Glance PR#394](https://github.com/openstack-k8s-operators/glance-operator/pull/394), we are not going to return an err if Pods are not deployed and attached to a given `NAD`, so we shouldn't have issues when we land this patch.