### PR TITLE
Remove nncp next-hope-interface from ConfigMap

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
@@ -186,7 +186,6 @@ data:
     config:
       - destination: 192.168.122.0/24
         next-hop-address: 192.168.122.1
-        next-hop-interface: enp6s0
 
   rabbitmq:
     endpoint_annotations:

--- a/examples/va/nfv/ovs-dpdk/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/nncp/values.yaml
@@ -186,7 +186,6 @@ data:
     config:
       - destination: 192.168.122.0/24
         next-hop-address: 192.168.122.1
-        next-hop-interface: enp6s0
 
   rabbitmq:
     endpoint_annotations:

--- a/examples/va/nfv/sriov/nncp/values.yaml
+++ b/examples/va/nfv/sriov/nncp/values.yaml
@@ -186,7 +186,6 @@ data:
     config:
       - destination: 192.168.122.0/24
         next-hop-address: 192.168.122.1
-        next-hop-interface: enp6s0
 
   rabbitmq:
     endpoint_annotations:


### PR DESCRIPTION
All the network-values ConfigMaps has the next-hope-interface set in the route placed there. That value is not consumed anywhere as the generated NNCPs uses the bridge interface name as next-hop and not the one set there.
The presence of this field may confuse a user.