### PR TITLE
Add missing 's' to timeout in automation file

### DIFF
--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -10,7 +10,7 @@ vas:
             oc -n openstack wait nncp
             -l osp/nncm-config-type=standard
             --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
-            --timeout=60
+            --timeout=60s
         values:
           - name: network-values
             src_file: values.yaml


### PR DESCRIPTION
When I initially copy-pasted the validation content in the PoC for this structure, I missed an `s` qualifier for a `timeout` parameter