### PR TITLE
Fix observability-operator name in readme

### DIFF
--- a/examples/dt/uni01alpha/control-plane.md
+++ b/examples/dt/uni01alpha/control-plane.md
@@ -24,7 +24,7 @@ metadata:
 spec:
   channel: development
   installPlanApproval: Automatic
-  name: observability-operator
+  name: cluster-observability-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 EOF


### PR DESCRIPTION
The `name` in the spec should be `cluster-observability-operator`.

Ref: https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/openshift_obs/defaults/main.yml#L29C11-L29C40