### PR TITLE
Enforce actual "wait"

### DIFF
--- a/.ci/automation-schema.yaml
+++ b/.ci/automation-schema.yaml
@@ -20,7 +20,7 @@ _hook:
 ---
 _stage:
   path: str()
-  wait_conditions: list(str(matches='^(oc|kubectl) .*'), min=1)
+  wait_conditions: list(str(matches='^(oc|kubectl) .* wait .*'), min=1)
   values: list(include('_values'), min=1)
   build_output: str()
   pre_stage_run: list(include('_hook'), required=False)


### PR DESCRIPTION
It seems some wants to use the wait_conditions to do other tasks than
`oc wait`. This should catch that kind of misusage.

If anything else has to be done via commands, it must be either:
- a stage (allowing to kustomize)
- a post_run hook
