### PR TITLE
Temporarily add nodeset.networks section back to VA1

### DIFF
--- a/examples/va/hci/edpm-pre-ceph/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/values.yaml
@@ -103,6 +103,18 @@ data:
         storage_mgmt_vlan_id: 23
         storage_mgmt_cidr: "24"
         storage_mgmt_host_routes: []
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: StorageMgmt
+        subnetName: subnet1
     nodes:
       edpm-compute-0:
         ansible:


### PR DESCRIPTION
Put the `networks` section back in VA1's `edpm-pre-ceph/values.yaml` for the moment to fix...

```
kustomize command failed with: Error: accumulating components: accumulateDirectory: "recursed accumulation of path '/home/zuul/src/github.com/openstack-k8s-operators/architecture/va/hci/edpm-pre-ceph': accumulating components: accumulateDirectory: \"recursed accumulation of path '/home/zuul/src/github.com/openstack-k8s-operators/architecture/lib/dataplane': fieldPath `data.nodeset.networks` is missing for replacement source ConfigMap.[noVer].[noGrp]/edpm-values.[noNs]\""
```

...while we think about the approach we want to take.