### PR TITLE
Drop nncp ctlplane routes

### DIFF
--- a/examples/dt/uni01alpha/control-plane/nncp/values.yaml
+++ b/examples/dt/uni01alpha/control-plane/nncp/values.yaml
@@ -207,10 +207,7 @@ data:
           - 192.168.122.1
 
   routes:
-    config:
-      - destination: 0.0.0.0/0
-        next-hop-address: 192.168.122.1
-        next-hop-interface: enp6s0
+    config: []
 
   rabbitmq:
     endpoint_annotations:

--- a/examples/dt/uni06zeta/control-plane/nncp/values.yaml
+++ b/examples/dt/uni06zeta/control-plane/nncp/values.yaml
@@ -183,10 +183,7 @@ data:
           - 192.168.122.1
 
   routes:
-    config:
-      - destination: 192.168.122.0/24
-        next-hop-address: 192.168.122.1
-        next-hop-interface: ospbr
+    config: []
 
   rabbitmq:
     endpoint_annotations:

--- a/examples/va/hci/control-plane/nncp/values.yaml
+++ b/examples/va/hci/control-plane/nncp/values.yaml
@@ -193,10 +193,7 @@ data:
           - 192.168.122.1
 
   routes:
-    config:
-      - destination: 0.0.0.0/0
-        next-hop-address: 192.168.122.1
-        next-hop-interface: enp6s0
+    config: []
 
   rabbitmq:
     endpoint_annotations:

--- a/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
@@ -183,10 +183,7 @@ data:
           - 192.168.122.1
 
   routes:
-    config:
-      - destination: 192.168.122.0/24
-        next-hop-address: 192.168.122.1
-        next-hop-interface: enp6s0
+    config: []
 
   rabbitmq:
     endpoint_annotations:

--- a/examples/va/nfv/ovs-dpdk/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/nncp/values.yaml
@@ -183,10 +183,7 @@ data:
           - 192.168.122.1
 
   routes:
-    config:
-      - destination: 192.168.122.0/24
-        next-hop-address: 192.168.122.1
-        next-hop-interface: enp6s0
+    config: []
 
   rabbitmq:
     endpoint_annotations:

--- a/examples/va/nfv/sriov/nncp/values.yaml
+++ b/examples/va/nfv/sriov/nncp/values.yaml
@@ -183,10 +183,7 @@ data:
           - 192.168.122.1
 
   routes:
-    config:
-      - destination: 192.168.122.0/24
-        next-hop-address: 192.168.122.1
-        next-hop-interface: enp6s0
+    config: []
 
   rabbitmq:
     endpoint_annotations:

--- a/lib/nncp/kustomization.yaml
+++ b/lib/nncp/kustomization.yaml
@@ -418,21 +418,12 @@ replacements:
   - source:
       kind: ConfigMap
       name: network-values
-      fieldPath: data.routes.config.0.destination
+      fieldPath: data.routes
     targets:
       - select:
           kind: NodeNetworkConfigurationPolicy
         fieldPaths:
-          - spec.desiredState.routes.config.0.destination
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.routes.config.0.next-hop-address
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-        fieldPaths:
-          - spec.desiredState.routes.config.0.next-hop-address
+          - spec.desiredState.routes
   - source:
       kind: ConfigMap
       name: network-values
@@ -441,5 +432,4 @@ replacements:
       - select:
           kind: NodeNetworkConfigurationPolicy
         fieldPaths:
-          - spec.desiredState.routes.config.0.next-hop-interface
           - spec.desiredState.interfaces.[type=linux-bridge].name

--- a/lib/nncp/ocp_node_template.yaml
+++ b/lib/nncp/ocp_node_template.yaml
@@ -10,10 +10,7 @@ spec:
         search: []
         server: []
     routes:
-      config:
-        - destination: _replaced_
-          next-hop-address: _replaced_
-          next-hop-interface: _replaced_
+      config: []
     interfaces:
       - description: internalapi vlan interface
         ipv4:


### PR DESCRIPTION
These ctlplane routes were originally added as part of [1], and since then they required various adjustment due to one or the other issues. It was pointed out these routes shouldn't be needed for the use case it was originally added for, so let's drop these ctlplane routes for va and dts. It would still be possible to add some custom host routes by passing config like in values.yaml:-

routes:
  config:
    - destination: <destination>
      next-hop-address: <gateway>
      next-hop-interface: <interface/bridge>

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/481

Related-Issue: OSPRH-6307