### PR TITLE
Increase edpm-deployment-post-ceph validation timeout

### DIFF
--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -45,7 +45,7 @@ vas:
           - >-
             oc -n openstack wait
             osdpd edpm-deployment-post-ceph --for condition=Ready
-            --timeout=1200s
+            --timeout=2100s
         values:
           - name: service-values
             src_file: service-values.yaml


### PR DESCRIPTION
**Note: this change is being tested right now**

Similarly to https://github.com/openstack-k8s-operators/architecture/pull/135, this patch increases the timeout for the edpm-deployment-post-ceph OpenStackDataPlaneDeployment to get Ready in VA for shiftonstack case, which includes the next overrides in ci-framework:

 - cifmw_libvirt_manager_compute_disksize: 200
 - cifmw_libvirt_manager_compute_memory: 50
 - cifmw_libvirt_manager_compute_cpus: 8
 - cifmw_block_device_size: 100G

This patch increases it from 20min (1200s) to 35min (2100s) as it's taking ~29min to get Ready in my tests.