### PR TITLE
Enable glance sparse image upload

### DIFF
--- a/examples/va/hci/service-values.yaml
+++ b/examples/va/hci/service-values.yaml
@@ -37,6 +37,7 @@ data:
       store_description = "RBD backend"
       rbd_store_pool = images
       rbd_store_user = openstack
+      rbd_thin_provisioning = True
     glanceAPIs:
       default:
         replicas: 3


### PR DESCRIPTION
When Glance is configured with Ceph RBD there are performance benefits for storage usage and upload time when `rbd_thin_provisioning` is set.

https://specs.openstack.org/openstack/glance-specs/specs/victoria/approved/glance_store/handle-sparse-image.html