### PR TITLE
Creating `controlplane-values` config map

### DIFF
--- a/examples/va/hci/kustomization.yaml
+++ b/examples/va/hci/kustomization.yaml
@@ -8,4 +8,5 @@ components:
   ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
 
 resources:
+  - values.yml
   - nncp/values.yaml

--- a/examples/va/hci/nncp/values.yaml
+++ b/examples/va/hci/nncp/values.yaml
@@ -42,7 +42,7 @@ data:
     iface: enp7s0
     mtu: 9000
     lb_addresses:
-    - 192.168.122.80-192.168.122.90
+      - 192.168.122.80-192.168.122.90
     endpoint_annotations:
       metallb.universe.tf/address-pool: ctlplane
       metallb.universe.tf/allow-shared-ip: ctlplane
@@ -75,12 +75,12 @@ data:
     vlan: 20
     base_iface: enp7s0
     lb_addresses:
-    - 172.17.0.80-172.17.0.90
+      - 172.17.0.80-172.17.0.90
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
       metallb.universe.tf/allow-shared-ip: internalapi
       metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-    net-attach-def:  |
+    net-attach-def: |
       {
         "cniVersion": "0.3.1",
         "name": "internalapi",
@@ -108,7 +108,7 @@ data:
     vlan: 21
     base_iface: enp7s0
     lb_addresses:
-    - 172.18.0.80-172.18.0.90
+      - 172.18.0.80-172.18.0.90
     net-attach-def: |
       {
         "cniVersion": "0.3.1",
@@ -122,7 +122,7 @@ data:
           "range_end": "172.18.0.70"
         }
       }
-  storagemgmt:  # used on RHEL, not used on OpenShift
+  storagemgmt: # used on RHEL, not used on OpenShift
     dnsDomain: storagemgmt.example.com
     subnets:
       - allocationRanges:
@@ -147,7 +147,7 @@ data:
     vlan: 22
     base_iface: enp7s0
     lb_addresses:
-    - 172.19.0.80-172.19.0.90
+      - 172.19.0.80-172.19.0.90
     net-attach-def: |
       {
         "cniVersion": "0.3.1",
@@ -184,9 +184,9 @@ data:
 
   routes:
     config:
-    - destination: 0.0.0.0/0
-      next-hop-address: 192.168.122.1
-      next-hop-interface: enp7s0
+      - destination: 0.0.0.0/0
+        next-hop-address: 192.168.122.1
+        next-hop-interface: enp7s0
 
   rabbitmq:
     endpoint_annotations:
@@ -198,4 +198,3 @@ data:
       metallb.universe.tf/loadBalancerIPs: 172.17.0.86
 
   lbServiceType: LoadBalancer
-  storageClass: host-nfs-storageclass

--- a/examples/va/hci/values.yml
+++ b/examples/va/hci/values.yml
@@ -1,0 +1,9 @@
+# local-config: referenced, but not emitted by kustomize
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: controlplane-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  storageClass: host-nfs-storageclass

--- a/lib/control-plane/kustomization.yaml
+++ b/lib/control-plane/kustomization.yaml
@@ -2,111 +2,111 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 secretGenerator:
-- name: osp-secret
-  behavior: create
-  envs:
-  - osp-secrets.env
-  options:
-    disableNameSuffixHash: true
+  - name: osp-secret
+    behavior: create
+    envs:
+      - osp-secrets.env
+    options:
+      disableNameSuffixHash: true
 
 resources:
-- openstackcontrolplane.yaml
+  - openstackcontrolplane.yaml
 
 replacements:
-- source:
-    kind: ConfigMap
-    name: network-values
-    fieldPath: data.internalapi.endpoint_annotations
-  targets:
-  - select:
-      kind: OpenStackControlPlane
-    fieldPaths:
-    - spec.cinder.template.cinderAPI.override.service.internal.metadata.annotations
-    - spec.glance.template.glanceAPIs.default.override.service.internal.metadata.annotations
-    - spec.heat.template.heatAPI.override.service.internal.metadata.annotations
-    - spec.heat.template.heatEngine.override.service.internal.metadata.annotations
-    - spec.keystone.template.override.service.internal.metadata.annotations
-    - spec.manila.template.manilaAPI.override.service.internal.metadata.annotations
-    - spec.neutron.template.override.service.internal.metadata.annotations
-    - spec.nova.template.apiServiceTemplate.override.service.internal.metadata.annotations
-    - spec.nova.template.metadataServiceTemplate.override.service.metadata.annotations
-    - spec.placement.template.override.service.internal.metadata.annotations
-    - spec.swift.template.swiftProxy.override.service.internal.metadata.annotations
-    options:
-      create: true
-- source:
-    kind: ConfigMap
-    name: network-values
-    fieldPath: data.ctlplane.endpoint_annotations
-  targets:
-  - select:
-      kind: OpenStackControlPlane
-    fieldPaths:
-    - spec.dns.template.override.service.metadata.annotations
-    options:
-      create: true
-- source:
-    kind: ConfigMap
-    name: network-values
-    fieldPath: data.rabbitmq.endpoint_annotations
-  targets:
-  - select:
-      kind: OpenStackControlPlane
-    fieldPaths:
-    - spec.rabbitmq.templates.rabbitmq.override.service.metadata.annotations
-    options:
-      create: true
-- source:
-    kind: ConfigMap
-    name: network-values
-    fieldPath: data.rabbitmq-cell1.endpoint_annotations
-  targets:
-  - select:
-      kind: OpenStackControlPlane
-    fieldPaths:
-    - spec.rabbitmq.templates.rabbitmq-cell1.override.service.metadata.annotations
-    options:
-      create: true
-- source:
-    kind: ConfigMap
-    name: network-values
-    fieldPath: data.lbServiceType
-  targets:
-  - select:
-      kind: OpenStackControlPlane
-    fieldPaths:
-    - spec.dns.template.override.service.spec.type
-    - spec.cinder.template.cinderAPI.override.service.internal.spec.type
-    - spec.glance.template.glanceAPIs.default.override.service.internal.spec.type
-    - spec.heat.template.heatAPI.override.service.internal.spec.type
-    - spec.heat.template.heatEngine.override.service.internal.spec.type
-    - spec.keystone.template.override.service.internal.spec.type
-    - spec.manila.template.manilaAPI.override.service.internal.spec.type
-    - spec.neutron.template.override.service.internal.spec.type
-    - spec.nova.template.apiServiceTemplate.override.service.internal.spec.type
-    - spec.nova.template.metadataServiceTemplate.override.service.spec.type
-    - spec.placement.template.override.service.internal.spec.type
-    - spec.swift.template.swiftProxy.override.service.internal.spec.type
-    - spec.rabbitmq.templates.rabbitmq.override.service.spec.type
-    - spec.rabbitmq.templates.rabbitmq-cell1.override.service.spec.type
-    options:
-      create: true
-- source:
-    kind: ConfigMap
-    name: network-values
-    fieldPath: data.dns-resolver.options
-  targets:
-  - select:
-      kind: OpenStackControlPlane
-    fieldPaths:
-    - spec.dns.template.options
-- source:
-    kind: ConfigMap
-    name: network-values
-    fieldPath: data.storageClass
-  targets:
-  - select:
-      kind: OpenStackControlPlane
-    fieldPaths:
-    - spec.storageClass
-    - spec.glance.template.storageClass
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderAPI.override.service.internal.metadata.annotations
+          - spec.glance.template.glanceAPIs.default.override.service.internal.metadata.annotations
+          - spec.heat.template.heatAPI.override.service.internal.metadata.annotations
+          - spec.heat.template.heatEngine.override.service.internal.metadata.annotations
+          - spec.keystone.template.override.service.internal.metadata.annotations
+          - spec.manila.template.manilaAPI.override.service.internal.metadata.annotations
+          - spec.neutron.template.override.service.internal.metadata.annotations
+          - spec.nova.template.apiServiceTemplate.override.service.internal.metadata.annotations
+          - spec.nova.template.metadataServiceTemplate.override.service.metadata.annotations
+          - spec.placement.template.override.service.internal.metadata.annotations
+          - spec.swift.template.swiftProxy.override.service.internal.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.dns.template.override.service.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq.override.service.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-cell1.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-cell1.override.service.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.lbServiceType
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.dns.template.override.service.spec.type
+          - spec.cinder.template.cinderAPI.override.service.internal.spec.type
+          - spec.glance.template.glanceAPIs.default.override.service.internal.spec.type
+          - spec.heat.template.heatAPI.override.service.internal.spec.type
+          - spec.heat.template.heatEngine.override.service.internal.spec.type
+          - spec.keystone.template.override.service.internal.spec.type
+          - spec.manila.template.manilaAPI.override.service.internal.spec.type
+          - spec.neutron.template.override.service.internal.spec.type
+          - spec.nova.template.apiServiceTemplate.override.service.internal.spec.type
+          - spec.nova.template.metadataServiceTemplate.override.service.spec.type
+          - spec.placement.template.override.service.internal.spec.type
+          - spec.swift.template.swiftProxy.override.service.internal.spec.type
+          - spec.rabbitmq.templates.rabbitmq.override.service.spec.type
+          - spec.rabbitmq.templates.rabbitmq-cell1.override.service.spec.type
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.dns-resolver.options
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.dns.template.options
+  - source:
+      kind: ConfigMap
+      name: controlplane-values
+      fieldPath: data.storageClass
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.storageClass
+          - spec.glance.template.storageClass


### PR DESCRIPTION
Since storageClass parameter isn't related to networking, i'm proposing creating a new configmap named `controlplane-values` that should be used in the future for further customizations.

* linting fixes