### PR TITLE
Enable Swift in VA2 and set it as Glance backend

### DIFF
--- a/examples/va/nfv/sriov/README.md
+++ b/examples/va/nfv/sriov/README.md
@@ -10,6 +10,7 @@ This is a collection of CR templates that represent a validated Red Hat OpenStac
 - OVN networking
 - Network isolation over a single NIC
 - 2 compute nodes with an additional SRIOV-enabled NIC
+- Swift enabled and used as Glance backend
 
 ## Considerations
 

--- a/examples/va/nfv/sriov/service-values.yaml
+++ b/examples/va/nfv/sriov/service-values.yaml
@@ -12,4 +12,20 @@ data:
       mechanism_drivers = ovn,sriovnicswitch
       [ml2_type_vlan]
       network_vlan_ranges = sriov-phy4
-
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:swift
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+    default:
+      replicas: 1
+  swift:
+    enabled: true

--- a/va/nfv/sriov/kustomization.yaml
+++ b/va/nfv/sriov/kustomization.yaml
@@ -21,7 +21,7 @@ components:
 - ../../../lib/control-plane
 
 replacements:
-# Neutron control plane SRIOV customization
+# Control plane customization
 - source:
     kind: ConfigMap
     name: service-values
@@ -31,5 +31,38 @@ replacements:
       kind: OpenStackControlPlane
     fieldPaths:
     - spec.neutron.template.customServiceConfig
+    options:
+      create: true
+- source:
+    kind: ConfigMap
+    name: service-values
+    fieldPath: data.glance.customServiceConfig
+  targets:
+  - select:
+      kind: OpenStackControlPlane
+    fieldPaths:
+    - spec.glance.template.customServiceConfig
+    options:
+      create: true
+- source:
+    kind: ConfigMap
+    name: service-values
+    fieldPath: data.glance.default.replicas
+  targets:
+  - select:
+      kind: OpenStackControlPlane
+    fieldPaths:
+    - spec.glance.template.glanceAPIs.default.replicas
+    options:
+      create: true
+- source:
+    kind: ConfigMap
+    name: service-values
+    fieldPath: data.swift.enabled
+  targets:
+  - select:
+      kind: OpenStackControlPlane
+    fieldPaths:
+    - spec.swift.enabled
     options:
       create: true


### PR DESCRIPTION
Glance is set to `replicas: 0` by default until a backend is chosen.
`VA1` has `Ceph`, and this means that the control plane is patched at `stage 5` to set it as a backend (and increase the `Glance` `replicas` to 1).
In `VA2`, however, `stage 3` doesn't enable `Glance` or set a backend.

This patch does two things:

1. Enable `Swift` in `VA2` (`VA1` has `RGW` provided by `Ceph`, it makes sense to have `Swift` here);
2. Set `Glance` with the `Swift` backend and increase replicas to 1

By doing this we can test VA2 with a backend different than Ceph.