### PR TITLE
Staticize dhcp config for eth0

### DIFF
--- a/examples/va/hci/edpm-pre-ceph/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/values.yaml
@@ -45,6 +45,10 @@ data:
           {%- endfor %}
           {% set min_viable_mtu = mtu_list | max %}
           network_config:
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            mtu: {{ min_viable_mtu }}
           - type: ovs_bridge
             name: {{ neutron_physical_bridge_name }}
             mtu: {{ min_viable_mtu }}


### PR DESCRIPTION
We used to rely on libvirt assigning (and keeping track) of dhcp leases to configure eth0 ip addresses.
Let's make sure we persist this into os-net-config so that we do not accidentally lose this config between reboots.