### PR TITLE
Removes openstack-operator-image from network-values configmap

### DIFF
--- a/examples/va/hci/control-plane/nncp/values.yaml
+++ b/examples/va/hci/control-plane/nncp/values.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  openstack-operator-image: "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
   # nodes
   node_0:
     name: ostest-master-0

--- a/examples/va/nfv/ovs-dpdk/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/nncp/values.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  openstack-operator-image: "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
   # nodes
   node_0:
     name: ostest-master-0

--- a/examples/va/nfv/sriov/nncp/values.yaml
+++ b/examples/va/nfv/sriov/nncp/values.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  openstack-operator-image: "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
   # nodes
   node_0:
     name: ostest-master-0


### PR DESCRIPTION
As per https://github.com/openstack-k8s-operators/architecture/pull/116 source of replacement for `data.openstack-operator-image` is moved to olm-values  from network-values