### PR TITLE
Remove references to host-nfs-storageclass

### DIFF
--- a/examples/va/hci/edpm-post-ceph/openstackcontrolplane.yaml
+++ b/examples/va/hci/edpm-post-ceph/openstackcontrolplane.yaml
@@ -109,7 +109,7 @@ spec:
                     metallb.universe.tf/loadBalancerIPs: 172.17.0.80
                 spec:
                   type: LoadBalancer
-      storageClass: host-nfs-storageclass
+      storageClass: local-storage
       storageRequest: 10G
       customServiceConfig: |
         [DEFAULT]
@@ -351,7 +351,7 @@ spec:
   redis:
     enabled: false
   secret: osp-secret
-  storageClass: host-nfs-storageclass
+  storageClass: local-storage
   swift:
     enabled: false
     proxyOverride:

--- a/examples/va/hci/nncp/values.yaml
+++ b/examples/va/hci/nncp/values.yaml
@@ -198,4 +198,4 @@ data:
       metallb.universe.tf/loadBalancerIPs: 172.17.0.86
 
   lbServiceType: LoadBalancer
-  storageClass: host-nfs-storageclass
+  storageClass: local-storage

--- a/examples/va/nfv/sriov/nncp/values.yaml
+++ b/examples/va/nfv/sriov/nncp/values.yaml
@@ -188,4 +188,4 @@ data:
       metallb.universe.tf/loadBalancerIPs: 172.17.0.86
 
   lbServiceType: LoadBalancer
-  storageClass: host-nfs-storageclass
+  storageClass: local-storage


### PR DESCRIPTION
Replace references to `host-nfs-storageclass` with `local-storage` instead.  The former is an old artifact for an OCP-cluster-deployment tool that was used in the nascent VA effort.  We now use `local-storage` with all our environments, so we should just have that as a default instead.  I've noticed situations multiple times now where the old storage class trips people up when somehow it stays in place during VA deployments.