### PR TITLE
[manila] Fix "enabled_share_protocols" configuration

### DIFF
--- a/examples/dt/uni02beta/control-plane/service-values.yaml
+++ b/examples/dt/uni02beta/control-plane/service-values.yaml
@@ -43,7 +43,7 @@ data:
       customServiceConfig: |
         [DEFAULT]
         debug = true
-        enabled_share_protocols=cifs
+        enabled_share_protocols = nfs
       replicas: 3
     manilaScheduler:
       replicas: 3


### PR DESCRIPTION
This config opt is used only by manila's API service; so it doesn't need to be in the customServiceConfig for manilaShares. Also, unibeta seeks to test Manila's NetApp driver with NFS; so it needs to enable NFS instead of CIFS (the default behavior without this override is that both those protocols are enabled).