### PR TITLE
Add ssh-known-hosts service to dataplane

### DIFF
--- a/examples/va/hci/edpm-pre-ceph/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/values.yaml
@@ -176,6 +176,7 @@ data:
       - install-os
       - ceph-hci-pre
       - configure-os
+      - ssh-known-hosts
       - run-os
       - reboot-os
   nova:

--- a/examples/va/nfv/ovs-dpdk-sriov/edpm/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/edpm/values.yaml
@@ -178,6 +178,7 @@ data:
       - validate-network
       - install-os
       - configure-os
+      - ssh-known-hosts
       - run-os
       - install-certs
       - ovn

--- a/examples/va/nfv/ovs-dpdk/edpm/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/edpm/values.yaml
@@ -159,6 +159,7 @@ data:
       - validate-network
       - install-os
       - configure-os
+      - ssh-known-hosts
       - run-os
       - install-certs
       - ovn

--- a/examples/va/nfv/sriov/edpm/values.yaml
+++ b/examples/va/nfv/sriov/edpm/values.yaml
@@ -132,6 +132,7 @@ data:
       - validate-network
       - install-os
       - configure-os
+      - ssh-known-hosts
       - run-os
       - reboot-os
       - install-certs


### PR DESCRIPTION
Nova requires that an SSH known hosts file is created on all hosts for live migration. All VAs and DTs require this service and we probably didn't notice it was missing because we're not testing live migration (but should). The recently added DTs already had this service.

Related:
https://github.com/openstack-k8s-operators/ci-framework/pull/1515