### PR TITLE
[uni01alpha] Addresses some of the failures observed during test execution

### DIFF
--- a/examples/dt/uni01alpha/control-plane/nncp/values.yaml
+++ b/examples/dt/uni01alpha/control-plane/nncp/values.yaml
@@ -219,5 +219,5 @@ data:
       metallb.universe.tf/loadBalancerIPs: 172.17.0.86
 
   lbServiceType: LoadBalancer
-  storageClass: host-nfs-storageclass
+  storageClass: local-storage
   bridgeName: ospbr

--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -21,8 +21,8 @@ data:
         target_protocol = iscsi
         target_helper = lioadm
         volume_backend_name = lvm_iscsi
-        target_ip_address=172.18.0.5
-        target_secondary_ip_addresses = 172.19.0.5
+        target_ip_address=172.18.0.10
+        target_secondary_ip_addresses = 172.19.0.10
 
   cinderBackup:
     customServiceConfig: |

--- a/lib/control-plane/kustomization.yaml
+++ b/lib/control-plane/kustomization.yaml
@@ -111,6 +111,7 @@ replacements:
         fieldPaths:
           - spec.storageClass
           - spec.glance.template.storageClass
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageClass
   - source:
       kind: ConfigMap
       name: network-values

--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -196,7 +196,7 @@ spec:
             retention: 24h
             persistent:
               pvcStorageRequest: 10Gi
-              pvcStorageClass: local-storage
+              pvcStorageClass: _replaced_
       autoscaling:
         enabled: false
         aodh:


### PR DESCRIPTION
In this change set, the following modifications are being carried for `uni01alpha` deployed tolopogies

- Fix the iSCSI address mentioned for `master-0`
- Allow custom storage class for telemetry's monitoring stack
- Default to `local-storage` as the storageClass.

*Tests*

_With fix_ 
Test run time 5 hours
```
Unit Test Report
Status: Pass 2090 Failure 93 Skip 537
```

_Without fix_
Test run time 6 hours
```
Unit Test Report
Status: Pass 2097 Failure 106 Skip 540
```