### PR TITLE
Use NIC name defaults commonly found in dev/test/CI environments

### DIFF
--- a/examples/va/hci/control-plane/nncp/values.yaml
+++ b/examples/va/hci/control-plane/nncp/values.yaml
@@ -39,7 +39,7 @@ data:
         gateway: 192.168.122.1
         name: subnet1
     prefix-length: 24
-    iface: enp7s0
+    iface: enp6s0
     mtu: 9000
     lb_addresses:
     - 192.168.122.80-192.168.122.90
@@ -73,7 +73,7 @@ data:
     prefix-length: 24
     iface: internalapi
     vlan: 20
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.17.0.80-172.17.0.90
     endpoint_annotations:
@@ -106,7 +106,7 @@ data:
     prefix-length: 24
     iface: storage
     vlan: 21
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.18.0.80-172.18.0.90
     net-attach-def: |
@@ -145,7 +145,7 @@ data:
     prefix-length: 24
     iface: tenant
     vlan: 22
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.19.0.80-172.19.0.90
     net-attach-def: |
@@ -195,7 +195,7 @@ data:
     config:
     - destination: 0.0.0.0/0
       next-hop-address: 192.168.122.1
-      next-hop-interface: enp7s0
+      next-hop-interface: enp6s0
 
   rabbitmq:
     endpoint_annotations:

--- a/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
@@ -39,7 +39,7 @@ data:
         gateway: 192.168.122.1
         name: subnet1
     prefix-length: 24
-    iface: enp7s0
+    iface: enp6s0
     mtu: 1500
     lb_addresses:
     - 192.168.122.80-192.168.122.90
@@ -71,9 +71,9 @@ data:
         vlan: 20
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.20
+    iface: enp6s0.20
     vlan: 20
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.17.0.80-172.17.0.90
     endpoint_annotations:
@@ -104,9 +104,9 @@ data:
         vlan: 21
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.21
+    iface: enp6s0.21
     vlan: 21
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.18.0.80-172.18.0.90
     net-attach-def: |
@@ -133,9 +133,9 @@ data:
         vlan: 22
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.22
+    iface: enp6s0.22
     vlan: 22
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.19.0.80-172.19.0.90
     net-attach-def: |
@@ -185,7 +185,7 @@ data:
     config:
     - destination: 192.168.122.0/24
       next-hop-address: 192.168.122.1
-      next-hop-interface: enp7s0
+      next-hop-interface: enp6s0
 
   rabbitmq:
     endpoint_annotations:

--- a/examples/va/nfv/ovs-dpdk/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/nncp/values.yaml
@@ -39,7 +39,7 @@ data:
         gateway: 192.168.122.1
         name: subnet1
     prefix-length: 24
-    iface: enp7s0
+    iface: enp6s0
     mtu: 1500
     lb_addresses:
     - 192.168.122.80-192.168.122.90
@@ -71,9 +71,9 @@ data:
         vlan: 20
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.20
+    iface: enp6s0.20
     vlan: 20
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.17.0.80-172.17.0.90
     endpoint_annotations:
@@ -104,9 +104,9 @@ data:
         vlan: 21
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.21
+    iface: enp6s0.21
     vlan: 21
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.18.0.80-172.18.0.90
     net-attach-def: |
@@ -133,9 +133,9 @@ data:
         vlan: 22
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.22
+    iface: enp6s0.22
     vlan: 22
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.19.0.80-172.19.0.90
     net-attach-def: |
@@ -185,7 +185,7 @@ data:
     config:
     - destination: 192.168.122.0/24
       next-hop-address: 192.168.122.1
-      next-hop-interface: enp7s0
+      next-hop-interface: enp6s0
 
   rabbitmq:
     endpoint_annotations:

--- a/examples/va/nfv/sriov/nncp/values.yaml
+++ b/examples/va/nfv/sriov/nncp/values.yaml
@@ -39,7 +39,7 @@ data:
         gateway: 192.168.122.1
         name: subnet1
     prefix-length: 24
-    iface: enp7s0
+    iface: enp6s0
     mtu: 1500
     lb_addresses:
     - 192.168.122.80-192.168.122.90
@@ -71,9 +71,9 @@ data:
         vlan: 20
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.20
+    iface: enp6s0.20
     vlan: 20
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.17.0.80-172.17.0.90
     endpoint_annotations:
@@ -104,9 +104,9 @@ data:
         vlan: 21
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.21
+    iface: enp6s0.21
     vlan: 21
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.18.0.80-172.18.0.90
     net-attach-def: |
@@ -133,9 +133,9 @@ data:
         vlan: 22
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.22
+    iface: enp6s0.22
     vlan: 22
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
     - 172.19.0.80-172.19.0.90
     net-attach-def: |
@@ -185,7 +185,7 @@ data:
     config:
     - destination: 192.168.122.0/24
       next-hop-address: 192.168.122.1
-      next-hop-interface: enp7s0
+      next-hop-interface: enp6s0
 
   rabbitmq:
     endpoint_annotations:


### PR DESCRIPTION
While it is ultimately the responsibility of the user or their automation to replace the various `values*.yaml` values, I think that using defaults common to our environments make some sense.  The NIC names we are using for the OSP trunk network are currently off-skew with what one typically finds in `install_yamls` and `CIFMW` infrastructure deployments.