### PR TITLE
Remove "src_file" when none is provided

### DIFF
--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -21,7 +21,6 @@ vas:
             --timeout=600s
         values:
           - name: network-values
-            src_file: none
         build_output: ../control-plane.yaml
 
       - path: examples/va/hci/edpm-pre-ceph


### PR DESCRIPTION
It's better/easier to ensure the "src_file" property is defined rather
than checking for "none" as a string, like ansible is doing against that
file.
