### PR TITLE
[uni01alpha] Add AZ parameter for octavia and re-enable

### DIFF
--- a/dt/uni01alpha/kustomization.yaml
+++ b/dt/uni01alpha/kustomization.yaml
@@ -192,6 +192,18 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.octavia.availabilityZones
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.lbMgmtNetwork.availabilityZones
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.octavia.octaviaAPI.networkAttachments
     targets:
       - select:

--- a/examples/dt/bgp/control-plane/nncp/values.yaml
+++ b/examples/dt/bgp/control-plane/nncp/values.yaml
@@ -189,9 +189,9 @@ data:
         "bridge": "octbr",
         "ipam": {
           "type": "whereabouts",
-          "range": "172.20.0.0/24",
-          "range_start": "172.20.0.30",
-          "range_end": "172.20.0.70"
+          "range": "172.24.0.0/24",
+          "range_start": "172.24.0.30",
+          "range_end": "172.24.0.70"
         }
       }
   external:

--- a/examples/dt/uni01alpha/README.md
+++ b/examples/dt/uni01alpha/README.md
@@ -37,7 +37,7 @@ This topology is used for executing integration tests that evaluate the
 | internalapi | VLAN tagged | 172.17.0.0/24     |
 | storage     | VLAN tagged | 172.18.0.0/24     |
 | tenant      | VLAN tagged | 172.19.0.0/24     |
-| octavia     | VLAN tagged | 172.20.0.0/24     |
+| octavia     | VLAN tagged | 172.24.0.0/24     |
 
 ### Services, enabled features and configurations
 

--- a/examples/dt/uni01alpha/control-plane/nncp/values.yaml
+++ b/examples/dt/uni01alpha/control-plane/nncp/values.yaml
@@ -169,9 +169,9 @@ data:
         "bridge": "octbr",
         "ipam": {
           "type": "whereabouts",
-          "range": "172.20.0.0/24",
-          "range_start": "172.20.0.30",
-          "range_end": "172.20.0.70"
+          "range": "172.24.0.0/24",
+          "range_start": "172.24.0.30",
+          "range_end": "172.24.0.70"
         }
       }
 

--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -54,11 +54,12 @@ data:
   swift:
     enabled: true
 
-  # ToDo: octavia needs to be enabled once the issue is fixed.
   octavia:
-    enabled: false
+    enabled: true
     amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image
     apacheContainerImage: registry.redhat.io/ubi9/httpd-24:latest
+    availabilityZones:
+      - zone-1
     octaviaAPI:
       networkAttachments:
         - internalapi


### PR DESCRIPTION
The uni01alpha uses AZs, some of which are not available at the time octavia is deployed. A recent patch to support using AZs in the octavia deployment should allow octavia to proceed as soon as the ovn controller in the control plane is available.

This patch adds the appropriate value for uni01alpha and re-enables octavia.

Depends-On: https://github.com/openstack-k8s-operators/octavia-operator/pull/302
Jira: OSPRH-6901