### PR TITLE
remove route in nncp

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
@@ -182,12 +182,6 @@ data:
         values:
           - 192.168.122.1
 
-  routes:
-    config:
-      - destination: 192.168.122.0/24
-        next-hop-address: 192.168.122.1
-        next-hop-interface: enp6s0
-
   rabbitmq:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi


### PR DESCRIPTION
It is causing issues, it is not possible to connect from any pod, for example tempest pod or openstackclient pod to compute nodes using control plane network (192.168.122.0/24)

Not sure what issue is trying to solve this route, I think it is not needed