### PR TITLE
[example] Delete routes from NNCP for environment

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov/nncp/kustomization.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/nncp/kustomization.yaml
@@ -22,3 +22,12 @@ components:
 
 resources:
   - values.yaml
+
+patches:
+  - target:
+      group: nmstate.io
+      version: v1
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: remove
+        path: /spec/desiredState/routes

--- a/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
@@ -182,6 +182,12 @@ data:
         values:
           - 192.168.122.1
 
+  routes:
+    config:
+      - destination: 192.168.122.0/24
+        next-hop-address: 192.168.122.1
+        next-hop-interface: enp6s0
+
   rabbitmq:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi

--- a/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
@@ -182,12 +182,6 @@ data:
         values:
           - 192.168.122.1
 
-  routes:
-    config:
-      - destination: 192.168.122.0/24
-        next-hop-address: 192.168.122.1
-        next-hop-interface: enp6s0
-
   rabbitmq:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi


### PR DESCRIPTION
Example PR to show how to drop generated objects not desired from the rendered object for specific environments vs removing the values.yaml entries, which are required by the base components.

Related to PR #177 