### PR TITLE
[manila] Adjust service replica counts

### DIFF
--- a/examples/dt/uni02beta/control-plane/service-values.yaml
+++ b/examples/dt/uni02beta/control-plane/service-values.yaml
@@ -44,9 +44,9 @@ data:
         [DEFAULT]
         debug = true
         enabled_share_protocols=cifs
-      replicas: 1
+      replicas: 3
     manilaScheduler:
-      replicas: 1
+      replicas: 3
     manilaShares:
       share1:
         networkAttachments:

--- a/examples/va/hci/service-values.yaml
+++ b/examples/va/hci/service-values.yaml
@@ -47,11 +47,15 @@ data:
   manila:
     enabled: true
     manilaAPI:
+      replicas: 3
       customServiceConfig: |
         [DEFAULT]
         enabled_share_protocols=nfs,cephfs
+    manilaScheduler:
+      replicas: 3
     manilaShares:
       share1:
+        replicas: 1
         customServiceConfig: |
           [DEFAULT]
           enabled_share_backends = cephfs

--- a/va/hci/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/va/hci/edpm-post-ceph/nodeset/kustomization.yaml
@@ -124,6 +124,28 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.manila.manilaAPI.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaAPI.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.manilaScheduler.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaScheduler.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.manila.manilaShares.share1.customServiceConfig
     targets:
       - select:


### PR DESCRIPTION
The default replica count we want for ManilaAPI and ManilaScheduler is 3; while we want ManilaShare to have 1 replica at most.