### PR TITLE
Neutron API policies integration tempest changes

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
@@ -32,6 +32,8 @@ data:
       numa_nodes = 0 # CHANGEME
       [neutron_tunnel] # CHANGEME
       numa_nodes = 0 # CHANGEME
+      [oslo_policy]
+      policy_file=/etc/neutron/policy.d/policy.yaml
   ovn:
     ovnController:
       nicMappings:
@@ -58,3 +60,18 @@ data:
     template:
       ceilometer:
         enabled: true
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+            - NeutronAPI
+          extraVolType: Policy
+          volumes:
+            - name: neutron-policy
+              configMap:
+                name: neutron-policy
+          mounts:
+            - name: neutron-policy
+              mountPath: /etc/neutron/policy.d
+              readOnly: true

--- a/va/nfv/ovs-dpdk-sriov/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-sriov/kustomization.yaml
@@ -21,6 +21,9 @@ components:
   - ../../../lib/networking
   - ../../../lib/control-plane
 
+resources:
+  - policy.yaml
+
 replacements:
   # Neutron control plane OvS DPDK & SRIOV customization
   - source:
@@ -99,5 +102,16 @@ replacements:
           kind: OpenStackControlPlane
         fieldPaths:
           - spec.telemetry.template.ceilometer.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.extraMounts
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.extraMounts
         options:
           create: true

--- a/va/nfv/ovs-dpdk-sriov/policy.yaml
+++ b/va/nfv/ovs-dpdk-sriov/policy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: neutron-policy
+data:
+  "create_port:binding:profile": "rule:admin_or_network_owner"
+  "get_port:binding:profile": "rule:admin_or_network_owner"
+  "update_port:binding:profile": "rule:admin_or_network_owner"
+  "create_network:provider:network_type": "rule:regular_user"
+  "get_network:provider:network_type": "rule:regular_user"
+  "update_network:provider:network_type": "rule:regular_user"
+  "create_network:provider:physical_network": "rule:regular_user"
+  "get_network:provider:physical_network": "rule:regular_user"
+  "update_network:provider:physical_network": "rule:regular_user"
+  "create_network:provider:segmentation_id": "rule:regular_user"
+  "get_network:provider:segmentation_id": "rule:regular_user"
+  "update_network:provider:segmentation_id": "rule:regular_user"


### PR DESCRIPTION
This change is to provide option to configure neutron API policies to run tempest on environment.