### PR TITLE
Don't use networks both in camelcase and smallcase

### DIFF
--- a/examples/va/hci/edpm-pre-ceph/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/values.yaml
@@ -103,18 +103,6 @@ data:
         storage_mgmt_vlan_id: 23
         storage_mgmt_cidr: "24"
         storage_mgmt_host_routes: []
-    networks:
-      - defaultRoute: true
-        name: CtlPlane
-        subnetName: subnet1
-      - name: InternalApi
-        subnetName: subnet1
-      - name: Storage
-        subnetName: subnet1
-      - name: Tenant
-        subnetName: subnet1
-      - name: StorageMgmt
-        subnetName: subnet1
     nodes:
       edpm-compute-0:
         ansible:
@@ -123,15 +111,15 @@ data:
         networks:
           - defaultRoute: true
             fixedIP: 192.168.122.100
-            name: CtlPlane
+            name: ctlplane
             subnetName: subnet1
-          - name: InternalApi
+          - name: internalapi
             subnetName: subnet1
-          - name: Storage
+          - name: storage
             subnetName: subnet1
-          - name: StorageMgmt
+          - name: storagemgmt
             subnetName: subnet1
-          - name: Tenant
+          - name: tenant
             subnetName: subnet1
       edpm-compute-1:
         ansible:
@@ -140,15 +128,15 @@ data:
         networks:
           - defaultRoute: true
             fixedIP: 192.168.122.101
-            name: CtlPlane
+            name: ctlplane
             subnetName: subnet1
-          - name: InternalApi
+          - name: internalapi
             subnetName: subnet1
-          - name: Storage
+          - name: storage
             subnetName: subnet1
-          - name: StorageMgmt
+          - name: storagemgmt
             subnetName: subnet1
-          - name: Tenant
+          - name: tenant
             subnetName: subnet1
       edpm-compute-2:
         ansible:
@@ -157,15 +145,15 @@ data:
         networks:
           - defaultRoute: true
             fixedIP: 192.168.122.102
-            name: CtlPlane
+            name: ctlplane
             subnetName: subnet1
-          - name: InternalApi
+          - name: internalapi
             subnetName: subnet1
-          - name: Storage
+          - name: storage
             subnetName: subnet1
-          - name: StorageMgmt
+          - name: storagemgmt
             subnetName: subnet1
-          - name: Tenant
+          - name: tenant
             subnetName: subnet1
     services:
       - bootstrap

--- a/examples/va/nfv/ovs-dpdk-sriov/edpm/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/edpm/values.yaml
@@ -93,7 +93,7 @@ data:
               mtu: {{ min_viable_mtu }}
               # force the MAC address of the bridge to this interface
               primary: true
-          {% for network in nodeset_networks if network not in ['External', 'Tenant'] %}
+          {% for network in nodeset_networks if network not in ['external', 'tenant'] %}
             - type: vlan
               mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
               vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
@@ -104,10 +104,10 @@ data:
           - type: ovs_user_bridge
             name: br-link1
             use_dhcp: false
-            ovs_extra: "set port br-link1 tag={{ lookup('vars', networks_lower['Tenant'] ~ '_vlan_id') }}"
+            ovs_extra: "set port br-link1 tag={{ lookup('vars', networks_lower['tenant'] ~ '_vlan_id') }}"
             addresses:
-              - ip_netmask: {{ lookup('vars', networks_lower['Tenant'] ~ '_ip') }}/{{ lookup('vars', networks_lower['Tenant'] ~ '_cidr') }}
-            mtu: {{ lookup('vars', networks_lower['Tenant'] ~ '_mtu') }}
+              - ip_netmask: {{ lookup('vars', networks_lower['tenant'] ~ '_ip') }}/{{ lookup('vars', networks_lower['tenant'] ~ '_cidr') }}
+            mtu: {{ lookup('vars', networks_lower['tenant'] ~ '_mtu') }}
             rx_queue: 1
             members:
             - type: ovs_dpdk_port
@@ -156,13 +156,13 @@ data:
         edpm_selinux_mode: enforcing
     networks:
       - defaultRoute: true
-        name: CtlPlane
+        name: ctlplane
         subnetName: subnet1
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
     nodes:
       edpm-compute-0:

--- a/examples/va/nfv/ovs-dpdk/edpm/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/edpm/values.yaml
@@ -87,7 +87,7 @@ data:
               mtu: {{ min_viable_mtu }}
               # force the MAC address of the bridge to this interface
               primary: true
-          {% for network in nodeset_networks if network not in ['External', 'Tenant'] %}
+          {% for network in nodeset_networks if network not in ['external', 'tenant'] %}
             - type: vlan
               mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
               vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
@@ -98,10 +98,10 @@ data:
           - type: ovs_user_bridge
             name: br-link1
             use_dhcp: false
-            ovs_extra: "set port br-link1 tag={{ lookup('vars', networks_lower['Tenant'] ~ '_vlan_id') }}"
+            ovs_extra: "set port br-link1 tag={{ lookup('vars', networks_lower['tenant'] ~ '_vlan_id') }}"
             addresses:
-            - ip_netmask: {{ lookup('vars', networks_lower['Tenant'] ~ '_ip') }}/{{ lookup('vars', networks_lower['Tenant'] ~ '_cidr') }}
-            mtu: {{ lookup('vars', networks_lower['Tenant'] ~ '_mtu') }}
+            - ip_netmask: {{ lookup('vars', networks_lower['tenant'] ~ '_ip') }}/{{ lookup('vars', networks_lower['tenant'] ~ '_cidr') }}
+            mtu: {{ lookup('vars', networks_lower['tenant'] ~ '_mtu') }}
             members:
             - type: ovs_dpdk_port
               name: dpdk1
@@ -137,13 +137,13 @@ data:
         edpm_selinux_mode: enforcing
     networks:
       - defaultRoute: true
-        name: CtlPlane
+        name: ctlplane
         subnetName: subnet1
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
     nodes:
       edpm-compute-0:

--- a/examples/va/nfv/sriov/edpm/values.yaml
+++ b/examples/va/nfv/sriov/edpm/values.yaml
@@ -112,13 +112,13 @@ data:
         edpm_neutron_sriov_agent_SRIOV_NIC_physical_device_mappings: 'sriov-phy4:eno4'
     networks:
       - defaultRoute: true
-        name: CtlPlane
+        name: ctlplane
         subnetName: subnet1
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
     nodes:
       edpm-compute-0:

--- a/lib/networking/kustomization.yaml
+++ b/lib/networking/kustomization.yaml
@@ -225,7 +225,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=CtlPlane].dnsDomain
+          - spec.networks.[name=ctlplane].dnsDomain
   - source:
       kind: ConfigMap
       name: network-values
@@ -234,7 +234,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=InternalApi].dnsDomain
+          - spec.networks.[name=internalapi].dnsDomain
   - source:
       kind: ConfigMap
       name: network-values
@@ -243,7 +243,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=External].dnsDomain
+          - spec.networks.[name=external].dnsDomain
   - source:
       kind: ConfigMap
       name: network-values
@@ -252,7 +252,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=Storage].dnsDomain
+          - spec.networks.[name=storage].dnsDomain
   - source:
       kind: ConfigMap
       name: network-values
@@ -261,7 +261,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=Tenant].dnsDomain
+          - spec.networks.[name=tenant].dnsDomain
 
   # NetConfig MTU
   - source:
@@ -272,7 +272,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=CtlPlane].mtu
+          - spec.networks.[name=ctlplane].mtu
   - source:
       kind: ConfigMap
       name: network-values
@@ -281,7 +281,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=InternalApi].mtu
+          - spec.networks.[name=internalapi].mtu
   - source:
       kind: ConfigMap
       name: network-values
@@ -290,7 +290,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=External].mtu
+          - spec.networks.[name=external].mtu
   - source:
       kind: ConfigMap
       name: network-values
@@ -299,7 +299,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=Storage].mtu
+          - spec.networks.[name=storage].mtu
   - source:
       kind: ConfigMap
       name: network-values
@@ -308,7 +308,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=Tenant].mtu
+          - spec.networks.[name=tenant].mtu
 
   # NetConfig subnets
   - source:
@@ -319,7 +319,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=CtlPlane].subnets
+          - spec.networks.[name=ctlplane].subnets
   - source:
       kind: ConfigMap
       name: network-values
@@ -328,7 +328,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=InternalApi].subnets
+          - spec.networks.[name=internalapi].subnets
   - source:
       kind: ConfigMap
       name: network-values
@@ -337,7 +337,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=External].subnets
+          - spec.networks.[name=external].subnets
   - source:
       kind: ConfigMap
       name: network-values
@@ -346,7 +346,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=Storage].subnets
+          - spec.networks.[name=storage].subnets
   - source:
       kind: ConfigMap
       name: network-values
@@ -355,4 +355,4 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=Tenant].subnets
+          - spec.networks.[name=tenant].subnets

--- a/lib/networking/netconfig.yaml
+++ b/lib/networking/netconfig.yaml
@@ -7,27 +7,27 @@ metadata:
 spec:
   networks:
     - dnsDomain: _replaced_
-      name: CtlPlane
+      name: ctlplane
       subnets:
         - _replaced_
       mtu: 1500
     - dnsDomain: _replaced_
-      name: InternalApi
+      name: internalapi
       subnets:
         - _replaced_
       mtu: 1500
     - dnsDomain: _replaced_
-      name: External
+      name: external
       subnets:
         - _replaced_
       mtu: 1500
     - dnsDomain: _replaced_
-      name: Storage
+      name: storage
       subnets:
         - _replaced_
       mtu: 1500
     - dnsDomain: _replaced_
-      name: Tenant
+      name: tenant
       subnets:
         - _replaced_
       mtu: 1500

--- a/va/hci/kustomization.yaml
+++ b/va/hci/kustomization.yaml
@@ -21,7 +21,7 @@ components:
   - ../../lib/networking
   - ../../lib/control-plane
 
-# Add StorageMgmt network template, as it is needed for CephHCI
+# Add storagemgmt network template, as it is needed for CephHCI
 patches:
   - target:
       version: v1beta1
@@ -32,12 +32,12 @@ patches:
         path: /spec/networks/-
         value:
           dnsDomain: _replaced_
-          name: StorageMgmt
+          name: storagemgmt
           subnets:
             - _replaced_
           mtu: 1500
 
-# Add StorageMgmt network replacements
+# Add storagemgmt network replacements
 replacements:
   # NetConfig dnsDomain specific to this VA
   - source:
@@ -48,7 +48,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=StorageMgmt].dnsDomain
+          - spec.networks.[name=storagemgmt].dnsDomain
   # NetConfig MTU specific to this VA
   - source:
       kind: ConfigMap
@@ -58,7 +58,7 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=StorageMgmt].mtu
+          - spec.networks.[name=storagemgmt].mtu
   # NetConfig subnets specific to this VA
   - source:
       kind: ConfigMap
@@ -68,4 +68,4 @@ replacements:
       - select:
           kind: NetConfig
         fieldPaths:
-          - spec.networks.[name=StorageMgmt].subnets
+          - spec.networks.[name=storagemgmt].subnets


### PR DESCRIPTION
Don't use network names both in camelcase and smallcase in the same spec. Also you don't need to set them in nodeset template if provided in the node section.

Also changes networks to make them all smallcase.