### PR TITLE
Add missing libvirt-secret

### DIFF
--- a/lib/dataplane/kustomization.yaml
+++ b/lib/dataplane/kustomization.yaml
@@ -2,6 +2,14 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+secretGenerator:
+  - name: libvirt-secret
+    behavior: create
+    literals:
+      - LibvirtPassword=12345678
+    options:
+      disableNameSuffixHash: true
+
 resources:
   - dataplane-ssh-secret.yaml
   - nova-migration-ssh-secret.yaml


### PR DESCRIPTION
With the commit in [dataplane-operator#831](https://github.com/openstack-k8s-operators/dataplane-operator/pull/831), libvirt-secret is now required to be available before nova service can be deployed on the compute nodes.

```
message: Deployment error occurred Secret "libvirt-secret" not found  (non ceph job)
```

