### PR TITLE
Set Cinder API and Backup replicas to 3 for HCI VA

### DIFF
--- a/examples/va/hci/service-values.yaml
+++ b/examples/va/hci/service-values.yaml
@@ -7,7 +7,10 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  cinderAPI:
+    replicas: 3
   cinderBackup:
+    replicas: 3
     customServiceConfig: |
       [DEFAULT]
       backup_driver = cinder.backup.drivers.ceph.CephBackupDriver

--- a/va/hci/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/va/hci/edpm-post-ceph/nodeset/kustomization.yaml
@@ -58,6 +58,28 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.cinderAPI.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderAPI.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.glance.customServiceConfig
     targets:
       - select:


### PR DESCRIPTION
Update HCI VA so that replicas for cinderAPI and cinderBackup are 3.