### PR TITLE
Revert "Added github-gate pipeline"

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,6 +3,3 @@
     github-check:
       jobs:
         - noop
-    github-gate:
-      jobs:
-        - noop


### PR DESCRIPTION
Reverts openstack-k8s-operators/architecture#217
We want to test zuul merge and tide workflow first in testing repo. Then we will add back.