### PR TITLE
Add uni08theta SR-IOV and AMD-SEV

### DIFF
--- a/examples/dt/uni08theta/sriov_amd-sev/edpm/README.md
+++ b/examples/dt/uni08theta/sriov_amd-sev/edpm/README.md
@@ -1,0 +1,62 @@
+**Based on OpenStack K8S operators from the "main" branch of the [OpenStack Operator repo](https://github.com/openstack-k8s-operators/openstack-operator/tree/78b3c876eaf9168f9d95b201997ebdc2da42fa02) on Oct 17th, 2023**
+
+## General information
+
+| Revision | Change              |  Date   |
+| -------: | :------------------ | :-----: |
+|     v0.1 | Initial publication | 2023-12-14 |
+
+## Node topology
+
+| Node role                                  | bm/vm | amount |
+| ------------------------------------------ | ----- | ------ |
+| Openshift master/worker combo-node cluster | vm    | 1      |
+| Compute nodes                              | bm    | 2      |
+
+## Services, enabled features and configurations
+
+| Service   | configuration                | Lock-in coverage?  |
+| --------- | ---------------------------- | ------------------ |
+| Neutron   | ML2/OVN, Geneve              | Must have          |
+| Compute   | Refer to kustomization.yaml  | Must have          |
+
+
+## Support services
+## Additional services required for integration testing that may not be the subject of this DT
+| Service   |  Reason                |
+| --------- | ---------------------- |
+| Glance    | Must have              |
+| Keystone  | needed by all services |
+| FIPS      | Enabled by default     |
+
+
+#### OVN
+add configuration of ovn extras
+
+## Considerations/Constraints
+
+1. Baremetal Computes must be AMD Hardware capable of supporting SEV
+2. Physical setups are required.
+3. Physical setups require SR-IOV supported NICs (e.g. Intel Corporation Ethernet Controller X710)
+
+## Testing tree
+
+| Test framework                  | Stage to run | Special configuration | Test case to report |
+| ------------------------------- | -------------|---------------------- | :-----------------: |
+| Tempest/whitebox                | stage7       | cirros/rhel guest     |       <TBD>         |
+| Tempest/neutron_tempest_plugin  | stage7       | rhel guest            |       <TBD>         |
+| Tempest/nfv-tempest-plugin      | stage7       | rhel guest            |       <TBD>         |
+| Tempest/neutron_plugin          | stage7       | rhel guest            |       <TBD>         |
+| Tempest/api.compute*            | stage7       | cirros/rhel guest     |       <TBD>         |
+
+## Stages
+
+All stages must be executed in the order listed below. Everything is required unless otherwise indicated.
+
+1. [Install dependencies for the OpenStack K8S operators](stage1)
+2. [Install the OpenStack K8S operators](stage2)
+3. [Configuring networking on the OCP nodes](stage3)
+4. [Configure and deploy the control plane](stage4)
+5. [Execute non destructive testing](stage7)
+6. [Execute load testing](stage8) (TBD)
+7. [Destructive testing](stage9) (TBD)

--- a/examples/dt/uni08theta/sriov_amd-sev/edpm/openstackdataplanedeployment.yaml
+++ b/examples/dt/uni08theta/sriov_amd-sev/edpm/openstackdataplanedeployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: edpm-amd-sev-deployment
+  namespace: openstack
+spec:
+  nodeSets:
+  - openstack-edpm-amd-sev

--- a/examples/dt/uni08theta/sriov_amd-sev/edpm/openstackdataplanenodeset.yaml
+++ b/examples/dt/uni08theta/sriov_amd-sev/edpm/openstackdataplanenodeset.yaml
@@ -1,0 +1,270 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm-amd-sev
+spec:
+  env:
+    - name: ANSIBLE_FORCE_COLOR
+      value: "True"
+  services:
+    - bootstrap
+    - configure-network
+    - configure-ovs-dpdk
+    - validate-network
+    - install-os
+    - configure-os
+    - run-os
+    - libvirt
+    - ovn
+    - neutron-metadata
+    - neutron-sriov
+    - sriov-amd
+  preProvisioned: true
+  nodes:
+    edpm-computeamdsev-0:
+      ansible:
+        ansibleHost: 192.168.122.100 # CHANGEME
+      hostName: edpm-computeamdsev-0
+      networks:
+      - defaultRoute: true
+        fixedIP: 192.168.122.100 # CHANGEME
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+    edpm-computeamdsev-1:
+      ansible:
+        ansibleHost: 192.168.122.101 # CHANGEME
+      hostName: edpm-computeamdsev-1
+      networks:
+      - defaultRoute: true
+        fixedIP: 192.168.122.101 # CHANGEME
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+  networkAttachments:
+    - ctlplane
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    managementNetwork: ctlplane
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        # CHANGEME -- see https://access.redhat.com/solutions/253273
+        # edpm_bootstrap_command: |
+        #       subscription-manager register --username <subscription_manager_username> --password <subscription_manager_password>
+        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
+        service_net_map:
+          nova_api_network: internal_api
+          nova_libvirt_network: internal_api
+        timesync_ntp_servers:
+          - hostname: clock.redhat.com
+        # CPU pinning settings
+        edpm_kernel_args: "hugepagesz=1GB hugepages=192 default_hugepagesz=1GB iommu=pt amd_iommu=on isolcpus=2-127,130-255 numa_balancing=disable processor.max_cstate=0 mem_encrypt=on kvm kvm_amd.sev=1"
+        # edpm_network_config
+        # These vars are edpm_network_config role vars
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_tuned_isolated_cores: "2-15,18-127,130-255"
+        edpm_ovs_dpdk_pmd_core_list: "16,17,144,145"
+        edpm_ovs_dpdk_lcore_list: "0,1,128,129"
+        edpm_ovs_dpdk_socket_memory: "1024,4096,1024,1024,1024,1024,1024,1024"
+        edpm_ovs_dpdk_memory_channels: "2"
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in role_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            mtu: {{ min_viable_mtu }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            members:
+            - type: interface
+              name: enp7s0
+              mtu: {{ min_viable_mtu }}
+              # force the MAC address of the bridge to this interface
+              primary: true
+          {% for network in role_networks %}
+            - type: vlan
+              mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+              vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+              addresses:
+              - ip_netmask:
+                  {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+              routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+          - type: sriov_pf
+            name: eno4
+            numvfs: 10
+            use_dhcp: false
+            promisc: true
+          - type: sriov_pf
+            name: nic5
+            mtu: 9000
+            numvfs: 10
+            use_dhcp: false
+            defroute: false
+            nm_controlled: true
+            hotplug: true
+            promisc: false
+          - type: sriov_pf
+            name: nic6
+            mtu: 9000
+            numvfs: 10
+            use_dhcp: false
+            defroute: false
+            nm_controlled: true
+            hotplug: true
+            promisc: false
+          - type: linux_bond
+            name: bond_api
+            bonding_options: "mode=active-backup"
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            members:
+            - type: sriov_vf
+              device: nic5
+              driver: mlx5_core
+              spoofcheck: false
+              promisc: true
+              vfid: 0
+              vlan_id: {{ internal_api_vlan_id }}
+            - type: sriov_vf
+              device: nic6
+              driver: mlx5_core
+              spoofcheck: false
+              promisc: true
+              vfid: 0
+              vlan_id: {{ internal_api_vlan_id }}
+            addresses:
+            - ip_netmask: {{ internal_api_ip }}/{{ internal_api_cidr }}
+            routes: {{ internal_api_host_routes }}
+          - type: linux_bond
+            name: storage_bond
+            bonding_options: mode=active-backup
+            use_dhcp: false
+            members:
+            - type: sriov_vf
+              device: nic5
+              driver: mlx5_core
+              spoofcheck: false
+              promisc: true
+              vfid: 1
+              vlan_id: {{ storage_vlan_id }}
+            - type: sriov_vf
+              device: nic6
+              driver: mlx5_core
+              spoofcheck: false
+              promisc: true
+              vfid: 1
+              vlan_id: {{ storage_vlan_id }}
+            addresses:
+            - ip_netmask: {{ storage_ip }}/{{ storage_cidr }}
+            routes: {{ storage_host_routes }}
+          - type: ovs_user_bridge
+            name: br-link0
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ tenant_ip }}/{{ tenant_cidr }}
+            members:
+              - type: ovs_dpdk_bond
+                name: dpdkbond0
+                mtu: 9000
+                rx_queue: 1
+                members:
+                - type: ovs_dpdk_port
+                  driver: mlx5_core
+                  name: dpdk0
+                  members:
+                  - type: sriov_vf
+                    device: nic5
+                    vfid: 2
+                    vlan_id: {{ tenant_vlan_id }}
+                - type: ovs_dpdk_port
+                  driver: mlx5_core
+                  name: dpdk1
+                  members:
+                  - type: sriov_vf
+                    device: nic6
+                    vfid: 2
+                    vlan_id: {{ tenant_vlan_id }}
+          - type: ovs_user_bridge
+            name: br-dpdk0
+            use_dhcp: false
+            members:
+            - type: ovs_dpdk_port
+              driver: mlx5_core
+              name: dpdk2
+              mtu: 9000
+              rx_queue: 1
+              members:
+              - type: sriov_vf
+                device: nic6
+                vfid: 3
+          - type: ovs_user_bridge
+            name: br-dpdk1
+            use_dhcp: false
+            members:
+            - type: ovs_dpdk_port
+              driver: mlx5_core
+              name: dpdk3
+              mtu: 9000
+              rx_queue: 1
+              members:
+              - type: sriov_vf
+                device: nic6
+                vfid: 4
+          - type: sriov_pf
+            name: nic3
+            mtu: 9000
+            numvfs: 4
+            use_dhcp: false
+            defroute: false
+            nm_controlled: true
+            hotplug: true
+            promisc: false
+          - type: sriov_pf
+            name: nic4
+            mtu: 9000
+            numvfs: 4
+            use_dhcp: false
+            defroute: false
+            nm_controlled: true
+            hotplug: true
+            promisc: false
+
+        # These vars are for the network config templates themselves and are
+        # considered EDPM network defaults.
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth0
+        # edpm_nodes_validation
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        dns_search_domains: []
+        gather_facts: false
+        enable_debug: false
+        # edpm firewall, change the allowed CIDR if needed
+        edpm_sshd_configure_firewall: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24 # CHANGEME
+        # SELinux module
+        edpm_selinux_mode: enforcing
+        edpm_neutron_sriov_agent_SRIOV_NIC_physical_device_mappings: 'sriov-1:eno35,sriov-2:eno36'

--- a/examples/dt/uni08theta/sriov_amd-sev/edpm/sriov-amd_sev.yaml
+++ b/examples/dt/uni08theta/sriov_amd-sev/edpm/sriov-amd_sev.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriov_amd-sev
+data:
+  65-sriov_amd-sev.conf: |
+    [DEFAULT]
+    reserved_host_memory_mb = 4096
+    reserved_huge_pages = node:0,size:4,count:524160
+    reserved_huge_pages = node:1,size:4,count:524160
+    [compute]
+    cpu_shared_set = 0-3,24-27
+    cpu_dedicated_set = 8-23,32-47
+    [libvirt]
+    virt_type=kvm
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: sriov-amd
+spec:
+  label: dataplane-deployment-sriov_amd-sev
+  configMaps:
+    - sriov_amd-sev
+  secrets:
+    - nova-cell1-compute-config
+    - nova-migration-ssh-key
+  playbook: osp.edpm.nova

--- a/examples/dt/uni08theta/sriov_amd-sev/kustomization.yaml
+++ b/examples/dt/uni08theta/sriov_amd-sev/kustomization.yaml
@@ -1,0 +1,37 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../va/nfv/sriov/
+  # - https://github.com/openstack-k8s-operators/architecture/va/nfv/sriov?ref=main
+  ## It's possible to replace ../../../va/nfv/sriov/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - service-values.yaml
+
+replacements:
+# Neutron control plane SRIOV customization
+- source:
+    kind: ConfigMap
+    name: service-values
+    fieldPath: data.neutron.customServiceConfig
+  targets:
+  - select:
+      kind: OpenStackControlPlane
+    fieldPaths:
+    - spec.neutron.template.customServiceConfig
+    options:
+      create: true
+# Nova control plane SRIOV customization
+- source:
+    kind: ConfigMap
+    name: service-values
+    fieldPath: data.nova.scheduler.customServiceConfig
+  targets:
+  - select:
+      kind: OpenStackControlPlane
+    fieldPaths:
+    - spec.nova.template.schedulerServiceTemplate.customServiceConfig
+    options:
+      create: true

--- a/examples/dt/uni08theta/sriov_amd-sev/service-values.yaml
+++ b/examples/dt/uni08theta/sriov_amd-sev/service-values.yaml
@@ -1,0 +1,14 @@
+# local-config: referenced, but not emitted by kustomize
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  neutron:
+    customServiceConfig: |
+      [ml2]
+      mechanism_drivers = ovn,sriovnicswitch
+      [ml2_type_vlan]
+      network_vlan_ranges = sriov-phy4


### PR DESCRIPTION
This DT attempts to consolidate the NFV, Neutron, and Nova requirements for covering SR-IOV in NextGen Openstack deployments.