### PR TITLE
Add automation directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Deployment topologies are only to be used for testing environments. Validated
 architectures are intended to represent production-style deployment
 environments.
 
+The [automation](automation) directory contains YAML files which
+define the stages for each VA/DT including the path to the CR
+kustomization and its values as well as a shell command which may
+be used to validate that the stage is complete.
+
 ## Requirements
 
 The templating provided here requires [kustomize](https://kustomize.io/)

--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -1,0 +1,56 @@
+---
+vas:
+  hci:
+    repo: https://github.com/openstack-k8s-operators/architecture.git
+    branch: main
+    stages:
+      - path: examples/va/hci/control-plane/nncp
+        validations:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=60
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - path: examples/va/hci/control-plane
+        validations:
+          - >-
+            oc -n openstack wait osctlplane controlplane --for condition=Ready
+            --timeout=600s
+        values:
+          - name: network-values
+            src_file: none
+        build_output: ../control-plane.yaml
+
+      - path: examples/va/hci/edpm-pre-ceph
+        validations:
+          - >-
+            oc -n openstack wait
+            osdpd edpm-deployment-pre-ceph --for condition=Ready
+            --timeout=1200s
+        values:
+          - name: edpm-values
+            src_file: values.yaml
+        build_output: dataplane-pre-ceph.yaml
+        post_stage_run:
+          - name: Deploy Ceph
+            type: playbook
+            source: "../../playbooks/ceph.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+
+      - path: examples/va/hci
+        validations:
+          - >-
+            oc -n openstack wait
+            osdpd edpm-deployment-post-ceph --for condition=Ready
+            --timeout=1200s
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: edpm-values-post-ceph
+            src_file: values.yaml
+        build_output: dataplane-post-ceph.yaml


### PR DESCRIPTION
The automation directory contains YAML files which define the stages for each VA/DT including the path to the CR kustomization and its values as well as a shell command which may be used to validate that the stage is complete.

These YAML files may be parsed by external tools which apply the CRs in stages to automate the full deployment.

Because the structure of the architecture may change the automation directory is separate and at the top of the repository so that it does not need to change with the rest of the architecture repo.