### PR TITLE
Ensure wait_conditions starts with specific pattern

### DIFF
--- a/.ci/automation-schema.yaml
+++ b/.ci/automation-schema.yaml
@@ -20,7 +20,7 @@ _hook:
 ---
 _stage:
   path: str()
-  wait_conditions: list(min=1)
+  wait_conditions: list(str(matches='^(oc|kubectl) .*'), min=1)
   values: list(include('_values'), min=1)
   build_output: str()
   pre_stage_run: list(include('_hook'), required=False)


### PR DESCRIPTION
This ensures we're really facing a wait_condition, by checking we're
starting the command by either `oc ` or `kubectl ` (yes, with a space
after the command).
