### PR TITLE
Remove unused params from OpenStackDataPlaneNodeSet examples

### DIFF
--- a/examples/dt/bgp/edpm/nodeset/values.yaml
+++ b/examples/dt/bgp/edpm/nodeset/values.yaml
@@ -89,17 +89,12 @@ data:
             - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
-        edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
-        enable_debug: false
         gather_facts: false
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth1
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
     networks:
       - defaultRoute: true
         name: CtlPlane

--- a/examples/dt/uni01alpha/edpm/values.yaml
+++ b/examples/dt/uni01alpha/edpm/values.yaml
@@ -72,7 +72,6 @@ data:
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
 
-        enable_debug: false
         gather_facts: false
 
     networks:

--- a/examples/dt/uni01alpha/networker/nodeset/values.yaml
+++ b/examples/dt/uni01alpha/networker/nodeset/values.yaml
@@ -28,7 +28,6 @@ data:
           - hostname: clock.redhat.com
 
         gather_facts: false
-        enable_debug: false
 
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false

--- a/examples/dt/uni02beta/values.yaml
+++ b/examples/dt/uni02beta/values.yaml
@@ -24,9 +24,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
         timesync_ntp_servers:
           - hostname: clock.redhat.com
         edpm_network_config_hide_sensitive_logs: false
@@ -71,12 +68,10 @@ data:
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
 
-        edpm_selinux_mode: enforcing
         edpm_sshd_configure_firewall: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
 
-        enable_debug: false
         gather_facts: false
 
     networks:

--- a/examples/dt/uni04delta/values.yaml
+++ b/examples/dt/uni04delta/values.yaml
@@ -72,12 +72,10 @@ data:
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
 
-        edpm_selinux_mode: enforcing
         edpm_sshd_configure_firewall: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
 
-        enable_debug: false
         gather_facts: false
 
         image_tag: current-podified
@@ -85,9 +83,6 @@ data:
         neutron_public_interface_name: eth0
         registry_url: quay.io/podified-antelope-centos9
 
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
 
         storage_mtu: 9000
         storage_mgmt_mtu: 9000

--- a/examples/dt/uni05epsilon/values.yaml
+++ b/examples/dt/uni05epsilon/values.yaml
@@ -24,9 +24,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
         timesync_ntp_servers:
           - hostname: clock.redhat.com
         edpm_network_config_hide_sensitive_logs: false
@@ -71,12 +68,10 @@ data:
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
 
-        edpm_selinux_mode: enforcing
         edpm_sshd_configure_firewall: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
 
-        enable_debug: false
         gather_facts: false
 
     networks:

--- a/examples/dt/uni06zeta/values.yaml
+++ b/examples/dt/uni06zeta/values.yaml
@@ -24,9 +24,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
         timesync_ntp_servers:
           - hostname: clock.redhat.com
         edpm_network_config_hide_sensitive_logs: false
@@ -66,12 +63,10 @@ data:
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
 
-        edpm_selinux_mode: enforcing
         edpm_sshd_configure_firewall: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
 
-        enable_debug: false
         gather_facts: false
 
     networks:

--- a/examples/va/hci/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/nodeset/values.yaml
@@ -73,17 +73,12 @@ data:
           {% endfor %}
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
-        edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
-        enable_debug: false
         gather_facts: false
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth0
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
         edpm_ceph_hci_pre_enabled_services:
           - ceph_mon
           - ceph_mgr

--- a/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
@@ -37,9 +37,6 @@ data:
         #       subscription-manager register --username <subscription_manager_username> \
         #         --password <subscription_manager_password>
         #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
         timesync_ntp_servers:
           - hostname: clock.redhat.com
         # CPU pinning settings
@@ -147,13 +144,10 @@ data:
         edpm_nodes_validation_validate_gateway_icmp: false
         dns_search_domains: []
         gather_facts: false
-        enable_debug: false
         # edpm firewall, change the allowed CIDR if needed
         edpm_sshd_configure_firewall: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
-        # SELinux module
-        edpm_selinux_mode: enforcing
     networks:
       - defaultRoute: true
         name: ctlplane

--- a/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
@@ -36,9 +36,6 @@ data:
         #       subscription-manager register --username <subscription_manager_username> \
         #         --password <subscription_manager_password>
         #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
         timesync_ntp_servers:
           - hostname: clock.redhat.com
         # CPU pinning settings
@@ -128,13 +125,10 @@ data:
         edpm_nodes_validation_validate_gateway_icmp: false
         dns_search_domains: []
         gather_facts: false
-        enable_debug: false
         # edpm firewall, change the allowed CIDR if needed
         edpm_sshd_configure_firewall: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
-        # SELinux module
-        edpm_selinux_mode: enforcing
     networks:
       - defaultRoute: true
         name: ctlplane

--- a/examples/va/nfv/sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/sriov/edpm/nodeset/values.yaml
@@ -35,9 +35,6 @@ data:
         # edpm_bootstrap_command: |
         #       subscription-manager register --username <subscription_manager_username> --password <subscription_manager_password>
         #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
         timesync_ntp_servers:
           - hostname: clock.redhat.com
         # CPU pinning settings
@@ -101,13 +98,10 @@ data:
         edpm_nodes_validation_validate_gateway_icmp: false
         dns_search_domains: []
         gather_facts: false
-        enable_debug: false
         # edpm firewall, change the allowed CIDR if needed
         edpm_sshd_configure_firewall: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
-        # SELinux module
-        edpm_selinux_mode: enforcing
         # SRIOV settings
         edpm_neutron_sriov_agent_SRIOV_NIC_physical_device_mappings: 'sriov-phy4:eno4'
     networks:


### PR DESCRIPTION
This change removes unused parameters from the OpenStackDataPlaneNodeSet examples. Specifically, we remove the following parameters:
 - service_net_map;
 - enable_debug;
 - edpm_selinux_mode