### PR TITLE
Update manilaAPI (as we do for ManilaShare) after Ceph is deployed

### DIFF
--- a/va/hci/edpm-post-ceph/kustomization.yaml
+++ b/va/hci/edpm-post-ceph/kustomization.yaml
@@ -97,6 +97,17 @@ replacements:
 - source:
     kind: ConfigMap
     name: service-values
+    fieldPath: data.manila.manilaAPI.customServiceConfig
+  targets:
+    - select:
+        kind: OpenStackControlPlane
+      fieldPaths:
+        - spec.manila.template.manilaAPI.customServiceConfig
+      options:
+        create: true
+- source:
+    kind: ConfigMap
+    name: service-values
     fieldPath: data.manila.manilaShares.share1.customServiceConfig
   targets:
     - select:


### PR DESCRIPTION
`service-values` for `ManilaAPI` are not currently applied when `kustomize build examples/va/hci`

Fixes: [OSPRH-5915](https://issues.redhat.com/browse/OSPRH-5915) 