### PR TITLE
Add reboot-os service to hci and nfv va examples

### DIFF
--- a/examples/va/hci/edpm-pre-ceph/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/values.yaml
@@ -166,6 +166,7 @@ data:
     - ceph-hci-pre
     - configure-os
     - run-os
+    - reboot-os
   nova:
     migration:
       ssh_keys:

--- a/examples/va/nfv/ovs-dpdk/edpm/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/edpm/values.yaml
@@ -166,6 +166,7 @@ data:
     - install-os
     - configure-os
     - run-os
+    - reboot-os
     - ovn
     - neutron-metadata
     - libvirt


### PR DESCRIPTION
Add reboot-os service to nfv and hci validated architectures examples.
This service should be enabled by default in each architecture,
because there might be changes to host during deployment that
requires reboot to take effect.