### PR TITLE
Add cephfs auth_id for manila in VA1

### DIFF
--- a/examples/va/hci/service-values.yaml
+++ b/examples/va/hci/service-values.yaml
@@ -41,6 +41,10 @@ data:
         replicas: 3
   manila:
     enabled: true
+    manilaAPI:
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_share_protocols=nfs,cephfs
     manilaShares:
       share1:
         customServiceConfig: |
@@ -53,6 +57,7 @@ data:
           share_driver = manila.share.drivers.cephfs.driver.CephFSDriver
           cephfs_conf_path = /etc/ceph/ceph.conf
           cephfs_cluster_name = ceph
+          cephfs_auth_id=openstack
           cephfs_volume_mode = 0755
           cephfs_protocol_helper_type = CEPHFS
   extraMounts:


### PR DESCRIPTION
This patch fixes the `Manila` `native_cephfs` config for `VA1`.
A missing `cephfs_auth_id` let the share fail because it tries to authenticate with a different user.
The patch also adds the `manilaAPI` `customServiceConfig` to make sure we're able to handle that protocol at `API` level.