### PR TITLE
Move changeme statements

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
@@ -191,19 +191,20 @@ data:
   nova:
     compute:
       conf: |
+        # CHANGEME
         [DEFAULT]
         reserved_host_memory_mb = 4096
         [compute]
         cpu_shared_set = 0-3,24-27
         cpu_dedicated_set = 8-23,32-47
         [neutron]
-        physnets = dpdk1, dpdk2 # CHANGEME
-        [neutron_physnet_dpdk1] # CHANGEME
-        numa_nodes = 0 # CHANGEME
-        [neutron_physnet_dpdk2] # CHANGEME
-        numa_nodes = 0 # CHANGEME
-        [neutron_tunnel] # CHANGEME
-        numa_nodes = 0 # CHANGEME
+        physnets = dpdk1, dpdk2
+        [neutron_physnet_dpdk1]
+        numa_nodes = 0
+        [neutron_physnet_dpdk2]
+        numa_nodes = 0
+        [neutron_tunnel]
+        numa_nodes = 0
     migration:
       ssh_keys:
         private: CHANGEME4
@@ -211,6 +212,7 @@ data:
     pci:
       # yamllint disable-line rule:line-length
       conf: |
+        # CHANGEME
         [pci]
-        device_spec = {"vendor_id":"8086", "product_id":"1572", "address": "0000:19:00.3", "physical_network":"sriov1", "trusted":"true"}  # CHANGEME
-        device_spec = {"vendor_id":"8086", "product_id":"1572", "address": "0000:20:00.3", "physical_network":"sriov2", "trusted":"true"}  # CHANGEME
+        device_spec = {"vendor_id":"8086", "product_id":"1572", "address": "0000:19:00.3", "physical_network":"sriov1", "trusted":"true"}
+        device_spec = {"vendor_id":"8086", "product_id":"1572", "address": "0000:20:00.3", "physical_network":"sriov2", "trusted":"true"}

--- a/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
@@ -171,19 +171,20 @@ data:
   nova:
     compute:
       conf: |
+        # CHANGEME
         [DEFAULT]
         reserved_host_memory_mb = 4096
         [compute]
         cpu_shared_set = 0-3,24-27
         cpu_dedicated_set = 8-23,32-47
         [neutron]
-        physnets = dpdk1, dpdk2 # CHANGEME
-        [neutron_physnet_dpdk1] # CHANGEME
-        numa_nodes = 0 # CHANGEME
-        [neutron_physnet_dpdk2] # CHANGEME
-        numa_nodes = 0 # CHANGEME
-        [neutron_tunnel] # CHANGEME
-        numa_nodes = 0 # CHANGEME
+        physnets = dpdk1, dpdk2
+        [neutron_physnet_dpdk1]
+        numa_nodes = 0
+        [neutron_physnet_dpdk2]
+        numa_nodes = 0
+        [neutron_tunnel]
+        numa_nodes = 0
     migration:
       ssh_keys:
         private: CHANGEME4

--- a/examples/va/nfv/sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/sriov/edpm/nodeset/values.yaml
@@ -145,6 +145,7 @@ data:
   nova:
     compute:
       conf: |
+        # CHANGEME
         [DEFAULT]
         reserved_host_memory_mb = 4096
         reserved_huge_pages = node:0,size:4,count:524160
@@ -158,5 +159,6 @@ data:
         public: CHANGEME5
     pci:
       conf: |
+        # CHANGEME
         [pci]
         device_spec = {"vendor_id":"8086", "product_id":"1572", "address": "0000:19:00.3", "physical_network":"sriov-phy4", "trusted":"true"}


### PR DESCRIPTION
Inline changeme statements within raw section were causing nove to fail in case they were not removed, moving statements out of line.