### PR TITLE
OVN Controller bridge mapping to enable floating ip

### DIFF
--- a/examples/va/nfv/ovs-dpdk/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk/service-values.yaml
@@ -23,15 +23,19 @@ data:
       [ovn]
       vhost_sock_dir = /var/lib/vhost_sockets
       [ml2_type_vlan]
-      network_vlan_ranges = dpdk1:206:209,dpdk2:206:209 # CHANGE
+      network_vlan_ranges = dpdk1:206:209,dpdk2:206:209 # CHANGEME
       [neutron]
-      physnets = dpdk1, dpdk2 # CHANGE
-      [neutron_physnet_dpdk1] # CHANGE
-      numa_nodes = 0 # CHANGE
-      [neutron_physnet_dpdk2 # CHANGE
-      numa_nodes = 0 # CHANGE
-      [neutron_tunnel] # CHANGE
-      numa_nodes = 0 # CHANGE
+      physnets = dpdk1, dpdk2 # CHANGEME
+      [neutron_physnet_dpdk1] # CHANGEME
+      numa_nodes = 0 # CHANGEME
+      [neutron_physnet_dpdk2 # CHANGEME
+      numa_nodes = 0 # CHANGEME
+      [neutron_tunnel] # CHANGEME
+      numa_nodes = 0 # CHANGEME
+  ovn:
+    ovnController:
+      nicMappings:
+        datacentre: enp4s0 # CHANGEME
   glance:
     customServiceConfig: |
       [DEFAULT]

--- a/va/nfv/ovs-dpdk/kustomization.yaml
+++ b/va/nfv/ovs-dpdk/kustomization.yaml
@@ -33,3 +33,15 @@ replacements:
     - spec.neutron.template.customServiceConfig
     options:
       create: true
+# OVN control plane OvS DPDK customization
+- source:
+    kind: ConfigMap
+    name: service-values
+    fieldPath: data.ovn.ovnController
+  targets:
+  - select:
+      kind: OpenStackControlPlane
+    fieldPaths:
+    - spec.ovn.template.ovnController
+    options:
+      create: true


### PR DESCRIPTION
This change is to provide external connectivity for the guest instances.