### PR TITLE
Missing glance and swift controlplane service values

### DIFF
--- a/examples/va/nfv/ovs-dpdk/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk/service-values.yaml
@@ -32,3 +32,20 @@ data:
       numa_nodes = 0 # CHANGE
       [neutron_tunnel] # CHANGE
       numa_nodes = 0 # CHANGE
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:swift
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+    default:
+      replicas: 1
+  swift:
+    enabled: true


### PR DESCRIPTION
This change is to add the missing glance and swift controlplane service values for OVS DPDK deployment.