### PR TITLE
Fix the spec path for the amphora and apache images for octavia

### DIFF
--- a/dt/bgp/kustomization.yaml
+++ b/dt/bgp/kustomization.yaml
@@ -194,7 +194,7 @@ replacements:
       - select:
           kind: OpenStackControlPlane
         fieldPaths:
-          - spec.octavia.amphoraImageContainerImage
+          - spec.octavia.template.amphoraImageContainerImage
         options:
           create: true
 
@@ -206,7 +206,7 @@ replacements:
       - select:
           kind: OpenStackControlPlane
         fieldPaths:
-          - spec.octavia.apacheContainerImage
+          - spec.octavia.template.apacheContainerImage
         options:
           create: true
 

--- a/dt/uni01alpha/kustomization.yaml
+++ b/dt/uni01alpha/kustomization.yaml
@@ -173,7 +173,7 @@ replacements:
       - select:
           kind: OpenStackControlPlane
         fieldPaths:
-          - spec.octavia.amphoraImageContainerImage
+          - spec.octavia.template.amphoraImageContainerImage
         options:
           create: true
 
@@ -185,7 +185,7 @@ replacements:
       - select:
           kind: OpenStackControlPlane
         fieldPaths:
-          - spec.octavia.apacheContainerImage
+          - spec.octavia.template.apacheContainerImage
         options:
           create: true
 


### PR DESCRIPTION
Patch fixes the path to configure the octavia operator for the apacheContainerImage and amphoraImageContainerImage.