### PR TITLE
Configure OVN Controller to act as gateway

### DIFF
--- a/examples/va/hci/control-plane/nncp/values.yaml
+++ b/examples/va/hci/control-plane/nncp/values.yaml
@@ -52,7 +52,7 @@ data:
         "cniVersion": "0.3.1",
         "name": "ctlplane",
         "type": "macvlan",
-        "master": "enp7s0",
+        "master": "ospbr",
         "ipam": {
           "type": "whereabouts",
           "range": "192.168.122.0/24",
@@ -171,6 +171,15 @@ data:
         gateway: 10.0.0.1
         name: subnet1
     mtu: 1500
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
 
   dns-resolver:
     config:
@@ -199,3 +208,4 @@ data:
 
   lbServiceType: LoadBalancer
   storageClass: host-nfs-storageclass
+  bridgeName: ospbr

--- a/examples/va/nfv/ovs-dpdk/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/nncp/values.yaml
@@ -52,7 +52,7 @@ data:
         "cniVersion": "0.3.1",
         "name": "ctlplane",
         "type": "macvlan",
-        "master": "enp7s0",
+        "master": "ospbr",
         "ipam": {
           "type": "whereabouts",
           "range": "192.168.122.0/24",
@@ -161,6 +161,15 @@ data:
         gateway: 10.0.0.1
         name: subnet1
     mtu: 1500
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
 
   dns-resolver:
     config:
@@ -189,3 +198,4 @@ data:
 
   lbServiceType: LoadBalancer
   storageClass: host-nfs-storageclass
+  bridgeName: ospbr

--- a/examples/va/nfv/sriov/nncp/values.yaml
+++ b/examples/va/nfv/sriov/nncp/values.yaml
@@ -52,7 +52,7 @@ data:
         "cniVersion": "0.3.1",
         "name": "ctlplane",
         "type": "macvlan",
-        "master": "enp7s0",
+        "master": "ospbr",
         "ipam": {
           "type": "whereabouts",
           "range": "192.168.122.0/24",
@@ -161,6 +161,15 @@ data:
         gateway: 10.0.0.1
         name: subnet1
     mtu: 1500
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
 
   dns-resolver:
     config:
@@ -189,3 +198,4 @@ data:
 
   lbServiceType: LoadBalancer
   storageClass: host-nfs-storageclass
+  bridgeName: ospbr

--- a/lib/control-plane/kustomization.yaml
+++ b/lib/control-plane/kustomization.yaml
@@ -110,3 +110,12 @@ replacements:
     fieldPaths:
     - spec.storageClass
     - spec.glance.template.storageClass
+- source:
+    kind: ConfigMap
+    name: network-values
+    fieldPath: data.bridgeName
+  targets:
+  - select:
+      kind: OpenStackControlPlane
+    fieldPaths:
+    - spec.ovn.template.ovnController.nicMappings.datacentre

--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -141,6 +141,8 @@ spec:
     template:
       ovnController:
         networkAttachment: tenant
+        nicMappings:
+          datacentre: _replaced_
       ovnDBCluster:
         ovndbcluster-nb:
           dbType: NB

--- a/lib/networking/kustomization.yaml
+++ b/lib/networking/kustomization.yaml
@@ -59,6 +59,16 @@ replacements:
       name: tenant
     fieldPaths:
     - spec.config
+- source:
+    kind: ConfigMap
+    name: network-values
+    fieldPath: data.datacentre.net-attach-def
+  targets:
+  - select:
+      kind: NetworkAttachmentDefinition
+      name: datacentre
+    fieldPaths:
+    - spec.config
 
 # IPAddressPool addresses
 - source:
@@ -163,7 +173,7 @@ replacements:
 - source:
     kind: ConfigMap
     name: network-values
-    fieldPath: data.ctlplane.iface
+    fieldPath: data.bridgeName
   targets:
   - select:
       group: metallb.io

--- a/lib/networking/ocp_networks_netattach.yaml
+++ b/lib/networking/ocp_networks_netattach.yaml
@@ -30,3 +30,11 @@ metadata:
   labels:
     osp/net: tenant
     osp/net-attach-def-type: standard
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: datacentre
+  labels:
+    osp/net: datacentre
+    osp/net-attach-def-type: standard

--- a/lib/nncp/kustomization.yaml
+++ b/lib/nncp/kustomization.yaml
@@ -103,6 +103,7 @@ replacements:
       kind: NodeNetworkConfigurationPolicy
     fieldPaths:
     - spec.desiredState.interfaces.[type=ethernet].name
+    - spec.desiredState.interfaces.[type=linux-bridge].bridge.port.0.name
 - source:
     kind: ConfigMap
     name: network-values
@@ -112,6 +113,7 @@ replacements:
       kind: NodeNetworkConfigurationPolicy
     fieldPaths:
     - spec.desiredState.interfaces.[type=ethernet].mtu
+    - spec.desiredState.interfaces.[type=linux-bridge].mtu
 
 # Static Node IPs: node-0
 - source:
@@ -143,7 +145,7 @@ replacements:
       kind: NodeNetworkConfigurationPolicy
       name: node-0
     fieldPaths:
-    - spec.desiredState.interfaces.[type=ethernet].ipv4.address.0.ip
+    - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
 - source:
     kind: ConfigMap
     name: network-values
@@ -185,7 +187,7 @@ replacements:
       kind: NodeNetworkConfigurationPolicy
       name: node-1
     fieldPaths:
-    - spec.desiredState.interfaces.[type=ethernet].ipv4.address.0.ip
+    - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
 - source:
     kind: ConfigMap
     name: network-values
@@ -227,7 +229,7 @@ replacements:
       kind: NodeNetworkConfigurationPolicy
       name: node-2
     fieldPaths:
-    - spec.desiredState.interfaces.[type=ethernet].ipv4.address.0.ip
+    - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
 - source:
     kind: ConfigMap
     name: network-values
@@ -249,7 +251,7 @@ replacements:
       kind: NodeNetworkConfigurationPolicy
       name: node-0
     fieldPaths:
-    - spec.desiredState.interfaces.[type=ethernet].ipv4.address.0.prefix-length
+    - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.prefix-length
 - source:
     kind: ConfigMap
     name: network-values
@@ -291,7 +293,7 @@ replacements:
       kind: NodeNetworkConfigurationPolicy
       name: node-1
     fieldPaths:
-    - spec.desiredState.interfaces.[type=ethernet].ipv4.address.0.prefix-length
+    - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.prefix-length
 - source:
     kind: ConfigMap
     name: network-values
@@ -333,7 +335,7 @@ replacements:
       kind: NodeNetworkConfigurationPolicy
       name: node-2
     fieldPaths:
-    - spec.desiredState.interfaces.[type=ethernet].ipv4.address.0.prefix-length
+    - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.prefix-length
 - source:
     kind: ConfigMap
     name: network-values
@@ -433,9 +435,10 @@ replacements:
 - source:
     kind: ConfigMap
     name: network-values
-    fieldPath: data.routes.config.0.next-hop-interface
+    fieldPath: data.bridgeName
   targets:
   - select:
       kind: NodeNetworkConfigurationPolicy
     fieldPaths:
     - spec.desiredState.routes.config.0.next-hop-interface
+    - spec.desiredState.interfaces.[type=linux-bridge].name

--- a/lib/nncp/ocp_node_template.yaml
+++ b/lib/nncp/ocp_node_template.yaml
@@ -63,6 +63,11 @@ spec:
         id: _replaced_
       mtu: 1500
     - description: ctlplane interface
+      name: _replaced_
+      state: up
+      type: ethernet
+      mtu: 1500
+    - description: linux-bridge over ctlplane interface
       ipv4:
         address:
         - ip: _replaced_
@@ -73,7 +78,14 @@ spec:
         enabled: false
       name: _replaced_
       state: up
-      type: ethernet
+      type: linux-bridge
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+          - name: _replaced_
+            vlan: {}
       mtu: 1500
   nodeSelector:
     kubernetes.io/hostname: _replaced_


### PR DESCRIPTION
To configure nicMappings(external net-attach-def) for ovnController CR, it requires dedicated nic with
external connectivity on the worker nodes.

With network isolation we already setup an additional nic on the worker nodes and as that is already used by MetalLB and net-attach-definitions it cannot be
shared by OVN Controllers as it uses host-device
plugin and requires a dedicated NIC.

In order to use same interface for ovn controller, a linux bridge is created with with ctlplane interface as one of it's port. Utilizing this bridge a net-attach-def of bridge type is created for usage by the OVN Controllers.

If there is additional external NIC dedicated for OSP traffic on worker nodes then that can also be used.

Issue: OSPRH-3947