### PR TITLE
Use 'local-storage' as storageClass default in values.yaml

### DIFF
--- a/examples/va/hci/control-plane/nncp/values.yaml
+++ b/examples/va/hci/control-plane/nncp/values.yaml
@@ -207,5 +207,5 @@ data:
       metallb.universe.tf/loadBalancerIPs: 172.17.0.86
 
   lbServiceType: LoadBalancer
-  storageClass: host-nfs-storageclass
+  storageClass: local-storage
   bridgeName: ospbr

--- a/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
@@ -197,5 +197,5 @@ data:
       metallb.universe.tf/loadBalancerIPs: 172.17.0.86
 
   lbServiceType: LoadBalancer
-  storageClass: host-nfs-storageclass
+  storageClass: local-storage
   bridgeName: ospbr

--- a/examples/va/nfv/ovs-dpdk/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/nncp/values.yaml
@@ -197,5 +197,5 @@ data:
       metallb.universe.tf/loadBalancerIPs: 172.17.0.86
 
   lbServiceType: LoadBalancer
-  storageClass: host-nfs-storageclass
+  storageClass: local-storage
   bridgeName: ospbr

--- a/examples/va/nfv/sriov/nncp/values.yaml
+++ b/examples/va/nfv/sriov/nncp/values.yaml
@@ -197,5 +197,5 @@ data:
       metallb.universe.tf/loadBalancerIPs: 172.17.0.86
 
   lbServiceType: LoadBalancer
-  storageClass: host-nfs-storageclass
+  storageClass: local-storage
   bridgeName: ospbr


### PR DESCRIPTION
Let's use a default `data.storageClass` entry in the various VA `values.yaml`s that better-aligns with what the majority of our environments will have