### PR TITLE
Added libvirt-secret required for VA2

### DIFF
--- a/va/nfv/ovs-dpdk-sriov/edpm/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-sriov/edpm/kustomization.yaml
@@ -24,6 +24,14 @@ resources:
   - baremetalset-password-secret.yaml
   - nova_ovs_dpdk_sriov.yaml
 
+secretGenerator:
+  - name: libvirt-secret
+    behavior: create
+    literals:
+      - LibvirtPassword=12345678
+    options:
+      disableNameSuffixHash: true
+
 replacements:
   - source:
       kind: ConfigMap

--- a/va/nfv/ovs-dpdk/edpm/kustomization.yaml
+++ b/va/nfv/ovs-dpdk/edpm/kustomization.yaml
@@ -24,6 +24,14 @@ resources:
   - baremetalset-password-secret.yaml
   - nova_ovs_dpdk.yaml
 
+secretGenerator:
+  - name: libvirt-secret
+    behavior: create
+    literals:
+      - LibvirtPassword=12345678
+    options:
+      disableNameSuffixHash: true
+
 replacements:
   - source:
       kind: ConfigMap

--- a/va/nfv/sriov/edpm/kustomization.yaml
+++ b/va/nfv/sriov/edpm/kustomization.yaml
@@ -24,6 +24,14 @@ resources:
   - baremetalset-password-secret.yaml
   - nova_sriov.yaml
 
+secretGenerator:
+  - name: libvirt-secret
+    behavior: create
+    literals:
+      - LibvirtPassword=12345678
+    options:
+      disableNameSuffixHash: true
+
 replacements:
   - source:
       kind: ConfigMap


### PR DESCRIPTION
Added libvirt-secret required for VA2, this should resolve an issue with edpm not being able to run the nova service.

Should resolve: https://issues.redhat.com/browse/OSPRH-6702