### PR TITLE
Remove networkAttachment for ovnNorthd

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -153,8 +153,6 @@ spec:
           dbType: SB
           networkAttachment: internalapi
           storageRequest: 10G
-      ovnNorthd:
-        networkAttachment: internalapi
   placement:
     apiOverride:
       route: {}


### PR DESCRIPTION
ovnNorthd does not require additional interface via networkAttachment, this patch removes it from the sample files.

Closes: OSPRH-659