### PR TITLE
Revert "Revert "Added github-gate pipeline""

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,3 +3,6 @@
     github-check:
       jobs:
         - noop
+    github-gate:
+      jobs:
+        - noop


### PR DESCRIPTION
Reverts openstack-k8s-operators/architecture#219

https://github.com/openshift/release/pull/51796 adds prow config for architecture repo. The prow and zuul config was tested here: https://github.com/openstack-k8s-operators/ci-playground/pull/6