### PR TITLE
Consolidate gitignores for uni-jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-examples/dt/one
+examples/dt/uni*/control-plane/control-plane.yaml
+examples/dt/uni*/control-plane/nncp/nncp.yaml
+examples/dt/uni*/data-plane.yaml
+examples/dt/uni*/networker/edpm-networker.yaml

--- a/examples/dt/uni01alpha/.gitignore
+++ b/examples/dt/uni01alpha/.gitignore
@@ -1,1 +1,0 @@
-data-plane.yaml

--- a/examples/dt/uni01alpha/control-plane/.gitignore
+++ b/examples/dt/uni01alpha/control-plane/.gitignore
@@ -1,1 +1,0 @@
-control-plane.yaml

--- a/examples/dt/uni01alpha/control-plane/nncp/.gitignore
+++ b/examples/dt/uni01alpha/control-plane/nncp/.gitignore
@@ -1,1 +1,0 @@
-nncp.yaml

--- a/examples/dt/uni01alpha/networker/.gitignore
+++ b/examples/dt/uni01alpha/networker/.gitignore
@@ -1,1 +1,0 @@
-edpm-networker.yaml

--- a/examples/dt/uni02beta/.gitignore
+++ b/examples/dt/uni02beta/.gitignore
@@ -1,1 +1,0 @@
-data-plane.yaml

--- a/examples/dt/uni02beta/control-plane/.gitignore
+++ b/examples/dt/uni02beta/control-plane/.gitignore
@@ -1,1 +1,0 @@
-control-plane.yaml

--- a/examples/dt/uni02beta/control-plane/nncp/.gitignore
+++ b/examples/dt/uni02beta/control-plane/nncp/.gitignore
@@ -1,1 +1,0 @@
-nncp.yaml

--- a/examples/dt/uni06zeta/.gitignore
+++ b/examples/dt/uni06zeta/.gitignore
@@ -1,1 +1,0 @@
-data-plane.yaml

--- a/examples/dt/uni06zeta/control-plane/.gitignore
+++ b/examples/dt/uni06zeta/control-plane/.gitignore
@@ -1,1 +1,0 @@
-control-plane.yaml

--- a/examples/dt/uni06zeta/control-plane/nncp/.gitignore
+++ b/examples/dt/uni06zeta/control-plane/nncp/.gitignore
@@ -1,1 +1,0 @@
-nncp.yaml


### PR DESCRIPTION
Right now in `examples/dt` we keep multiple .gitignores that basically share the same entries and when we introduce a new DT, there are those all additional files that are not really meaningful. Having in review just 11 files instead of 15 would look more affordable when browsing in GitHub interface.