### PR TITLE
Increase edpm-pre-ceph validation timeout

### DIFF
--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -29,7 +29,7 @@ vas:
           - >-
             oc -n openstack wait
             osdpd edpm-deployment-pre-ceph --for condition=Ready
-            --timeout=1200s
+            --timeout=1500s
         values:
           - name: edpm-values
             src_file: values.yaml


### PR DESCRIPTION
It's been noticed that 1200s is not sufficient for the edpm-deployment-pre-ceph OpenStackDataPlaneDeployment to get Ready in VA for shiftonstack case, which includes the next overrides in ci-framework:
 - cifmw_libvirt_manager_compute_disksize: 200
 - cifmw_libvirt_manager_compute_memory: 50
 - cifmw_libvirt_manager_compute_cpus: 8
 - cifmw_block_device_size: 100G

This patch increases it to 1500s.