### PR TITLE
Set edpmRoleServiceName for nova-custom-ceph

### DIFF
--- a/va/hci/edpm-post-ceph/nodeset/nova_ceph.yaml
+++ b/va/hci/edpm-post-ceph/nodeset/nova_ceph.yaml
@@ -25,4 +25,5 @@ spec:
     networks:
       - ctlplane
     issuer: osp-rootca-issuer-internal
+    edpmRoleServiceName: nova
   caCerts: combined-ca-bundle


### PR DESCRIPTION
This is now required after
https://github.com/openstack-k8s-operators/edpm-ansible/pull/658 has
merged.

Signed-off-by: James Slagle <jslagle@redhat.com>
Jira: https://issues.redhat.com/browse/OSPRH-7257
