### PR TITLE
Add bgp_dt01 Deployed Topology

### DIFF
--- a/automation/mocks/bgp_dt01.yaml
+++ b/automation/mocks/bgp_dt01.yaml
@@ -1,0 +1,840 @@
+---
+cifmw_networking_env_definition:
+  instances:
+    compute-0:
+      hostname: compute-0
+      name: compute-0
+      networks:
+        ctlplane:
+          interface_name: eth1
+          ip_v4: 192.168.122.100
+          mac_addr: 52:54:00:6a:4a:25
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.100
+          mac_addr: 52:54:00:14:8c:e5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.100
+          mac_addr: 52:54:00:0d:c3:a1
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.100
+          mac_addr: '52:54:00:16:41:11'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    compute-1:
+      hostname: compute-1
+      name: compute-1
+      networks:
+        ctlplane:
+          interface_name: eth1
+          ip_v4: 192.168.122.101
+          mac_addr: 52:54:00:9b:e6:98
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.101
+          mac_addr: 52:54:00:38:f8:36
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.101
+          mac_addr: 52:54:00:4d:c4:0b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.101
+          mac_addr: 52:54:00:14:06:e3
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    compute-2:
+      hostname: compute-2
+      name: compute-2
+      networks:
+        ctlplane:
+          interface_name: eth1
+          ip_v4: 192.168.122.102
+          mac_addr: 52:54:00:98:a6:ae
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.102
+          mac_addr: 52:54:00:6a:da:29
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.102
+          mac_addr: 52:54:00:03:0a:e8
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.102
+          mac_addr: 52:54:00:78:92:ee
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    controller-0:
+      hostname: controller-0
+      name: controller-0
+      networks:
+        ctlplane:
+          interface_name: eth1
+          ip_v4: 192.168.122.9
+          mac_addr: 52:54:00:b2:7c:cb
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+    networker-0:
+      hostname: networker-0
+      name: networker-0
+      networks:
+        ctlplane:
+          interface_name: eth1
+          ip_v4: 192.168.122.106
+          mac_addr: 52:54:00:15:d3:88
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.106
+          mac_addr: 52:54:00:10:fd:f9
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.106
+          mac_addr: '52:54:00:42:16:57'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    networker-1:
+      hostname: networker-1
+      name: networker-1
+      networks:
+        ctlplane:
+          interface_name: eth1
+          ip_v4: 192.168.122.107
+          mac_addr: 52:54:00:de:46:aa
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.107
+          mac_addr: 52:54:00:3c:46:9b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.107
+          mac_addr: 52:54:00:6c:66:38
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    networker-2:
+      hostname: networker-2
+      name: networker-2
+      networks:
+        ctlplane:
+          interface_name: eth1
+          ip_v4: 192.168.122.108
+          mac_addr: 52:54:00:3f:b8:15
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.108
+          mac_addr: 52:54:00:7c:e7:5f
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.108
+          mac_addr: 52:54:00:12:ef:f8
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-0:
+      hostname: master-0
+      name: ocp-0
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.10
+          mac_addr: 52:54:00:a6:a2:28
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.10
+          mac_addr: 52:54:00:4d:b7:40
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.10
+          mac_addr: 52:54:00:01:fb:71
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.10
+          mac_addr: 52:54:00:1d:70:f5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.10
+          mac_addr: 52:54:00:19:a0:48
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-1:
+      hostname: master-1
+      name: ocp-1
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.11
+          mac_addr: 52:54:00:5d:5c:75
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.11
+          mac_addr: 52:54:00:43:51:94
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.11
+          mac_addr: 52:54:00:4c:f6:5b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.11
+          mac_addr: 52:54:00:4e:3f:30
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.11
+          mac_addr: '52:54:00:52:32:54'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-2:
+      hostname: master-2
+      name: ocp-2
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.12
+          mac_addr: 52:54:00:51:83:2d
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.12
+          mac_addr: 52:54:00:5c:31:ac
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.12
+          mac_addr: 52:54:00:64:39:96
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.12
+          mac_addr: 52:54:00:2e:71:ce
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.12
+          mac_addr: 52:54:00:2f:c7:35
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-0:
+      hostname: worker-0
+      name: ocp_worker-0
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.13
+          mac_addr: 52:54:00:89:69:43
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.13
+          mac_addr: 52:54:00:35:4f:c2
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.13
+          mac_addr: 52:54:00:13:5a:96
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.13
+          mac_addr: '52:54:00:36:09:28'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.13
+          mac_addr: 52:54:00:5c:09:09
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-1:
+      hostname: worker-1
+      name: ocp_worker-1
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.14
+          mac_addr: 52:54:00:4b:f9:06
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.14
+          mac_addr: 52:54:00:4d:35:b4
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.14
+          mac_addr: 52:54:00:06:6b:f0
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.14
+          mac_addr: 52:54:00:2c:69:fe
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.14
+          mac_addr: 52:54:00:47:50:3b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-2:
+      hostname: worker-2
+      name: ocp_worker-2
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.15
+          mac_addr: 52:54:00:a3:32:7a
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.15
+          mac_addr: 52:54:00:2a:55:0f
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.15
+          mac_addr: 52:54:00:13:4e:27
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.15
+          mac_addr: 52:54:00:12:6e:dc
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.15
+          mac_addr: 52:54:00:18:2f:ac
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-3:
+      hostname: worker-3
+      name: ocp_worker-3
+      networks:
+        ctlplane:
+          interface_name: enp7s0
+          ip_v4: 192.168.122.16
+          mac_addr: 52:54:00:67:1b:c5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp7s0.20
+          ip_v4: 172.17.0.16
+          mac_addr: 52:54:00:65:17:db
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp7s0.23
+          ip_v4: 172.23.0.16
+          mac_addr: 52:54:00:2f:28:7e
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp7s0.21
+          ip_v4: 172.18.0.16
+          mac_addr: 52:54:00:46:68:6b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp7s0.22
+          ip_v4: 172.19.0.16
+          mac_addr: 52:54:00:31:3b:02
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+  networks:
+    ctlplane:
+      dns_v4:
+        - 192.168.122.1
+      dns_v6: []
+      gw_v4: 192.168.122.1
+      mtu: 1500
+      network_name: ctlplane
+      network_v4: 192.168.122.0/24
+      search_domain: ctlplane.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.122.90
+              end_host: 90
+              length: 11
+              start: 192.168.122.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.122.70
+              end_host: 70
+              length: 41
+              start: 192.168.122.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.122.120
+              end_host: 120
+              length: 21
+              start: 192.168.122.100
+              start_host: 100
+            - end: 192.168.122.200
+              end_host: 200
+              length: 51
+              start: 192.168.122.150
+              start_host: 150
+          ipv6_ranges: []
+    external:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: external
+      network_v4: 192.168.32.0/20
+      search_domain: external.example.com
+      tools:
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.32.250
+              end_host: 250
+              length: 121
+              start: 192.168.32.130
+              start_host: 130
+          ipv6_ranges: []
+      vlan_id: 99
+    internalapi:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: internalapi
+      network_v4: 172.17.0.0/24
+      search_domain: internalapi.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 172.17.0.90
+              end_host: 90
+              length: 11
+              start: 172.17.0.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 172.17.0.70
+              end_host: 70
+              length: 41
+              start: 172.17.0.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 172.17.0.250
+              end_host: 250
+              length: 151
+              start: 172.17.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 20
+    octavia:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: octavia
+      network_v4: 172.23.0.0/24
+      search_domain: octavia.example.com
+      tools:
+        multus:
+          ipv4_ranges:
+            - end: 172.23.0.70
+              end_host: 70
+              length: 41
+              start: 172.23.0.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 172.23.0.250
+              end_host: 250
+              length: 151
+              start: 172.23.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 23
+    storage:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: storage
+      network_v4: 172.18.0.0/24
+      search_domain: storage.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 172.18.0.90
+              end_host: 90
+              length: 11
+              start: 172.18.0.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 172.18.0.70
+              end_host: 70
+              length: 41
+              start: 172.18.0.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 172.18.0.250
+              end_host: 250
+              length: 151
+              start: 172.18.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 21
+    tenant:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: tenant
+      network_v4: 172.19.0.0/24
+      search_domain: tenant.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 172.19.0.90
+              end_host: 90
+              length: 11
+              start: 172.19.0.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 172.19.0.70
+              end_host: 70
+              length: 41
+              start: 172.19.0.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 172.19.0.250
+              end_host: 250
+              length: 151
+              start: 172.19.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 22
+  routers: {}

--- a/automation/vars/bgp.yaml
+++ b/automation/vars/bgp.yaml
@@ -51,3 +51,81 @@ vas:
           - name: edpm-deployment-values
             src_file: values.yaml
         build_output: deployment-dataplane.yaml
+  bgp_dt01:
+    stages:
+      - pre_stage_run:
+          - name: Apply taint on worker-3
+            type: cr
+            definition:
+              spec:
+                taints:
+                  - effect: NoSchedule
+                    key: testOperator
+                    value: 'true'
+                  - effect: NoExecute
+                    key: testOperator
+                    value: 'true'
+            kind: Node
+            resource_name: worker-3
+            state: patched
+        path: examples/dt/bgp/bgp_dt01/control-plane/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=60s
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - path: examples/dt/bgp/bgp_dt01/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackcontrolplane
+            controlplane
+            --for condition=Ready
+            --timeout=30m
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+
+      - path: examples/dt/bgp/bgp_dt01/edpm/networkers
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-networker-nodeset.yaml
+
+      - path: examples/dt/bgp/bgp_dt01/edpm/computes
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-compute-nodeset.yaml
+
+      - path: examples/dt/bgp/bgp_dt01/edpm/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanedeployment
+            edpm-deployment
+            --for condition=Ready
+            --timeout=2400s
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: edpm-deployment.yaml

--- a/automation/vars/bgp.yaml
+++ b/automation/vars/bgp.yaml
@@ -118,14 +118,26 @@ vas:
             src_file: values.yaml
         build_output: edpm-compute-nodeset.yaml
 
-      - path: examples/dt/bgp/bgp_dt01/edpm/deployment
+      - path: examples/dt/bgp/bgp_dt01/edpm/networkers-deployment
         wait_conditions:
           - >-
             oc -n openstack wait openstackdataplanedeployment
-            edpm-deployment
+            networkers-deployment
             --for condition=Ready
             --timeout=2400s
         values:
           - name: edpm-deployment-values
             src_file: values.yaml
-        build_output: edpm-deployment.yaml
+        build_output: edpm-networkers-deployment.yaml
+
+      - path: examples/dt/bgp/bgp_dt01/edpm/computes-deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanedeployment
+            computes-deployment
+            --for condition=Ready
+            --timeout=2400s
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: edpm-computes-deployment.yaml

--- a/examples/dt/bgp/bgp_dt01/README.md
+++ b/examples/dt/bgp/bgp_dt01/README.md
@@ -11,7 +11,7 @@ should be enabled on those spine and leaf routers.
 ## Purpose
 
 This first BGP DT (DT01) tests default BGP configuration:
-* OVN routing (instead of kernel routing)
+* Kernel routing (instead of OVN routing)
 * OVN NB DB driver (instead of OVN SB DB driver)
 
 The OCP cluster consists on the following nodes:

--- a/examples/dt/bgp/bgp_dt01/README.md
+++ b/examples/dt/bgp/bgp_dt01/README.md
@@ -1,0 +1,109 @@
+# RHOSO Deployed Topology - BGP DT01 - OVN routing and OVN NB DB driver
+
+This document describes the first BGP Deployed Topology (DT), used to test the
+BGP Dynamic Routing functionality on Red Hat OpenStack Services on OpenShift
+(RHOSO).
+
+The CRs included within this DT should be applied on an environment where EDPM
+and OCP nodes are connected through a spine/leaf network. The BGP protocol
+should be enabled on those spine and leaf routers.
+
+## Purpose
+
+This first BGP DT (DT01) tests default BGP configuration:
+* OVN routing (instead of kernel routing)
+* OVN NB DB driver (instead of OVN SB DB driver)
+
+The OCP cluster consists on the following nodes:
+* 3 OCP master nodes
+* 3 OCP worker nodes
+* 1 OCP worker node with special configuration (OCP tester node)
+
+This DT creates an OCP cluster that includes both master and worker nodes,
+instead of the usual master/worker combo nodes. The reason for this is to run
+disruptive tests only on the OCP workers, which host the Openstack Control
+Plane services, avoiding potential issues when OCP master nodes are disrupted
+that would not be relevant when testing RHOSO high availability scenarios.
+
+The extra OCP worker (OCP tester) is needed to run tests from it because:
+* disruptive tests can be run from this worker on the other workers without
+  affecting the test exection
+* this worker is connected to the spine/leaf routers with a special routing
+  configuration, so that it can reach the Openstack provider network
+The OCP tester is configured so that only test pods (created by the
+Openstack test-operator) run on it.
+
+This DT configures both compute and networker EDPM nodes. So far, networker
+nodes are needed when BGP is used on RHOSO, in order to expose routes to SNAT
+traffic (OVN Gateway IPs). In other words, when RHOSO is used with BGP, the OCP
+workers cannot be configured as OVN Gateways.
+
+The OCP and EDPM nodes deployed with this DT are distributed into three
+different racks. Each rack is connected to two leaves.
+Hence, the distribution of the nodes in the racks is the following one:
+* rack0: compute-0, networker-0, ocp-master-0, ocp-worker-0, leaf-0, leaf-1
+* rack1: compute-1, networker-1, ocp-master-1, ocp-worker-1, leaf-2, leaf-3
+* rack2: compute-2, networker-2, ocp-master-2, ocp-worker-2, leaf-4, leaf-5
+
+The OCP tester (ocp-worker-3) is not included into any rack. It is not
+connected to any leaves, but to a router connected to the spines, due to the
+reasons described before (it needs special connectivity to reach the provider
+network).
+
+## Node topology
+| Node role               | bm/vm | amount |
+| ----------------------- | ----- | ------ |
+| Openshift master nodes  | vm    | 3      |
+| Openshift worker nodes  | vm    | 4      |
+| Openstack Computes      | vm    | 3      |
+| Openstack Networker     | vm    | 3      |
+| Leaf routers            | vm    | 6      |
+| Spine routers           | vm    | 2      |
+| External routers        | vm    | 1      |
+| Ansible Controller      | vm    | 1      |
+
+### Networks
+
+| Name                     | Type     | CIDR             |
+| ------------------------ | -------- | ---------------- |
+| Provisioning             | untagged | 192.168.122.0/24 |
+| Provider network         | untagged | 192.168.133.0/24 |
+| RH OSP                   | untagged | 192.168.111.0/24 |
+| edpm/ocp to left leaves  | untagged | 100.64.x.y/30    |
+| edpm/ocp to right leaves | untagged | 100.65.x.y/30    |
+
+## Services, enabled features and configurations
+
+| Service          | configuration    | Lock-in coverage?  |
+| ---------------- | ---------------- | ------------------ |
+| Glance           | Swift            | Must have          |
+| Swift            | (default)        | Must have          |
+| Octavia          | (default)        | Must have          |
+| Heat             | (default)        | Must have          |
+| frr              | dataplane        | Must have          |
+| ovn-bgp-agent    | dataplane        | Must have          |
+
+## Considerations/Constraints
+
+1. Virtual networks should be created to connect the nodes to the routers.
+2. All the VMs that are neither Openstack nor Openshift nodes, i.e. those that
+   act as routers, need to be properly configured in order to support the BGP
+   protocol.
+3. The spine/leaf topology separates the overcloud nodes into different L2
+   network segments, called racks. Each rack includes two leaves, some OCP
+   nodes and some EDPM nodes.
+4. A separate provisioning network is necessary to install Openstack on those
+   nodes.
+5. Once Openstack is installed on them, dataplane connectivity is achieved
+   using the BGP protocol.
+6. Tests are executed from the OCP worker to verify external connectivity.
+
+## Stages
+
+All stages must be executed in the order listed below. Everything is required unless otherwise indicated.
+
+1. [Configure taints on the OCP worker](configure-taints.md)
+2. [Install the OpenStack K8S operators and their dependencies](../../../common/)
+3. [Apply metallb customization required to run a speaker pod on the OCP tester node](metallb/)
+4. [Configuring networking and deploy the OpenStack control plane](control-plane.md)
+5. [Configure and deploy the dataplane - networker and compute nodes](data-plane.md)

--- a/examples/dt/bgp/bgp_dt01/configure-taints.md
+++ b/examples/dt/bgp/bgp_dt01/configure-taints.md
@@ -1,0 +1,21 @@
+# Apply taints on OCP tester node
+
+This OCP worker node should not run any Openstack service apart from those
+created by the test-operator.
+It should also run a metallb's speaker pod, in order to obtain the proper
+network configuration.
+Due to this, taints should be configured on this worker.
+
+Execute the following command:
+```
+oc patch node/worker-3 --type merge --patch '
+  spec:
+    taints:
+      - effect: NoSchedule
+        key: testOperator
+        value: "true"
+      - effect: NoExecute
+        key: testOperator
+        value: "true"
+'
+```

--- a/examples/dt/bgp/bgp_dt01/control-plane.md
+++ b/examples/dt/bgp/bgp_dt01/control-plane.md
@@ -1,0 +1,57 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `local-storage` should already exist.
+- An infrastructure of spine/leaf routers exists, is properly connected to the
+  OCP nodes and the routers are configured to support BGP.
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the bgp_dt01/control-plane directory
+```
+cd architecture/examples/dt/bgp/bgp_dt01/control-plane
+```
+Edit the [nncp/values.yaml](control-plane/nncp/values.yaml) and
+[service-values.yaml](control-plane/service-values.yaml) files to suit 
+your environment.
+```
+vi nncp/values.yaml
+vi service-values.yaml
+```
+
+## Apply node network configuration
+
+Generate the node network configuration
+```
+kustomize build nncp > nncp.yaml
+```
+Apply the NNCP CRs
+```
+oc apply -f nncp.yaml
+```
+Wait for NNCPs to be available
+```
+oc wait nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=300s
+```
+
+## Apply networking and control-plane configuration
+
+Generate the control-plane and networking CRs.
+```
+kustomize build > control-plane.yaml
+```
+Apply the CRs
+```
+oc apply -f control-plane.yaml
+```
+
+Wait for control plane to be available
+```
+oc wait osctlplane controlplane --for condition=Ready --timeout=600s
+```
+

--- a/examples/dt/bgp/bgp_dt01/control-plane/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/kustomization.yaml
@@ -1,0 +1,219 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bgp/
+
+resources:
+  - nncp/values.yaml
+  - service-values.yaml
+  - metallb_bgppeers.yaml
+  - ocp_networks_netattach.yaml
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+patches:
+  # Add BGPPeer to BGPAdvertisement
+  - target:
+      kind: BGPAdvertisement
+    patch: |-
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-3-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-3-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-4-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-4-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-5-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-5-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-6-0
+  - target:
+      kind: NetworkAttachmentDefinition
+      labelSelector: "osp/net-attach-def-type=bgp"
+      name: bgpnet-[3-6]-[0-1]
+    path: ocp_network_template.yaml
+
+replacements:
+  # BGP peer IP addresses
+  # node3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-3-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-3-1
+        fieldPaths:
+          - spec.peerAddress
+  # node4
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-4-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-4-1
+        fieldPaths:
+          - spec.peerAddress
+  # node5
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-5-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-5-1
+        fieldPaths:
+          - spec.peerAddress
+  # node6
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-6-0
+        fieldPaths:
+          - spec.peerAddress
+  # BGP NetworkAttachmentDefinition customization
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node3.bgpnet0
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-3-0
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node3.bgpnet1
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-3-1
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node4.bgpnet0
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-4-0
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node4.bgpnet1
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-4-1
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node5.bgpnet0
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-5-0
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node5.bgpnet1
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-5-1
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node6.bgpnet0
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-6-0
+        fieldPaths:
+          - spec.config
+  # disable OCP workers as gateway nodes
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.ovn.ovnController.external-ids
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ovn.template.ovnController.external-ids
+        options:
+          create: true

--- a/examples/dt/bgp/bgp_dt01/control-plane/metallb_bgppeers.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/metallb_bgppeers.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-3-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-0"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-3-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-0"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-4-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-1"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-4-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-1"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-5-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-2"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-5-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-2"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-6-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-3"]  # worker-3 has only one bgp-peer

--- a/examples/dt/bgp/bgp_dt01/control-plane/nncp/.gitignore
+++ b/examples/dt/bgp/bgp_dt01/control-plane/nncp/.gitignore
@@ -1,0 +1,1 @@
+nncp.yaml

--- a/examples/dt/bgp/bgp_dt01/control-plane/nncp/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/nncp/kustomization.yaml
@@ -1,0 +1,943 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../../../lib/nncp
+
+resources:
+  - values.yaml
+  - ocp_worker_nodes_nncp.yaml
+
+patches:
+  # Add BGP and octavia interfaces
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 1
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "master-.*"  # node-6 does not need a second BGP interface
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "node-[3-5]"  # node-6 does not need a second BGP interface
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: loopback interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          name: _replaced_
+          mtu: 65536
+          state: up
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia vlan host interface
+          name: octavia
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia bridge
+          mtu: 1500
+          name: octbr
+          type: linux-bridge
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+              - name: octavia
+  # Fix roles on masters
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "master-.*"
+    patch: |-
+      - op: add
+        path: /spec/nodeSelector/node-role.kubernetes.io~1master
+        value: ""
+      - op: remove
+        path: /spec/nodeSelector/node-role.kubernetes.io~1worker
+
+replacements:
+  # Node names (workers)
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-4
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-5
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-6
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  # Static Node IPs: node-3/worker-0
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.internalapi_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.tenant_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.storage_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
+
+  # Static Node IPs: node-4 / worker-1
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.internalapi_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.tenant_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.storage_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
+
+  # Static Node IPs: node-5 / worker-2
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.internalapi_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.tenant_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.storage_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
+
+  # Static Node IPs: node-6 / worker-3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.internalapi_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.tenant_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.storage_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
+
+
+  # prefix-lengths
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.prefix-length
+
+  # BGP master-0/node-0 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP master-1/node-1 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP master-2/node-2 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-0/node-3 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-1/node-4 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-2/node-5 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-3/node-6 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+
+  # BGP values
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.ifaces.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.ifaces.1
+    targets:  # target all nodes except worker-3 (regexs do not seem to work on select.name value)
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.iface
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:  # in case of worker-3, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.prefix-length
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:  # in case of worker-3, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.prefix-length
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:  # in case of worker-3, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.prefix-length-ipv6
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:  # in case of worker-3, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+  # Octavia
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.base_iface
+    targets:  # octavia interfaces are needed on the workers, except worker-3
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.vlan
+    targets:  # octavia interfaces are needed on the workers, except worker-3
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.id
+  # Overwrite worker-3 base interface
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.base_if
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].vlan.base-iface
+          - spec.desiredState.interfaces.[name=tenant].vlan.base-iface
+          - spec.desiredState.interfaces.[name=storage].vlan.base-iface
+          - spec.desiredState.interfaces.[description=^ctlplane.*].name
+          - spec.desiredState.interfaces.[description=^linux-bridge.*].bridge.port.0.name
+          - spec.desiredState.interfaces.[name=octavia].vlan.base-iface
+  # Overwrite worker-3 base routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.routes

--- a/examples/dt/bgp/bgp_dt01/control-plane/nncp/ocp_worker_nodes_nncp.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/nncp/ocp_worker_nodes_nncp.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-3
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-4
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-5
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-6
+  labels:
+    osp/nncm-config-type: standard

--- a/examples/dt/bgp/bgp_dt01/control-plane/nncp/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/nncp/values.yaml
@@ -1,0 +1,595 @@
+---
+# local-config: referenced, but not emitted by kustomize
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # nodes
+  node_0:
+    name: master-0
+    internalapi_ip: 172.17.0.5
+    tenant_ip: 172.19.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+    bgp_ip:
+      - 100.64.0.10
+      - 100.65.0.10
+    bgp_peers:
+      - 100.64.0.9
+      - 100.65.0.9
+    loopback_ip: 172.30.0.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:13
+  node_1:
+    name: master-1
+    internalapi_ip: 172.17.0.6
+    tenant_ip: 172.19.0.6
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.6
+    bgp_ip:
+      - 100.64.1.10
+      - 100.65.1.10
+    bgp_peers:
+      - 100.64.1.9
+      - 100.65.1.9
+    loopback_ip: 172.30.1.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:23
+  node_2:
+    name: master-2
+    internalapi_ip: 172.17.0.7
+    tenant_ip: 172.19.0.7
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.7
+    bgp_ip:
+      - 100.64.2.10
+      - 100.65.2.10
+    bgp_peers:
+      - 100.64.2.9
+      - 100.65.2.9
+    loopback_ip: 172.30.2.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:33
+  node_3:
+    name: worker-0
+    internalapi_ip: 172.17.0.8
+    tenant_ip: 172.19.0.8
+    ctlplane_ip: 192.168.122.13
+    storage_ip: 172.18.0.8
+    bgp_ip:
+      - 100.64.0.14
+      - 100.65.0.14
+    bgp_peers:
+      - 100.64.0.12
+      - 100.65.0.12
+    loopback_ip: 172.30.0.4
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:14
+  node_4:
+    name: worker-1
+    internalapi_ip: 172.17.0.9
+    tenant_ip: 172.19.0.9
+    ctlplane_ip: 192.168.122.14
+    storage_ip: 172.18.0.9
+    bgp_ip:
+      - 100.64.1.14
+      - 100.65.1.14
+    bgp_peers:
+      - 100.64.1.13
+      - 100.65.1.13
+    loopback_ip: 172.30.1.4
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:24
+  node_5:
+    name: worker-2
+    internalapi_ip: 172.17.0.10
+    tenant_ip: 172.19.0.10
+    ctlplane_ip: 192.168.122.15
+    storage_ip: 172.18.0.10
+    bgp_ip:
+      - 100.64.2.14
+      - 100.65.2.14
+    bgp_peers:
+      - 100.64.2.13
+      - 100.65.2.13
+    loopback_ip: 172.30.2.4
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+  node_6:
+    name: worker-3
+    internalapi_ip: 172.17.0.11
+    tenant_ip: 172.19.0.11
+    ctlplane_ip: 192.168.122.16
+    storage_ip: 172.18.0.11
+    bgp_ip:
+      - 100.64.10.2
+    bgp_peers:
+      - 100.64.10.1
+    loopback_ip: 172.30.10.2
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:43
+    base_if: enp7s0
+    routes:
+      config:
+        - destination: 192.168.133.0/24
+          next-hop-address: 100.64.10.1
+          next-hop-interface: enp6s0
+
+  # networks
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet1
+    prefix-length: 24
+    iface: enp8s0
+    mtu: 1500
+    lb_addresses:
+      - 192.168.122.80-192.168.122.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "macvlan",
+        "master": "ospbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.122.0/24",
+          "range_start": "192.168.122.30",
+          "range_end": "192.168.122.70"
+        }
+      }
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp8s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "macvlan",
+        "master": "internalapi",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 1500
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp8s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "macvlan",
+        "master": "storage",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+  tenant:
+    dnsDomain: tenant.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        name: subnet1
+        vlan: 22
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp8s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "macvlan",
+        "master": "tenant",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70"
+        }
+      }
+  octavia:
+    dnsDomain: octavia.openstack.lab
+    mtu: 1500
+    vlan: 23
+    base_iface: enp8s0
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "octavia",
+        "type": "bridge",
+        "bridge": "octbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.23.0.0/24",
+          "range_start": "172.23.0.30",
+          "range_end": "172.23.0.70"
+        }
+      }
+  external:
+    dnsDomain: external.example.com
+    subnets:
+      - allocationRanges:
+          - end: 10.0.0.250
+            start: 10.0.0.100
+        cidr: 10.0.0.0/24
+        gateway: 10.0.0.1
+        name: subnet1
+    mtu: 1500
+
+  bgp:
+    prefix-length: 30
+    ifaces:
+      - enp6s0
+      - enp7s0
+    asn: 64999
+    peer_asn: 64999
+    subnets:
+      bgpnet0:
+        - name: subnet0
+          allocationRanges:
+            - end: 100.64.0.6
+              start: 100.64.0.1
+          cidr: 100.64.0.0/29
+          gateway: 100.64.0.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.0.1
+        - name: subnet1
+          allocationRanges:
+            - end: 100.64.1.6
+              start: 100.64.1.1
+          cidr: 100.64.1.0/29
+          gateway: 100.64.1.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.1.1
+        - name: subnet2
+          allocationRanges:
+            - end: 100.64.2.6
+              start: 100.64.2.1
+          cidr: 100.64.2.0/29
+          gateway: 100.64.2.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.2.1
+      bgpnet1:
+        - name: subnet0
+          allocationRanges:
+            - end: 100.65.0.6
+              start: 100.65.0.1
+          cidr: 100.65.0.0/29
+          gateway: 100.65.0.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.0.1
+        - name: subnet1
+          allocationRanges:
+            - end: 100.65.1.6
+              start: 100.65.1.1
+          cidr: 100.65.1.0/29
+          gateway: 100.65.1.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.1.1
+        - name: subnet2
+          allocationRanges:
+            - end: 100.65.2.6
+              start: 100.65.2.1
+          cidr: 100.65.2.0/29
+          gateway: 100.65.2.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.2.1
+      bgpmainnet:
+        - name: subnet0
+          cidr: 172.30.0.0/28
+          allocationRanges:
+            - end: 172.30.0.14
+              start: 172.30.0.2
+        - name: subnet1
+          cidr: 172.30.1.0/28
+          allocationRanges:
+            - end: 172.30.1.14
+              start: 172.30.1.2
+        - name: subnet2
+          cidr: 172.30.2.0/28
+          allocationRanges:
+            - end: 172.30.2.14
+              start: 172.30.2.2
+        - name: subnet10
+          cidr: 172.30.10.0/28
+          allocationRanges:
+            - end: 172.30.10.14
+              start: 172.30.10.2
+      bgpmainnetv6:
+        - name: subnet0
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0010/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:001e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
+        - name: subnet1
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0020/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:002e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0022
+        - name: subnet2
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0030/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:003e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0032
+        - name: subnet3
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0040/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:004e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0042
+    net-attach-def:
+      node0:
+        bgpnet0: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-0-0",
+            "type": "interface",
+            "master": "enp6s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.64.0.8/30",
+              "range_start": "100.64.0.9",
+              "range_end": "100.64.0.10"
+            }
+          }
+        bgpnet1: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-0-1",
+            "type": "interface",
+            "master": "enp7s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.65.0.8/30",
+              "range_start": "100.65.0.9",
+              "range_end": "100.65.0.10"
+            }
+          }
+      node1:
+        bgpnet0: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-1-0",
+            "type": "interface",
+            "master": "enp6s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.64.1.8/30",
+              "range_start": "100.64.1.9",
+              "range_end": "100.64.1.10"
+            }
+          }
+        bgpnet1: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-1-1",
+            "type": "interface",
+            "master": "enp7s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.65.1.8/30",
+              "range_start": "100.65.1.9",
+              "range_end": "100.65.1.10"
+            }
+          }
+      node2:
+        bgpnet0: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-2-0",
+            "type": "interface",
+            "master": "enp6s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.64.2.8/30",
+              "range_start": "100.64.2.9",
+              "range_end": "100.64.2.10"
+            }
+          }
+        bgpnet1: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-2-1",
+            "type": "interface",
+            "master": "enp7s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.65.2.8/30",
+              "range_start": "100.65.2.9",
+              "range_end": "100.65.2.10"
+            }
+          }
+      node3:
+        bgpnet0: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-3-0",
+            "type": "interface",
+            "master": "enp6s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.64.0.12/30",
+              "range_start": "100.64.0.13",
+              "range_end": "100.64.0.14"
+            }
+          }
+        bgpnet1: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-3-1",
+            "type": "interface",
+            "master": "enp7s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.65.0.12/30",
+              "range_start": "100.65.0.13",
+              "range_end": "100.65.0.14"
+            }
+          }
+      node4:
+        bgpnet0: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-4-0",
+            "type": "interface",
+            "master": "enp6s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.64.1.12/30",
+              "range_start": "100.64.1.13",
+              "range_end": "100.64.1.14"
+            }
+          }
+        bgpnet1: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-4-1",
+            "type": "interface",
+            "master": "enp7s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.65.1.12/30",
+              "range_start": "100.65.1.13",
+              "range_end": "100.65.1.14"
+            }
+          }
+      node5:
+        bgpnet0: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-5-0",
+            "type": "interface",
+            "master": "enp6s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.64.2.12/30",
+              "range_start": "100.64.2.13",
+              "range_end": "100.64.2.14"
+            }
+          }
+        bgpnet1: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-5-1",
+            "type": "interface",
+            "master": "enp7s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.65.2.12/30",
+              "range_start": "100.65.2.13",
+              "range_end": "100.65.2.14"
+            }
+          }
+      node6:
+        bgpnet0: |
+          {
+            "cniVersion": "0.3.1",
+            "name": "bgpnet-6-0",
+            "type": "interface",
+            "master": "enp6s0",
+            "ipam": {
+              "type": "whereabouts",
+              "range": "100.64.10.0/30",
+              "range_start": "100.64.10.1",
+              "range_end": "100.64.10.2"
+            }
+          }
+        routes:
+          config:
+            - destination: 192.168.133.0/24
+              next-hop-address: 100.64.10.1
+              next-hop-interface: enp6s0
+
+  loopback:
+    prefix-length: 32
+    prefix-length-ipv6: 128
+    iface: lo
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config: []
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr

--- a/examples/dt/bgp/bgp_dt01/control-plane/ocp_network_template.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/ocp_network_template.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: nmstate.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: _ignored_
+spec:
+  config: |
+    _replaced_

--- a/examples/dt/bgp/bgp_dt01/control-plane/ocp_networks_netattach.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/ocp_networks_netattach.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgpnet-3-0
+  labels:
+    osp/net: bgpnet-3-0
+    osp/net-attach-def-type: bgp
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgpnet-3-1
+  labels:
+    osp/net: bgpnet-3-1
+    osp/net-attach-def-type: bgp
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgpnet-4-0
+  labels:
+    osp/net: bgpnet-4-0
+    osp/net-attach-def-type: bgp
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgpnet-4-1
+  labels:
+    osp/net: bgpnet-4-1
+    osp/net-attach-def-type: bgp
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgpnet-5-0
+  labels:
+    osp/net: bgpnet-5-0
+    osp/net-attach-def-type: bgp
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgpnet-5-1
+  labels:
+    osp/net: bgpnet-5-1
+    osp/net-attach-def-type: bgp
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgpnet-6-0
+  labels:
+    osp/net: bgpnet-6-0
+    osp/net-attach-def-type: bgp

--- a/examples/dt/bgp/bgp_dt01/control-plane/service-values.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/service-values.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:swift
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+    default:
+      replicas: 1
+
+  swift:
+    enabled: true
+
+  octavia:
+    enabled: true
+    amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image
+    apacheContainerImage: registry.redhat.io/ubi9/httpd-24:latest
+    octaviaAPI:
+      networkAttachments:
+        - internalapi
+    octaviaHousekeeping:
+      networkAttachments:
+        - octavia
+    octaviaHealthManager:
+      networkAttachments:
+        - octavia
+    octaviaWorker:
+      networkAttachments:
+        - octavia
+
+  ovn:
+    ovnController:
+      nicMappings:
+        datacentre: ocpbr
+        octavia: octbr
+      external-ids:
+        enable-chassis-as-gateway: false

--- a/examples/dt/bgp/bgp_dt01/data-plane.md
+++ b/examples/dt/bgp/bgp_dt01/data-plane.md
@@ -1,0 +1,74 @@
+# Configuring and deploying the dataplane - networker and compute nodes
+
+## Assumptions
+
+- The [control plane](control-plane.md) has been created and successfully deployed
+- An infrastructure of spine/leaf routers exists, is properly connected to the
+  pre-provisioned EDPM nodes and the routers are configured to support BGP.
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the bgp_dt01/ directory
+```
+cd architecture/examples/dt/bgp/bgp_dt01/
+```
+Edit the [edpm/networkers/values.yaml](edpm/networkers/values.yaml) file to suit
+your environment.
+```
+vi values.yaml
+```
+Edit the [edpm/networkers/values.yaml](edpm/computes/values.yaml) file to suit
+your environment.
+```
+vi values.yaml
+```
+
+## Create Networker and Compute Nodeset CRs
+
+Generate the networkers dataplane nodeset CR.
+```
+kustomize build edpm/networkers > edpm-networker-nodeset.yaml
+```
+Generate the computes dataplane nodeset CR.
+```
+kustomize build edpm/computes > edpm-compute-nodeset.yaml
+```
+
+## Create EDPM  Deployment CR
+Generate the dataplane deployment CR.
+```
+kustomize build edpm/deployment > edpm-deployment.yaml
+```
+
+## Apply the Nodeset CRs
+
+Apply the Networker nodeset CR
+```
+oc apply -f edpm-networker-nodeset.yaml
+```
+Wait for Networker dataplane nodeset setup to finish
+```
+oc wait osdpns networker-nodes --for condition=SetupReady --timeout=600s
+```
+Apply the Compute nodeset CR
+```
+oc apply -f edpm-compute-nodeset.yaml
+```
+Wait for Compute dataplane nodeset setup to finish
+```
+oc wait osdpns compute-nodes --for condition=SetupReady --timeout=600s
+```
+
+## Apply the deployment
+Start the deployment
+```
+oc apply -f edpm-deployment.yaml
+```
+Wait for dataplane deployment to finish
+```
+oc wait osdpd edpm-deployment --for condition=Ready --timeout=2400s
+```

--- a/examples/dt/bgp/bgp_dt01/data-plane.md
+++ b/examples/dt/bgp/bgp_dt01/data-plane.md
@@ -21,7 +21,7 @@ your environment.
 ```
 vi values.yaml
 ```
-Edit the [edpm/networkers/values.yaml](edpm/computes/values.yaml) file to suit
+Edit the [edpm/computes/values.yaml](edpm/computes/values.yaml) file to suit
 your environment.
 ```
 vi values.yaml
@@ -38,10 +38,11 @@ Generate the computes dataplane nodeset CR.
 kustomize build edpm/computes > edpm-compute-nodeset.yaml
 ```
 
-## Create EDPM  Deployment CR
-Generate the dataplane deployment CR.
+## Create Networker and Compute Deployment CRs
+Generate the dataplane deployment CRs.
 ```
-kustomize build edpm/deployment > edpm-deployment.yaml
+kustomize build edpm/networkers-deployment > edpm-networkers-deployment.yaml
+kustomize build edpm/computes-deployment > edpm-computes-deployment.yaml
 ```
 
 ## Apply the Nodeset CRs
@@ -63,12 +64,20 @@ Wait for Compute dataplane nodeset setup to finish
 oc wait osdpns compute-nodes --for condition=SetupReady --timeout=600s
 ```
 
-## Apply the deployment
-Start the deployment
+## Apply the Deployment CRs
+Start the Networkers deployment
 ```
-oc apply -f edpm-deployment.yaml
+oc apply -f edpm-networkers-deployment.yaml
 ```
-Wait for dataplane deployment to finish
+Wait for Networkers deployment to finish
 ```
-oc wait osdpd edpm-deployment --for condition=Ready --timeout=2400s
+oc wait osdpd networkers-deployment --for condition=Ready --timeout=2400s
+```
+Start the Computes deployment
+```
+oc apply -f edpm-computes-deployment.yaml
+```
+Wait for Computes deployment to finish
+```
+oc wait osdpd computes-deployment --for condition=Ready --timeout=2400s
 ```

--- a/examples/dt/bgp/bgp_dt01/edpm/computes-deployment/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes-deployment/kustomization.yaml
@@ -14,6 +14,15 @@ replacements:
   - source:
       kind: ConfigMap
       name: edpm-deployment-values
+      fieldPath: data.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - metadata.name
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
       fieldPath: data.nodeSets
     targets:
       - select:

--- a/examples/dt/bgp/bgp_dt01/edpm/computes-deployment/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes-deployment/values.yaml
@@ -1,0 +1,12 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: computes-deployment
+  nodeSets:
+    - compute-nodes

--- a/examples/dt/bgp/bgp_dt01/edpm/computes/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: compute-nodes

--- a/examples/dt/bgp/bgp_dt01/edpm/computes/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/values.yaml
@@ -96,17 +96,12 @@ data:
             - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
-        edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
-        enable_debug: false
         gather_facts: false
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth1
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
     networks:
       - defaultRoute: true
         name: CtlPlane

--- a/examples/dt/bgp/bgp_dt01/edpm/computes/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/values.yaml
@@ -1,0 +1,268 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks:
+          - nic3
+          - nic4
+        timesync_ntp_servers:
+          - hostname: clock.redhat.com
+        # CHANGEME -- see https://access.redhat.com/solutions/253273
+        # edpm_bootstrap_command: |
+        #       subscription-manager register --username <subscription_manager_username> \
+        #         --password <subscription_manager_password>
+        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+          edpm-compute-1:
+            nic2: 6b:fe:54:3f:8a:02  # CHANGEME
+          edpm-compute-2:
+            nic2: 6c:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            routes: []
+            members:
+              - type: interface
+                name: nic2
+                mtu: {{ min_viable_mtu }}
+                # force the MAC address of the bridge to this interface
+                primary: true
+          {% for network in nodeset_networks %}
+          {%   if not network.lower().startswith('bgp') %}
+              - type: vlan
+                mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+                vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+                addresses:
+                  - ip_netmask: >-
+                      {{
+                        lookup('vars', networks_lower[network] ~ '_ip')
+                      }}/{{
+                        lookup('vars', networks_lower[network] ~ '_cidr')
+                      }}
+                routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endif %}
+          {% endfor %}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_selinux_mode: enforcing
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        enable_debug: false
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+        service_net_map:
+          nova_api_network: internalapi
+          nova_libvirt_network: internalapi
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-compute-0:
+        hostName: edpm-compute-0
+        ansible:
+          ansibleHost: 192.168.122.100
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.0.1
+              - 100.65.0.1
+            edpm_frr_bgp_peers:
+              - 100.64.0.1
+              - 100.65.0.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet0
+            fixedIP: 100.64.0.2
+          - name: Bgpnet1
+            subnetName: subnet0
+            fixedIP: 100.65.0.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 172.30.0.2
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
+      edpm-compute-1:
+        hostName: edpm-compute-1
+        ansible:
+          ansibleHost: 192.168.122.101
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.1.1
+              - 100.65.1.1
+            edpm_frr_bgp_peers:
+              - 100.64.1.1
+              - 100.65.1.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.1.2
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.1.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 172.30.1.3
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
+      edpm-compute-2:
+        hostName: edpm-compute-2
+        ansible:
+          ansibleHost: 192.168.122.102
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.2.1
+              - 100.65.2.1
+            edpm_frr_bgp_peers:
+              - 100.64.2.1
+              - 100.65.2.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.102
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet2
+            fixedIP: 100.64.2.2
+          - name: Bgpnet1
+            subnetName: subnet2
+            fixedIP: 100.65.2.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 172.30.2.3
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - frr
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+      - libvirt
+      - nova-custom
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp/bgp_dt01/edpm/deployment/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/deployment/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/deployment
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/deployment/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.nodeSets
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.nodeSets

--- a/examples/dt/bgp/bgp_dt01/edpm/deployment/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/deployment/values.yaml
@@ -1,0 +1,12 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeSets:
+    - networker-nodes
+    - compute-nodes

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers-deployment/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers-deployment/kustomization.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/deployment
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/deployment/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - metadata.name
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.nodeSets
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.nodeSets

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers-deployment/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers-deployment/values.yaml
@@ -7,6 +7,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  name: networkers-deployment
   nodeSets:
     - networker-nodes
-    - compute-nodes

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/values.yaml
@@ -97,17 +97,12 @@ data:
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
         edpm_enable_chassis_gw: true
-        edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
-        enable_debug: false
         gather_facts: false
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth1
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
     networks:
       - defaultRoute: true
         name: CtlPlane

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/values.yaml
@@ -1,0 +1,267 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks:
+          - nic3
+          - nic4
+        timesync_ntp_servers:
+          - hostname: clock.redhat.com
+        # CHANGEME -- see https://access.redhat.com/solutions/253273
+        # edpm_bootstrap_command: |
+        #       subscription-manager register --username <subscription_manager_username> \
+        #         --password <subscription_manager_password>
+        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+          edpm-networker-1:
+            nic2: 6e:fe:54:3f:8a:02  # CHANGEME
+          edpm-networker-2:
+            nic2: 6f:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            routes: []
+            members:
+              - type: interface
+                name: nic2
+                mtu: {{ min_viable_mtu }}
+                # force the MAC address of the bridge to this interface
+                primary: true
+          {% for network in nodeset_networks %}
+          {%   if not network.lower().startswith('bgp') %}
+              - type: vlan
+                mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+                vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+                addresses:
+                  - ip_netmask: >-
+                      {{
+                        lookup('vars', networks_lower[network] ~ '_ip')
+                      }}/{{
+                        lookup('vars', networks_lower[network] ~ '_cidr')
+                      }}
+                routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endif %}
+          {% endfor %}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_enable_chassis_gw: true
+        edpm_selinux_mode: enforcing
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        enable_debug: false
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+        service_net_map:
+          nova_api_network: internalapi
+          nova_libvirt_network: internalapi
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-networker-0:
+        hostName: edpm-networker-0
+        ansible:
+          ansibleHost: 192.168.122.105
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.0.5
+              - 100.65.0.5
+            edpm_frr_bgp_peers:
+              - 100.64.0.5
+              - 100.65.0.5
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.105
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet0
+            fixedIP: 100.64.0.6
+          - name: Bgpnet1
+            subnetName: subnet0
+            fixedIP: 100.65.0.6
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 172.30.0.3
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0013
+      edpm-networker-1:
+        hostName: edpm-networker-1
+        ansible:
+          ansibleHost: 192.168.122.106
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.1.5
+              - 100.65.1.5
+            edpm_frr_bgp_peers:
+              - 100.64.1.5
+              - 100.65.1.5
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.106
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.1.6
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.1.6
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 172.30.1.3
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
+      edpm-networker-2:
+        hostName: edpm-networker-2
+        ansible:
+          ansibleHost: 192.168.122.107
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.2.5
+              - 100.65.2.5
+            edpm_frr_bgp_peers:
+              - 100.64.2.5
+              - 100.65.2.5
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.107
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet2
+            fixedIP: 100.64.2.6
+          - name: Bgpnet1
+            subnetName: subnet2
+            fixedIP: 100.65.2.6
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 172.30.2.3
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - frr
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp/bgp_dt01/metallb/README.md
+++ b/examples/dt/bgp/bgp_dt01/metallb/README.md
@@ -1,0 +1,16 @@
+# MetalLB
+
+Observe CRs which will be generated.
+```
+kustomize build examples/dt/bgp/bgp_dt01/metallb/
+```
+
+Apply the metallb kustomization from this directory.
+```
+oc apply -k examples/dt/bgp/bgp_dt01/metallb/
+```
+
+Then, check that a speaker is running on the OCP tester node.
+```
+oc -n metallb-system wait pod -l component=speaker --field-selector=spec.host=worker-3 --for condition=Ready --timeout=300s
+```

--- a/examples/dt/bgp/bgp_dt01/metallb/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/metallb/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+components:
+  - ../../../../../lib/metallb
+
+patches:
+  - target:
+      kind: MetalLB
+      name: metallb
+      namespace: metallb-system
+    patch: |-
+      - op: add
+        path: /spec/speakerTolerations
+        value:
+          - key: "testOperator"
+            value: "true"
+            effect: "NoSchedule"
+          - key: "testOperator"
+            value: "true"
+            effect: "NoExecute"

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,6 +3,7 @@
       jobs: &id001
       - noop
       - rhoso-architecture-validate-bgp
+      - rhoso-architecture-validate-bgp_dt01
       - rhoso-architecture-validate-hci
       - rhoso-architecture-validate-ovs-dpdk
       - rhoso-architecture-validate-ovs-dpdk-sriov

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -17,8 +17,9 @@
     - examples/dt/bgp/bgp_dt01/control-plane
     - examples/dt/bgp/bgp_dt01/control-plane/nncp
     - examples/dt/bgp/bgp_dt01/edpm/computes
-    - examples/dt/bgp/bgp_dt01/edpm/deployment
+    - examples/dt/bgp/bgp_dt01/edpm/computes-deployment
     - examples/dt/bgp/bgp_dt01/edpm/networkers
+    - examples/dt/bgp/bgp_dt01/edpm/networkers-deployment
     - lib
     name: rhoso-architecture-validate-bgp_dt01
     parent: rhoso-architecture-base-job

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -13,6 +13,19 @@
       cifmw_architecture_scenario: bgp
 - job:
     files:
+    - automation/mocks/bgp_dt01.yaml
+    - examples/dt/bgp/bgp_dt01/control-plane
+    - examples/dt/bgp/bgp_dt01/control-plane/nncp
+    - examples/dt/bgp/bgp_dt01/edpm/computes
+    - examples/dt/bgp/bgp_dt01/edpm/deployment
+    - examples/dt/bgp/bgp_dt01/edpm/networkers
+    - lib
+    name: rhoso-architecture-validate-bgp_dt01
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: bgp_dt01
+- job:
+    files:
     - examples/va/hci
     - examples/va/hci/control-plane
     - examples/va/hci/control-plane/nncp


### PR DESCRIPTION
This DT deploys RHOSO with BGP Dynamic Routing using default BGP
configuration:
- OVN routing
- OVN NB DB driver

This setup requires from a previous spine/leaf virtual infrastructure.
The OCP and EDPM nodes are deployed on different racks, which means they
are connected to different leaves.
The OCP cluster includes both master and worker nodes, instead of the
usual master/worker combo nodes used within other DTs.
This DT deploys an extra OCP worker that acts as tester node: no
Openstack service runs on it, only test-operator and test pods.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1734
Related-Issue: [OSPRH-6932](https://issues.redhat.com//browse/OSPRH-6932)