### PR TITLE
Revert Staticize dhcp config for eth0

### DIFF
--- a/examples/va/hci/edpm-pre-ceph/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/values.yaml
@@ -47,10 +47,6 @@ data:
           {%- endfor %}
           {% set min_viable_mtu = mtu_list | max %}
           network_config:
-          - type: interface
-            name: nic1
-            use_dhcp: true
-            mtu: {{ min_viable_mtu }}
           - type: ovs_bridge
             name: {{ neutron_physical_bridge_name }}
             mtu: {{ min_viable_mtu }}


### PR DESCRIPTION
Using dhcp for  nic1 breaks the dns configuration by updating resolv.conf used by edpm. Reverting to fix current issues and if there is a requirement to use dhcp for nic1 it could be reworked.