### PR TITLE
Add edpmServiceType to nova-custom-sriov srv

### DIFF
--- a/va/nfv/ovs-dpdk/edpm/nodeset/nova_ovs_dpdk.yaml
+++ b/va/nfv/ovs-dpdk/edpm/nodeset/nova_ovs_dpdk.yaml
@@ -12,6 +12,7 @@ metadata:
   name: nova-custom-ovsdpdk
 spec:
   label: nova-custom-ovsdpdk
+  edpmServiceType: nova
   configMaps:
     - ovs-dpdk-cpu-pinning-nova
   secrets:

--- a/va/nfv/sriov/edpm/nodeset/nova_sriov.yaml
+++ b/va/nfv/sriov/edpm/nodeset/nova_sriov.yaml
@@ -19,6 +19,7 @@ metadata:
   name: nova-custom-sriov
 spec:
   label: dataplane-deployment-nova-custom-sriov
+  edpmServiceType: nova
   configMaps:
     - cpu-pinning-nova
     - sriov-nova


### PR DESCRIPTION
Add  `edpmServiceType: nova` to the nova-custom-sriov service for the sriov architecture scenario.