### PR TITLE
OSASINFRA DT

### DIFF
--- a/automation/vars/osasinfra.yaml
+++ b/automation/vars/osasinfra.yaml
@@ -1,0 +1,78 @@
+---
+vas:
+  osasinfra:
+    stages:
+      - path: examples/dt/osasinfra/control-plane/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=3m
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - path: examples/dt/osasinfra/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackcontrolplane
+            controlplane
+            --for condition=Ready
+            --timeout=30m
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: ../control-plane.yaml
+
+      - path: examples/dt/osasinfra/edpm-pre-ceph/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset-pre-ceph.yaml
+
+      - path: examples/dt/osasinfra/edpm-pre-ceph/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=1500s
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment-pre-ceph.yaml
+        post_stage_run:
+          - name: Deploy Ceph
+            type: playbook
+            source: "../../playbooks/ceph.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+
+      - path: examples/dt/osasinfra
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=10m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: edpm-nodeset-values-post-ceph
+            src_file: values.yaml
+        build_output: nodeset-post-ceph.yaml
+
+      - path: examples/dt/osasinfra/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=40m
+        values:
+          - name: edpm-deployment-values-post-ceph
+            src_file: values.yaml
+        build_output: deployment-post-ceph.yaml

--- a/dt/osasinfra/README.md
+++ b/dt/osasinfra/README.md
@@ -1,0 +1,11 @@
+# Deployed Topology - OSASINFRA
+
+If you are looking for information on how to deploy the OSASINFRA DT, then
+please the [README](../../examples/dt/osasinfra/README.md) in the examples
+directory.
+
+This directory `dt/osasinfra/`, exists so that the
+[kustomization.yaml](../../examples/dt/osasinfra/kustomization.yaml) in
+the examples directory of osasinfra topology, reference it by path as a
+component. It's contents are likely uninteresting unless you want to understand
+how kustomize was implemented in this repository.

--- a/dt/osasinfra/edpm-post-ceph/deployment/kustomization.yaml
+++ b/dt/osasinfra/edpm-post-ceph/deployment/kustomization.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/dataplane/deployment
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values-post-ceph
+      fieldPath: data.deployment.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true

--- a/dt/osasinfra/edpm-post-ceph/nodeset/ceph_secret.yaml
+++ b/dt/osasinfra/edpm-post-ceph/nodeset/ceph_secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+data:
+  ceph.client.openstack.keyring: _replaced_
+  ceph.conf: _replaced_
+kind: Secret
+metadata:
+  name: ceph-conf-files
+  namespace: openstack
+type: Opaque

--- a/dt/osasinfra/edpm-post-ceph/nodeset/extra_mounts.yaml
+++ b/dt/osasinfra/edpm-post-ceph/nodeset/extra_mounts.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm
+spec:
+  nodeTemplate:
+    extraMounts:
+      - extraVolType: Ceph
+        mounts:
+          - mountPath: /etc/ceph
+            name: ceph
+            readOnly: true
+        volumes:
+          - name: ceph
+            secret:
+              secretName: ceph-conf-files

--- a/dt/osasinfra/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/osasinfra/edpm-post-ceph/nodeset/kustomization.yaml
@@ -1,0 +1,312 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/control-plane
+  - ../../../../lib/dataplane/nodeset
+
+resources:
+  - ceph_secret.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    path: extra_mounts.yaml
+
+replacements:
+  # Control plane custom service configs
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderVolumes.ceph
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderVolumes.ceph
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderAPI.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderAPI.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.glanceAPIs.default.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.manilaAPI.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaAPI.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.manilaAPI.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaAPI.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.manilaScheduler.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaScheduler.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.manilaShares.share1.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaShares.share1.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.manilaShares.share1.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaShares.share1.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.extraMounts
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.extraMounts
+        options:
+          create: true
+  # Ceph keyring
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.ceph.keyring
+    targets:
+      - select:
+          kind: Secret
+          name: ceph-conf-files
+        fieldPaths:
+          - data.ceph\.client\.openstack\.keyring
+        options:
+          create: true
+  # Ceph conf
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.ceph.conf
+    targets:
+      - select:
+          kind: Secret
+          name: ceph-conf-files
+        fieldPaths:
+          - data.ceph\.conf
+        options:
+          create: true
+  # Dataplane services override (overrides ../../../lib/dataplane which
+  # is using edpm-nodeset-values ConfigMap)
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.nodeset.services
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - spec.services
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.amphoraImageContainerImage
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.amphoraImageContainerImage
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.apacheContainerImage
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.apacheContainerImage
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaAPI.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaAPI.networkAttachments
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaHousekeeping.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaHousekeeping.networkAttachments
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaHealthManager.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaHealthManager.networkAttachments
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaWorker.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaWorker.networkAttachments
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.ovn.ovnController.nicMappings
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ovn.template.ovnController.nicMappings
+        options:
+          create: true

--- a/dt/osasinfra/edpm-pre-ceph/deployment/kustomization.yaml
+++ b/dt/osasinfra/edpm-pre-ceph/deployment/kustomization.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/dataplane/deployment
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.deployment.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true

--- a/dt/osasinfra/edpm-pre-ceph/nodeset/kustomization.yaml
+++ b/dt/osasinfra/edpm-pre-ceph/nodeset/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/dataplane/nodeset

--- a/dt/osasinfra/kustomization.yaml
+++ b/dt/osasinfra/kustomization.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+secretGenerator:
+  - name: octavia-ca-passphrase
+    literals:
+      - server-ca-passphrase=12345678
+    options:
+      disableNameSuffixHash: true
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+      apiVersion: builtin
+      kind: NamespaceTransformer
+      metadata:
+        name: _ignored_
+        namespace: openstack
+      setRoleBindingSubjects: none
+      unsetOnly: true
+      fieldSpecs:
+        - path: metadata/name
+          kind: Namespace
+          create: true
+
+components:
+  - ../../lib/networking/metallb
+  - ../../lib/networking/netconfig
+  - ../../lib/networking/nad
+  - ../../lib/control-plane
+
+resources:
+  - ocp_networks_octavia_netattach.yaml
+
+# Add storagemgmt network template, as it is needed for CephHCI
+patches:
+  - target:
+      version: v1beta1
+      kind: NetConfig
+      name: netconfig
+    patch: |-
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: storagemgmt
+          subnets:
+            - _replaced_
+          mtu: 1500
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].dnsDomain
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].mtu
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].subnets
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: octavia
+        fieldPaths:
+          - spec.config

--- a/dt/osasinfra/namespace.yaml
+++ b/dt/osasinfra/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: builtin
+kind: NamespaceTransformer
+metadata:
+  name: _ignored_
+  namespace: openstack
+setRoleBindingSubjects: none
+unsetOnly: true
+fieldSpecs:
+  - path: metadata/name
+    kind: Namespace
+    create: true

--- a/dt/osasinfra/nncp/kustomization.yaml
+++ b/dt/osasinfra/nncp/kustomization.yaml
@@ -1,0 +1,187 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../lib/nncp
+
+patches:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-0
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia vlan host interface
+          name: octavia
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-0
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia bridge
+          mtu: 1500
+          name: octbr
+          type: linux-bridge
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+              - name: octavia
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-1
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia vlan host interface
+          name: octavia
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-1
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia bridge
+          mtu: 1500
+          name: octbr
+          type: linux-bridge
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+              - name: octavia
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-2
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia vlan host interface
+          name: octavia
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-2
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia bridge
+          mtu: 1500
+          name: octbr
+          type: linux-bridge
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+              - name: octavia
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.id
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.id
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.id

--- a/dt/osasinfra/ocp_networks_octavia_netattach.yaml
+++ b/dt/osasinfra/ocp_networks_octavia_netattach.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: octavia
+  labels:
+    osp/net: octavia
+    osp/net-attach-def-type: standard

--- a/examples/dt/osasinfra/.gitignore
+++ b/examples/dt/osasinfra/.gitignore
@@ -1,0 +1,4 @@
+nncp.yaml
+control-plane.yaml
+dataplane-pre-ceph.yaml
+dataplane-post-ceph.yaml

--- a/examples/dt/osasinfra/README.md
+++ b/examples/dt/osasinfra/README.md
@@ -1,0 +1,43 @@
+# OpenShift on OpenStack
+
+This is a collection of CR templates that represent a validated Red Hat
+OpenStack Services on OpenShift deployment following the recommendations from
+the (OpenShift on OpenStack reference
+architecture)[https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.2/html-single/reference_architecture_for_deploying_red_hat_openshift_container_platform_on_red_hat_openstack_platform/index]. It has the following characteristics:
+
+- 3 master/worker combo-node OpenShift cluster
+- 3-replica Galera database
+- RabbitMQ
+- OVN networking
+- Network isolation over a single NIC
+- 3 compute nodes
+- CephHCI installed on compute nodes and used by various OSP services
+    - Cinder Volume using RBD for backend
+    - Cinder Backup using RBD for backend
+    - Glance using RBD for backend
+    - Object Storage via Rados GW
+    - Manila using CephFS through NFS (ganesha) for backend
+- Nova ephemeral using local storage
+- Octavia with Amphora provider
+
+
+## Considerations
+
+1. These CRs are validated for the overall functionality of the OSP cloud deployed, but they nonetheless require customization for the particular environment in which they are utilized.  In this sense they are _templates_ meant to be consumed and tweaked to fit the specific constraints of the hardware available.
+
+2. The CRs are applied against an OpenShift cluster in _stages_.  That is, there is an ordering in which each grouping of CRs is fed to the cluster.  It is _not_ a case of simply taking all CRs from all stages and applying them all at once.
+
+3. In stages 1 and 2 [kustomize](https://kustomize.io/) is used to genereate the control plane CRs dynamically. The `control-plane/nncp/values.yaml` file(s) must be updated to fit your environment. kustomize version 5 or newer required.
+
+4. In stages 3 and 4 [kustomize](https://kustomize.io/) is used to generate the dataplane CRs dynamically. The `edpm-pre-ceph/values.yaml`, `values.yaml` and `service-values.yaml` files must be updated to fit your environment. kustomize version 5 or newer required.
+
+5. Between stages 3 and 4, _it is assumed that the user installs Ceph on the 3 OSP compute nodes._  OpenStack K8S CRDs do not provide a way to install Ceph via any sort of combination of CRs.
+
+## Stages
+
+All stages must be executed in the order listed below. Everything is required unless otherwise indicated.
+
+1. [Install the OpenStack K8S operators and their dependencies](../../common/)
+2. [Configuring networking and deploy the OpenStack control plane](control-plane.md)
+3. [Configure and deploy the initial data plane to prepare for Ceph installation](dataplane-pre-ceph.md)
+4. [Update the control plane and finish deploying the data plane after Ceph has been installed](dataplane-post-ceph.md)

--- a/examples/dt/osasinfra/control-plane.md
+++ b/examples/dt/osasinfra/control-plane.md
@@ -1,0 +1,51 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `local-storage` should already exist.
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the osasinfra directory
+```
+cd architecture/examples/dt/osasinfra
+```
+Edit the [control-plane/nncp/values.yaml](control-plane/nncp/values.yaml) file to suit your environment.
+```
+vi control-plane/nncp/values.yaml
+```
+
+## Apply node network configuration
+
+Generate the node network configuration
+```
+kustomize build control-plane/nncp > nncp.yaml
+```
+Apply the NNCP CRs
+```
+oc apply -f nncp.yaml
+```
+Wait for NNCPs to be available
+```
+oc wait nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=3m
+```
+
+## Apply networking and control-plane configuration
+
+Generate the control-plane and networking CRs.
+```
+kustomize build control-plane > control-plane.yaml
+```
+Apply the CRs
+```
+oc apply -f control-plane.yaml
+```
+
+Wait for control plane to be available
+```
+oc wait osctlplane controlplane --for condition=Ready --timeout=30m
+```

--- a/examples/dt/osasinfra/control-plane/.gitignore
+++ b/examples/dt/osasinfra/control-plane/.gitignore
@@ -1,0 +1,1 @@
+control-plane.yaml

--- a/examples/dt/osasinfra/control-plane/kustomization.yaml
+++ b/examples/dt/osasinfra/control-plane/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/osasinfra/
+
+resources:
+  - nncp/values.yaml
+  - service-values.yaml

--- a/examples/dt/osasinfra/control-plane/nncp/.gitignore
+++ b/examples/dt/osasinfra/control-plane/nncp/.gitignore
@@ -1,0 +1,1 @@
+nncp.yaml

--- a/examples/dt/osasinfra/control-plane/nncp/kustomization.yaml
+++ b/examples/dt/osasinfra/control-plane/nncp/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/osasinfra/nncp
+
+resources:
+  - values.yaml

--- a/examples/dt/osasinfra/control-plane/nncp/values.yaml
+++ b/examples/dt/osasinfra/control-plane/nncp/values.yaml
@@ -1,0 +1,234 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # nodes
+  node_0:
+    name: master-0
+    internalapi_ip: 172.17.0.5
+    tenant_ip: 172.19.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+  node_1:
+    name: master-1
+    internalapi_ip: 172.17.0.6
+    tenant_ip: 172.19.0.6
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.6
+  node_2:
+    name: master-2
+    internalapi_ip: 172.17.0.7
+    tenant_ip: 172.19.0.7
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.7
+
+  # networks
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet1
+    prefix-length: 24
+    iface: enp6s0
+    mtu: 9000
+    lb_addresses:
+      - 192.168.122.80-192.168.122.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "macvlan",
+        "master": "ospbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.122.0/24",
+          "range_start": "192.168.122.30",
+          "range_end": "192.168.122.70"
+        }
+      }
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "macvlan",
+        "master": "internalapi",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 9000
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "macvlan",
+        "master": "storage",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+  storagemgmt:  # used on RHEL, not used on OpenShift
+    dnsDomain: storagemgmt.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.20.0.250
+            start: 172.20.0.100
+        cidr: 172.20.0.0/24
+        name: subnet1
+        vlan: 23
+    mtu: 9000
+  tenant:
+    dnsDomain: tenant.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        name: subnet1
+        vlan: 22
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "macvlan",
+        "master": "tenant",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70"
+        }
+      }
+
+  octavia:
+    dnsDomain: octavia.example.com
+    mtu: 1500
+    vlan: 24
+    base_iface: enp6s0
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "octavia",
+        "type": "bridge",
+        "bridge": "octbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.23.0.0/24",
+          "range_start": "172.23.0.30",
+          "range_end": "172.23.0.70",
+          "routes": [
+            {
+              "dst": "172.24.0.0/16",
+              "gw": "172.23.0.150"
+            }
+          ]
+        }
+      }
+  external:
+    dnsDomain: external.example.com
+    subnets:
+      - allocationRanges:
+          - end: 10.0.0.250
+            start: 10.0.0.100
+        cidr: 10.0.0.0/24
+        gateway: 10.0.0.1
+        name: subnet1
+    mtu: 1500
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config: []
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr

--- a/examples/dt/osasinfra/control-plane/service-values.yaml
+++ b/examples/dt/osasinfra/control-plane/service-values.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  preserveJobs: false

--- a/examples/dt/osasinfra/dataplane-post-ceph.md
+++ b/examples/dt/osasinfra/dataplane-post-ceph.md
@@ -1,0 +1,77 @@
+# Configuring and deploying the post-Ceph dataplane
+
+## Assumptions
+
+- The pre-Ceph [dataplane](dataplane-pre-ceph.md) was already deployed and Ceph was manually installed afterwards
+
+## Initialize post-Ceph
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the osasinfra directory
+```
+cd architecture/examples/dt/osasinfra
+```
+Edit the [values.yaml](values.yaml) and [service-values.yaml](service-values.yaml)
+files to suit your environment.
+```
+vi values.yaml
+vi service-values.yaml
+```
+The ceph sections of [values.yaml](values.yaml) should have values like this.
+```yaml
+data:
+    ceph:
+        conf: $CONF
+        keyring: $KEY
+
+```
+Where the values of the variables above can be retrieved by
+running the following commands on the Ceph cluster.
+```shell
+CONF=$(cat /etc/ceph/ceph.conf | base64 -w 0)
+KEY=$(cat /etc/ceph/ceph.client.openstack.keyring | base64 -w 0)
+```
+
+Generate the post-Ceph dataplane nodeset CR.
+```
+kustomize build > nodeset-post-ceph.yaml
+```
+Generate the post-Ceph dataplane deployment CR.
+```
+kustomize build deployment > deployment-post-ceph.yaml
+```
+
+## Create post-Ceph CRs
+
+Create the nodeset CR
+```
+oc apply -f nodeset-post-ceph.yaml
+```
+Wait for post-Ceph dataplane nodeset setup to finish
+```
+oc wait osdpns openstack-edpm --for condition=SetupReady --timeout=600s
+```
+Create the deployment CR
+```
+oc apply -f deployment-post-ceph.yaml
+```
+
+Wait for control plane to be available after updating
+```
+oc wait osctlplane controlplane --for condition=Ready --timeout=40m
+```
+
+Wait for post-Ceph dataplane deployment to finish
+```
+oc wait osdpd edpm-deployment-post-ceph --for condition=Ready --timeout=1200s
+```
+
+## Finalize Nova computes
+
+Ask Nova to discover all compute hosts
+```bash
+oc rsh nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
+```

--- a/examples/dt/osasinfra/dataplane-pre-ceph.md
+++ b/examples/dt/osasinfra/dataplane-pre-ceph.md
@@ -1,0 +1,50 @@
+# Configuring and deploying the pre-Ceph dataplane
+
+## Assumptions
+
+- The [control plane](control-plane.md) has been created and successfully deployed
+
+## Initialize pre-Ceph
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the osasinfra directory
+```
+cd architecture/examples/dt/osasinfra
+```
+Edit the [edpm-pre-ceph/nodeset/values.yaml](edpm-pre-ceph/nodeset/values.yaml) file to suit
+your environment.
+```
+vi edpm-pre-ceph/nodeset/values.yaml
+```
+Generate the pre-Ceph dataplane nodeset CR.
+```
+kustomize build edpm-pre-ceph/nodeset > dataplane-nodeset-pre-ceph.yaml
+```
+Generate the pre-Ceph dataplane deployment CR.
+```
+kustomize build edpm-pre-ceph/deployment > dataplane-deployment-pre-ceph.yaml
+```
+
+## Create pre-Ceph CRs
+
+Create the nodeset CR
+```
+oc apply -f dataplane-nodeset-pre-ceph.yaml
+```
+Wait for pre-Ceph dataplane nodeset setup to finish
+```
+oc wait osdpns openstack-edpm --for condition=SetupReady --timeout=600s
+```
+
+Start the deployment
+```
+oc apply -f dataplane-deployment-pre-ceph.yaml
+```
+
+Wait for pre-Ceph dataplane deployment to finish
+```
+oc wait osdpd edpm-deployment-pre-ceph --for condition=Ready --timeout=1500s
+```

--- a/examples/dt/osasinfra/deployment/kustomization.yaml
+++ b/examples/dt/osasinfra/deployment/kustomization.yaml
@@ -1,0 +1,13 @@
+# This is the kustomization for the FINAL step, edpm-post-ceph
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/osasinfra/edpm-post-ceph/deployment
+  # - https://github.com/openstack-k8s-operators/architecture/dt/osasinfra/edpm-post-ceph/?ref=main
+  ## It's possible to replace ../../../dt/osasinfra/edpm-post-ceph/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml

--- a/examples/dt/osasinfra/deployment/values.yaml
+++ b/examples/dt/osasinfra/deployment/values.yaml
@@ -1,0 +1,11 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values-post-ceph
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  deployment:
+    name: edpm-deployment-post-ceph

--- a/examples/dt/osasinfra/edpm-pre-ceph/.gitignore
+++ b/examples/dt/osasinfra/edpm-pre-ceph/.gitignore
@@ -1,0 +1,1 @@
+dataplane-pre-ceph.yaml

--- a/examples/dt/osasinfra/edpm-pre-ceph/deployment/kustomization.yaml
+++ b/examples/dt/osasinfra/edpm-pre-ceph/deployment/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/osasinfra/edpm-pre-ceph/deployment
+  # - https://github.com/openstack-k8s-operators/architecture/dt/osasinfra/edpm-pre-ceph/?ref=main
+  ## It's possible to replace ../../../../dt/osasinfra/edpm-pre-ceph/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml

--- a/examples/dt/osasinfra/edpm-pre-ceph/deployment/values.yaml
+++ b/examples/dt/osasinfra/edpm-pre-ceph/deployment/values.yaml
@@ -1,0 +1,12 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  deployment:
+    name: edpm-deployment-pre-ceph

--- a/examples/dt/osasinfra/edpm-pre-ceph/nodeset/kustomization.yaml
+++ b/examples/dt/osasinfra/edpm-pre-ceph/nodeset/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/osasinfra/edpm-pre-ceph/nodeset
+  # - https://github.com/openstack-k8s-operators/architecture/dt/osasinfra/edpm-pre-ceph/?ref=main
+  ## It's possible to replace ../../../../dt/osasinfra/edpm-pre-ceph/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml

--- a/examples/dt/osasinfra/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/osasinfra/edpm-pre-ceph/nodeset/values.yaml
@@ -1,0 +1,171 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        timesync_ntp_servers:
+          - hostname: clock.redhat.com
+        # CHANGEME -- see https://access.redhat.com/solutions/253273
+        # edpm_bootstrap_command: |
+        #       subscription-manager register --username <subscription_manager_username> \
+        #         --password <subscription_manager_password>
+        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+          edpm-compute-1:
+            nic2: 6b:fe:54:3f:8a:02  # CHANGEME
+          edpm-compute-2:
+            nic2: 6c:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            mtu: {{ min_viable_mtu }}
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            mtu: {{ min_viable_mtu }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            members:
+            - type: interface
+              name: nic2
+              mtu: {{ min_viable_mtu }}
+              # force the MAC address of the bridge to this interface
+              primary: true
+          {% for network in nodeset_networks %}
+            - type: vlan
+              mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+              vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+              addresses:
+              - ip_netmask:
+                  {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+              routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth0
+        edpm_ceph_hci_pre_enabled_services:
+          - ceph_mon
+          - ceph_mgr
+          - ceph_osd
+          - ceph_rgw
+          - ceph_nfs
+          - ceph_rgw_frontend
+          - ceph_nfs_frontend
+        storage_mtu: 9000
+        storage_mgmt_mtu: 9000
+        storage_mgmt_vlan_id: 23
+        storage_mgmt_cidr: "24"
+        storage_mgmt_host_routes: []
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
+    nodes:
+      edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.122.100
+        hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: storagemgmt
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+      edpm-compute-1:
+        ansible:
+          ansibleHost: 192.168.122.101
+        hostName: edpm-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: storagemgmt
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+      edpm-compute-2:
+        ansible:
+          ansibleHost: 192.168.122.102
+        hostName: edpm-compute-2
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.102
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: storagemgmt
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+    services:
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - ceph-hci-pre
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/osasinfra/kustomization.yaml
+++ b/examples/dt/osasinfra/kustomization.yaml
@@ -1,0 +1,16 @@
+# This is the kustomization for the FINAL step, edpm-post-ceph
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../dt/osasinfra/edpm-post-ceph/nodeset
+  # - https://github.com/openstack-k8s-operators/architecture/dt/osasinfra/edpm-post-ceph/?ref=main
+  ## It's possible to replace ../../../dt/osasinfra/edpm-post-ceph/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - control-plane/nncp/values.yaml
+  - edpm-pre-ceph/nodeset/values.yaml
+  - service-values.yaml
+  - values.yaml

--- a/examples/dt/osasinfra/service-values.yaml
+++ b/examples/dt/osasinfra/service-values.yaml
@@ -1,0 +1,115 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  preserveJobs: false
+  cinderAPI:
+    replicas: 3
+  cinderBackup:
+    replicas: 3
+    customServiceConfig: |
+      [DEFAULT]
+      backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
+      backup_ceph_pool = backups
+      backup_ceph_user = openstack
+  cinderVolumes:
+    ceph:
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = ceph
+        [ceph]
+        volume_backend_name = ceph
+        volume_driver = cinder.volume.drivers.rbd.RBDDriver
+        rbd_ceph_conf = /etc/ceph/ceph.conf
+        rbd_user = openstack
+        rbd_pool = volumes
+        rbd_flatten_volume_from_snapshot = False
+        rbd_secret_uuid = CHANGEME
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:rbd
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      rbd_store_ceph_conf = /etc/ceph/ceph.conf
+      store_description = "RBD backend"
+      rbd_store_pool = images
+      rbd_store_user = openstack
+      rbd_thin_provisioning = True
+    glanceAPIs:
+      default:
+        replicas: 3
+  manila:
+    enabled: true
+    manilaAPI:
+      replicas: 3
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_share_protocols = nfs
+    manilaScheduler:
+      replicas: 3
+    manilaShares:
+      share1:
+        replicas: 1
+        customServiceConfig: |
+          [DEFAULT]
+          enabled_share_backends = cephfsnfs
+          debug = True
+
+          [cephfsnfs]
+          driver_handles_share_servers = False
+          share_backend_name = cephfs
+          share_driver = manila.share.drivers.cephfs.driver.CephFSDriver
+          cephfs_auth_id = openstack
+          cephfs_cluster_name = ceph
+          cephfs_nfs_cluster_id = cephfs
+          cephfs_protocol_helper_type = NFS
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+            - CinderVolume
+            - CinderBackup
+            - GlanceAPI
+            - ManilaShare
+          extraVolType: Ceph
+          volumes:
+            - name: ceph
+              projected:
+                sources:
+                  - secret:
+                      name: ceph-conf-files
+          mounts:
+            - name: ceph
+              mountPath: /etc/ceph
+              readOnly: true
+
+  octavia:
+    enabled: true
+    amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image
+    apacheContainerImage: registry.redhat.io/ubi9/httpd-24:latest
+    octaviaAPI:
+      networkAttachments:
+        - internalapi
+    octaviaHousekeeping:
+      networkAttachments:
+        - octavia
+    octaviaHealthManager:
+      networkAttachments:
+        - octavia
+    octaviaWorker:
+      networkAttachments:
+        - octavia
+
+  ovn:
+    ovnController:
+      nicMappings:
+        datacentre: ocpbr
+        octavia: octbr

--- a/examples/dt/osasinfra/values.yaml
+++ b/examples/dt/osasinfra/values.yaml
@@ -1,0 +1,20 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values-post-ceph
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeset:
+    services:
+      - install-certs
+      - ceph-client
+      - ovn
+      - neutron-metadata
+      - libvirt
+      - nova
+  ceph:
+    conf: CHANGEME_CEPH_CONF
+    keyring: CHANGEME_CEPH_KEYRING

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -5,6 +5,7 @@
       - rhoso-architecture-validate-bgp
       - rhoso-architecture-validate-bgp_dt01
       - rhoso-architecture-validate-hci
+      - rhoso-architecture-validate-osasinfra
       - rhoso-architecture-validate-ovs-dpdk
       - rhoso-architecture-validate-ovs-dpdk-sriov
       - rhoso-architecture-validate-pidone

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -41,6 +41,20 @@
       cifmw_architecture_scenario: hci
 - job:
     files:
+    - dt/osasinfra
+    - examples/dt/osasinfra
+    - examples/dt/osasinfra/control-plane
+    - examples/dt/osasinfra/control-plane/nncp
+    - examples/dt/osasinfra/deployment
+    - examples/dt/osasinfra/edpm-pre-ceph/deployment
+    - examples/dt/osasinfra/edpm-pre-ceph/nodeset
+    - lib
+    name: rhoso-architecture-validate-osasinfra
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: osasinfra
+- job:
+    files:
     - automation/mocks/ovs-dpdk.yaml
     - examples/va/nfv/ovs-dpdk
     - examples/va/nfv/ovs-dpdk/edpm/deployment


### PR DESCRIPTION
A DT for deploying OpenShift on OpenStack, following the recommendations
from the OpenShift on OpenStack reference architecture [1], in
particular:
- Ceph for Image, Block Storage, and Object Storage (using RGW).
- Nova ephemeral using local storage
- Octavia + Amphora
- Manila + NFS

[1] https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.2/html-single/reference_architecture_for_deploying_red_hat_openshift_container_platform_on_red_hat_openstack_platform/index