### PR TITLE
Bump control plane and dataplane deployment timeout to 30m

### DIFF
--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -18,7 +18,7 @@ vas:
         validations:
           - >-
             oc -n openstack wait osctlplane controlplane --for condition=Ready
-            --timeout=600s
+            --timeout=30m
         values:
           - name: network-values
             src_file: nncp/values.yaml
@@ -45,7 +45,7 @@ vas:
           - >-
             oc -n openstack wait
             osdpd edpm-deployment-post-ceph --for condition=Ready
-            --timeout=1200s
+            --timeout=40m
         values:
           - name: service-values
             src_file: service-values.yaml


### PR DESCRIPTION
Recently we have added VA HCI ci in downstream using ci-framework devscript reproducer. Sometimes control plane or dataplane deployment does not finishes with existing timeout.

In order to finish the deployment, we are bumping the timeout to 30 m for controlplane and dataplane deployment.

In upstream Zuul CI, the controlplane deploy timeout[1] is 30 mins and EDPM deploy timeout[2] is 40 mins.

Links:
[1]. https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/edpm_prepare/defaults/main.yml#L27 

[2]. https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/edpm_deploy/defaults/main.yml#L25