### PR TITLE
Switch glance replicas to 3 in HCI VA

### DIFF
--- a/examples/va/hci/service-values.yaml
+++ b/examples/va/hci/service-values.yaml
@@ -38,7 +38,7 @@ data:
       rbd_store_user = openstack
     glanceAPIs:
       default:
-        replicas: 1
+        replicas: 3
   manila:
     enabled: true
     manilaShares:


### PR DESCRIPTION
Glance distributed image import using the glance operator's stateful set has been tested and is known to work with three replicas. Increase replica count in HCI VA to so that when Glance is tested it will be tested with three replicas.