### PR TITLE
Add "missing" src_file in HCI stage_1

### DIFF
--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -21,6 +21,7 @@ vas:
             --timeout=600s
         values:
           - name: network-values
+            src_file: nncp/values.yaml
         build_output: ../control-plane.yaml
 
       - path: examples/va/hci/edpm-pre-ceph


### PR DESCRIPTION
While we don't really need that src_file (the values.yaml is already
generated during stage_0), it may happen we want to inject user provided
kustomization snippet during stage_1.

With this patch, the CI Framework will proceed as follow:

stage_0: take the nncp/values.yaml, combine it with CI generated content
and user provided kustomization, output the built kustomization

stage_1: take the same original nncp/values.yaml, combine with the same
CI generated snippet, and any (different?) user provided kustomization,
and output the built kustomization in a different file

A patch in CI Framework[1] will ensure we keep track of the overrides if
any for better debugging.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1301