### PR TITLE
Openstack dataplane service nova custom name changes

### DIFF
--- a/va/nfv/ovs-dpdk-sriov/edpm/nova_ovs_dpdk_sriov.yaml
+++ b/va/nfv/ovs-dpdk-sriov/edpm/nova_ovs_dpdk_sriov.yaml
@@ -16,9 +16,9 @@ data:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: nova-custom-ovsdpdk
+  name: nova-custom-ovsdpdksriov
 spec:
-  label: nova-custom-ovsdpdk
+  label: nova-custom-ovsdpdksriov
   configMaps:
     - ovs-dpdk-sriov-cpu-pinning-nova
     - sriov-nova


### PR DESCRIPTION
This change is to fix nova custom dataplane service naming issue for ovs dpdk sriov.