### PR TITLE
Generate build jobs for all automations

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -41,3 +41,23 @@ jobs:
         run: |
           kustomize version
           ./test-kustomizations.sh examples/
+
+  test-zuul:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install yaml
+        run: pip install pyyaml
+
+      - name: Run create-zuul-jobs
+        run: |
+          sha256sum zuul.d/* > checksum;
+          ./create-zuul-jobs.py;
+          sha256sum -c checksum || (git diff && exit 1) && exit 0;

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -2,6 +2,7 @@
 extends: default
 ignore:
   - '*.md'
+  - 'zuul.d/'
 
 rules:
   line-length:

--- a/automation/mocks/ovs-dpdk.yaml
+++ b/automation/mocks/ovs-dpdk.yaml
@@ -1,0 +1,1 @@
+ovs-dpdk-sriov.yaml

--- a/automation/mocks/sriov.yaml
+++ b/automation/mocks/sriov.yaml
@@ -1,0 +1,1 @@
+ovs-dpdk-sriov.yaml

--- a/automation/vars/README.md
+++ b/automation/vars/README.md
@@ -7,8 +7,47 @@ project if you add a new key, or modify a type!
 
 More information about [yamale](https://github.com/23andMe/Yamale).
 
-## Manually check schema
+### Manually check schema
 ```Bash
 $ pip install yamale
 $ yamale -s .ci/automation-schema.yaml automation/vars
 ```
+
+## Adding a new automation scenario
+
+You have to ensure new CI job is create for your new scenario.
+
+You can generate the new job running the `create-zuul-jobs.py`
+script located at the root of this repository.
+
+The script requires `pyyaml`.
+
+The Zuul job supports `Depends-On` in case your new scenario needs specific
+data from the CI Framework (usually in the
+[ci_gen_kustomize_values](https://ci-framework.readthedocs.io/en/latest/roles/ci_gen_kustomize_values.html)
+role).
+
+### Manually validating your scenario: CI Framework
+
+The [CI Framework](https://github.com/openstack-k8s-operators/ci-framework) project is
+able to consume the automation files. Therefore, it can be used in order to ensure
+the various pieces are working together.
+
+#### Read-only build
+
+The Framework provides a playbook able to run against the automation, and build the CRs.
+This is reflected in the Zuul CI tests associated to this project, like
+`rhoso-architecture-validate-hci`.
+
+If you want to manually test using the CI Framework before proposing a new scenario automation,
+you can run the following:
+```Bash
+$ cd ci-framework
+$ make run_ctx_architecture_test \
+    SCENARIO_NAME=your_scenario \
+    ARCH_REPO=../architecture  \
+    NET_ENV_FILE=./ci/playbooks/files/networking-env-definition.yml
+```
+You have to install `podman` to run this - everything will run in a container.
+
+You can find the built CRs in `~/ci-framework-data/your_scenario/artifacts/`.

--- a/create-zuul-jobs.py
+++ b/create-zuul-jobs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import os
+import yaml
+
+_AUTO_PATH = 'automation/vars/'
+_JOBS = []
+_PROJECTS = ['noop']
+_BASE_TRIGGER_FILES = [
+        'lib',
+        ]
+
+def create_job(name, data):
+    j_name = 'rhoso-architecture-validate-{}'.format(name)
+    _paths = [p['path'] for p in data['stages']] + _BASE_TRIGGER_FILES
+    for i in ['va', 'dt']:
+        if os.path.exists(os.path.join(i, name)):
+            _paths.append(os.path.join(i, name))
+    _mock = os.path.join('automation', 'mocks', '{}.yaml'.format(name))
+    if os.path.exists(_mock):
+        _paths.append(_mock)
+    _paths.sort()
+    job = {
+            'job': {
+                'name': j_name,
+                'parent': 'rhoso-architecture-base-job',
+                'vars': {
+                    'cifmw_architecture_scenario': name,
+                    },
+                'files': _paths,
+                }
+            }
+    _JOBS.append(job)
+    _PROJECTS.append(j_name)
+
+
+for fname in [f for f in os.listdir(_AUTO_PATH) if f.endswith('.yaml')]:
+    with open(os.path.join(_AUTO_PATH, fname), 'r') as y_file:
+        scenarios = yaml.safe_load(y_file)
+    for scenario, stages in scenarios['vas'].items():
+        create_job(scenario, stages)
+
+_sorted_jobs = sorted(_JOBS, key= lambda d: d['job']['name'])
+with open('./zuul.d/validations.yaml', 'w+') as zuul_jobs:
+    yaml.dump(_sorted_jobs, zuul_jobs)
+
+_PROJECTS.sort()
+with open('./zuul.d/projects.yaml', 'w+') as zuul_projects:
+    struct = [{'project': {'github-check': {'jobs': _PROJECTS},
+                           'github-gate': {'jobs': _PROJECTS}
+                           }
+               }
+              ]
+    yaml.dump(struct, zuul_projects)

--- a/zuul.d/base-jobs.yaml
+++ b/zuul.d/base-jobs.yaml
@@ -1,6 +1,6 @@
 ---
 # How to create a new job:
-# - check the syntax defined for the existing jobs
+# - run .ci/create-zuul-jobs.py script to regenerate based on automations
 # - if your scenario needs mocked data:
 #     - push a proper YAML file in automation/mocks/SCENARIO_NAME.yaml
 #     - that's all!
@@ -14,19 +14,3 @@
     parent: cifmw-architecture-validate-base
     required-projects:
       - openstack-k8s-operators/ci-framework
-
-- job:
-    name: rhoso-architecture-validate-hci
-    parent: rhoso-architecture-base-job
-    vars:
-      cifmw_architecture_scenario: hci
-    files:
-      - examples/va/hci
-
-- job:
-    name: rhoso-architecture-validate-ovs-dpdk-sriov
-    parent: rhoso-architecture-base-job
-    vars:
-      cifmw_architecture_scenario: ovs-dpdk-sriov
-    files:
-      - examples/va/nfv

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,12 +1,15 @@
----
 - project:
     github-check:
-      jobs:
-        - noop
-        - rhoso-architecture-validate-hci
-        - rhoso-architecture-validate-ovs-dpdk-sriov
+      jobs: &id001
+      - noop
+      - rhoso-architecture-validate-bgp
+      - rhoso-architecture-validate-hci
+      - rhoso-architecture-validate-ovs-dpdk
+      - rhoso-architecture-validate-ovs-dpdk-sriov
+      - rhoso-architecture-validate-sriov
+      - rhoso-architecture-validate-uni01alpha
+      - rhoso-architecture-validate-uni02beta
+      - rhoso-architecture-validate-uni04delta
+      - rhoso-architecture-validate-uni06zeta
     github-gate:
-      jobs:
-        - noop
-        - rhoso-architecture-validate-hci
-        - rhoso-architecture-validate-ovs-dpdk-sriov
+      jobs: *id001

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -1,0 +1,110 @@
+- job:
+    files:
+    - dt/bgp
+    - examples/dt/bgp/control-plane
+    - examples/dt/bgp/control-plane/nncp
+    - examples/dt/bgp/edpm/deployment
+    - examples/dt/bgp/edpm/nodeset
+    - lib
+    name: rhoso-architecture-validate-bgp
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: bgp
+- job:
+    files:
+    - examples/va/hci
+    - examples/va/hci/control-plane
+    - examples/va/hci/control-plane/nncp
+    - examples/va/hci/deployment
+    - examples/va/hci/edpm-pre-ceph/deployment
+    - examples/va/hci/edpm-pre-ceph/nodeset
+    - lib
+    - va/hci
+    name: rhoso-architecture-validate-hci
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: hci
+- job:
+    files:
+    - automation/mocks/ovs-dpdk.yaml
+    - examples/va/nfv/ovs-dpdk
+    - examples/va/nfv/ovs-dpdk/edpm/deployment
+    - examples/va/nfv/ovs-dpdk/edpm/nodeset
+    - examples/va/nfv/ovs-dpdk/nncp
+    - lib
+    name: rhoso-architecture-validate-ovs-dpdk
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: ovs-dpdk
+- job:
+    files:
+    - automation/mocks/ovs-dpdk-sriov.yaml
+    - examples/va/nfv/ovs-dpdk-sriov
+    - examples/va/nfv/ovs-dpdk-sriov/edpm/deployment
+    - examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset
+    - examples/va/nfv/ovs-dpdk-sriov/nncp
+    - lib
+    name: rhoso-architecture-validate-ovs-dpdk-sriov
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: ovs-dpdk-sriov
+- job:
+    files:
+    - automation/mocks/sriov.yaml
+    - examples/va/nfv/sriov
+    - examples/va/nfv/sriov/edpm/deployment
+    - examples/va/nfv/sriov/edpm/nodeset
+    - examples/va/nfv/sriov/nncp
+    - lib
+    name: rhoso-architecture-validate-sriov
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: sriov
+- job:
+    files:
+    - dt/uni01alpha
+    - examples/dt/uni01alpha
+    - examples/dt/uni01alpha/control-plane
+    - examples/dt/uni01alpha/control-plane/nncp
+    - examples/dt/uni01alpha/networker
+    - lib
+    name: rhoso-architecture-validate-uni01alpha
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: uni01alpha
+- job:
+    files:
+    - dt/uni02beta
+    - examples/dt/uni02beta
+    - examples/dt/uni02beta/control-plane
+    - examples/dt/uni02beta/control-plane/nncp
+    - lib
+    name: rhoso-architecture-validate-uni02beta
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: uni02beta
+- job:
+    files:
+    - dt/uni04delta
+    - examples/dt/uni04delta
+    - examples/dt/uni04delta/control-plane
+    - examples/dt/uni04delta/control-plane/nncp
+    - examples/dt/uni04delta/deployment
+    - examples/dt/uni04delta/edpm-pre-ceph
+    - examples/dt/uni04delta/edpm-pre-ceph/nodeset
+    - lib
+    name: rhoso-architecture-validate-uni04delta
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: uni04delta
+- job:
+    files:
+    - dt/uni06zeta
+    - examples/dt/uni06zeta
+    - examples/dt/uni06zeta/control-plane
+    - examples/dt/uni06zeta/control-plane/nncp
+    - lib
+    name: rhoso-architecture-validate-uni06zeta
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: uni06zeta


### PR DESCRIPTION
This patch provides a script generating all of the zuul.d content, based
on the automation files.

Each scenario will get its own job definition, and will be triggered
only when its files are changed.

Note that common files, such as "lib", will trigger all the jobs.

This patch also introduces a new github workflow, to ensure all of the
automation scenarios have a job, by re-running the script and ensuring
no chance happened in zuul.d directory.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1742