### PR TITLE
Add missing storageClass to Glance

### DIFF
--- a/examples/va/hci/edpm-post-ceph/openstackcontrolplane.yaml
+++ b/examples/va/hci/edpm-post-ceph/openstackcontrolplane.yaml
@@ -109,7 +109,7 @@ spec:
                     metallb.universe.tf/loadBalancerIPs: 172.17.0.80
                 spec:
                   type: LoadBalancer
-      storageClass: ""
+      storageClass: host-nfs-storageclass
       storageRequest: 10G
       customServiceConfig: |
         [DEFAULT]


### PR DESCRIPTION
Change storageClass used by Glance from "" to "host-nfs-storageclass". This makes the update to OpenStackControlPlane consistent with the original OpenStackControlPlane produced by kustomize (assuming that "host-nfs-storageclass" is used as in the default values.yaml).

Glance needs a PV from a storageClass for image staging regardless of if an external backend like Ceph RBD is used.

If we do not make this change and follow the README with the current defaults in values.yaml then the
glance-opertator complains that a forbidden change is being attempted in a StatefulSet.