### PR TITLE
Added the `openstack-operator-image` variable

### DIFF
--- a/examples/va/hci/control-plane/nncp/values.yaml
+++ b/examples/va/hci/control-plane/nncp/values.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  openstack-operator-image: "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
   # nodes
   node_0:
     name: ostest-master-0

--- a/examples/va/nfv/ovs-dpdk/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/nncp/values.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  openstack-operator-image: "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
   # nodes
   node_0:
     name: ostest-master-0

--- a/examples/va/nfv/sriov/nncp/values.yaml
+++ b/examples/va/nfv/sriov/nncp/values.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  openstack-operator-image: "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
   # nodes
   node_0:
     name: ostest-master-0

--- a/lib/olm-openstack/kustomization.yaml
+++ b/lib/olm-openstack/kustomization.yaml
@@ -1,5 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
 resources:
 - catalogsource.yaml
 - namespaces.yaml
 - operatorgroup.yaml
 - subscription.yaml
+
+replacements:
+- source:
+    kind: ConfigMap
+    name: network-values
+    fieldPath: data.openstack-operator-image
+  targets:
+  - select:
+      kind: CatalogSource
+    fieldPaths:
+    - spec.image


### PR DESCRIPTION
Added the ability to customize the "release" of the openstack-operator (index) image to deploy a different set of containers instead of the ones pinned in "latest"

Defaults to
`quay.io/openstack-k8s-operators/openstack-operator-index:latest`