### PR TITLE
Move `openstack-operator-version` variable to `olm-values` CM

### DIFF
--- a/examples/common/olm/kustomization.yaml
+++ b/examples/common/olm/kustomization.yaml
@@ -1,3 +1,5 @@
-resources:
+components:
   - ../../../lib/olm-deps
   - ../../../lib/olm-openstack
+resources:
+  - values.yaml

--- a/examples/common/olm/values.yaml
+++ b/examples/common/olm/values.yaml
@@ -1,0 +1,9 @@
+# local-config: referenced, but not emitted by kustomize
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: olm-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  openstack-operator-image: "quay.io/openstack-k8s-operators/openstack-operator-index:latest"

--- a/lib/olm-deps/kustomization.yaml
+++ b/lib/olm-deps/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
 resources:
 - cert_manager_namespace.yaml
 - cert_manager_operatorgroup.yaml

--- a/lib/olm-openstack/kustomization.yaml
+++ b/lib/olm-openstack/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 replacements:
 - source:
     kind: ConfigMap
-    name: network-values
+    name: olm-values
     fieldPath: data.openstack-operator-image
   targets:
   - select:


### PR DESCRIPTION
This is a followup to #115 since that approach failed while deploying OLM resources.

Also, `openstack-operator-version` variable has been moved to a new CM called `olm-values`