### PR TITLE
Allow lib/networking to be used without directly referencing sub-dirs

### DIFF
--- a/lib/networking/kustomization.yaml
+++ b/lib/networking/kustomization.yaml
@@ -2,8 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-resources:
-  - metallb/metallb_l2advertisement.yaml
-  - metallb/ocp_ip_pools.yaml
-  - nad/ocp_networks_netattach.yaml
-  - netconfig/netconfig.yaml
+components:
+  - metallb
+  - nad
+  - netconfig


### PR DESCRIPTION
This change allows `lib/networking` to be used directly instead of having to explicitly point to each sud-dir, i.e.

```
components:
  - ../../lib/networking/metallb
  - ../../lib/networking/netconfig
  - ../../lib/networking/nad
```

can be instead written as:

```
components:
  - ../../lib/networking
```