### PR TITLE
Move octavia-ca-passphrase to properly apply NamespaceTransformer

### DIFF
--- a/dt/bgp/kustomization.yaml
+++ b/dt/bgp/kustomization.yaml
@@ -2,6 +2,13 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+secretGenerator:
+  - name: octavia-ca-passphrase
+    literals:
+      - server-ca-passphrase=12345678
+    options:
+      disableNameSuffixHash: true
+
 transformers:
   # Set namespace to OpenStack on all namespaced objects without a namespace
   - |-

--- a/dt/uni01alpha/kustomization.yaml
+++ b/dt/uni01alpha/kustomization.yaml
@@ -2,6 +2,13 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+secretGenerator:
+  - name: octavia-ca-passphrase
+    literals:
+      - server-ca-passphrase=12345678
+    options:
+      disableNameSuffixHash: true
+
 transformers:
   - |-
       apiVersion: builtin

--- a/examples/dt/bgp/control-plane/kustomization.yaml
+++ b/examples/dt/bgp/control-plane/kustomization.yaml
@@ -2,13 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-secretGenerator:
-  - name: octavia-ca-passphrase
-    literals:
-      - server-ca-passphrase=12345678
-    options:
-      disableNameSuffixHash: true
-
 components:
   - ../../../../dt/bgp/
 

--- a/examples/dt/uni01alpha/control-plane/kustomization.yaml
+++ b/examples/dt/uni01alpha/control-plane/kustomization.yaml
@@ -2,13 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-secretGenerator:
-  - name: octavia-ca-passphrase
-    literals:
-      - server-ca-passphrase=12345678
-    options:
-      disableNameSuffixHash: true
-
 components:
   - ../../../../dt/uni01alpha
 


### PR DESCRIPTION
For some reason, when ci-framework generates the
octavia-ca-passphrase Secret, it does not include any namespace.
The output obtained with `kustomize build` is different and the
openstack namespace is correctly included in this case.

With this patch, the octavia-ca-passphrase secret is moved to the
kustomization.yaml file where the NamespaceTransformer is defined too.
After this change, the openstack namespace is properly added to the
secret.