### PR TITLE
Fix octavia network attachment subnet range.

### DIFF
--- a/examples/dt/bgp/control-plane/nncp/values.yaml
+++ b/examples/dt/bgp/control-plane/nncp/values.yaml
@@ -189,9 +189,9 @@ data:
         "bridge": "octbr",
         "ipam": {
           "type": "whereabouts",
-          "range": "172.24.0.0/24",
-          "range_start": "172.24.0.30",
-          "range_end": "172.24.0.70"
+          "range": "172.23.0.0/24",
+          "range_start": "172.23.0.30",
+          "range_end": "172.23.0.70"
         }
       }
   external:

--- a/examples/dt/uni01alpha/README.md
+++ b/examples/dt/uni01alpha/README.md
@@ -37,7 +37,7 @@ This topology is used for executing integration tests that evaluate the
 | internalapi | VLAN tagged | 172.17.0.0/24     |
 | storage     | VLAN tagged | 172.18.0.0/24     |
 | tenant      | VLAN tagged | 172.19.0.0/24     |
-| octavia     | VLAN tagged | 172.24.0.0/24     |
+| octavia     | VLAN tagged | 172.23.0.0/24     |
 
 ### Services, enabled features and configurations
 

--- a/examples/dt/uni01alpha/control-plane/nncp/values.yaml
+++ b/examples/dt/uni01alpha/control-plane/nncp/values.yaml
@@ -169,9 +169,9 @@ data:
         "bridge": "octbr",
         "ipam": {
           "type": "whereabouts",
-          "range": "172.24.0.0/24",
-          "range_start": "172.24.0.30",
-          "range_end": "172.24.0.70"
+          "range": "172.23.0.0/24",
+          "range_start": "172.23.0.30",
+          "range_end": "172.23.0.70"
         }
       }
 


### PR DESCRIPTION
Fixes the expected subnet IP range for the octavia network attachment. A previous change erroneously set this to the range for the tenant network instead of the provider network.