### PR TITLE
Re-add wrongly removed networks from edpm-pre-ceph

### DIFF
--- a/examples/va/hci/edpm-pre-ceph/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/values.yaml
@@ -103,6 +103,16 @@ data:
         storage_mgmt_vlan_id: 23
         storage_mgmt_cidr: "24"
         storage_mgmt_host_routes: []
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
     nodes:
       edpm-compute-0:
         ansible:


### PR DESCRIPTION
In #171, `data.networks` was removed from the va-hci edpm-pre-ceph,
leading to `kustomize build` to crash with the following:

```
    kustomize command failed with: Error: accumulating components: accumulateDirectory: "recursed accumulation of path '/home/zuul/src/github.com/openstack-k8s-operators/architecture/va/hci/edpm-pre-ceph': accumulating components: accumulateDirectory: \"recursed accumulation of path '/home/zuul/src/github.com/openstack-k8s-operators/architecture/lib/dataplane': fieldPath `data.nodeset.networks` is missing for replacement source ConfigMap.[noVer].[noGrp]/edpm-values.[noNs]\""
```
