### PR TITLE
Include install-certs dataplane service

### DIFF
--- a/examples/va/hci/values.yaml
+++ b/examples/va/hci/values.yaml
@@ -11,6 +11,7 @@ data:
     name: edpm-deployment-post-ceph
   nodeset:
     services:
+      - install-certs
       - ceph-client
       - ovn
       - neutron-metadata

--- a/examples/va/nfv/ovs-dpdk-sriov/edpm/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/edpm/values.yaml
@@ -179,6 +179,7 @@ data:
       - install-os
       - configure-os
       - run-os
+      - install-certs
       - ovn
       - neutron-metadata
       - neutron-sriov

--- a/examples/va/nfv/ovs-dpdk/edpm/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/edpm/values.yaml
@@ -160,6 +160,7 @@ data:
       - install-os
       - configure-os
       - run-os
+      - install-certs
       - ovn
       - neutron-metadata
       - libvirt

--- a/examples/va/nfv/sriov/edpm/values.yaml
+++ b/examples/va/nfv/sriov/edpm/values.yaml
@@ -134,6 +134,7 @@ data:
       - configure-os
       - run-os
       - reboot-os
+      - install-certs
       - libvirt
       - ovn
       - nova-custom-sriov


### PR DESCRIPTION
It's required with tls enabled, [1] already enabled tls by default so need to include the install-certs service before the services requiring the certs.
The issue should be visible once dataplane-operator is updated[2]

[1] https://github.com/openstack-k8s-operators/dataplane-operator/pull/754
[2] https://github.com/openstack-k8s-operators/openstack-operator/pull/732