### PR TITLE
Switch memcached to use three replicas

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -117,7 +117,7 @@ spec:
   memcached:
     templates:
       memcached:
-        replicas: 1
+        replicas: 3
   neutron:
     apiOverride:
       route: {}


### PR DESCRIPTION
We should deploy a three-replica memcached service to reflect what should be done in production.