### PR TITLE
Set default config options for all Cinder services

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -26,6 +26,10 @@ spec:
     apiOverride:
       route: {}
     template:
+      customServiceConfig: |
+        # Debug logs by default, jobs can override as needed.
+        [DEFAULT]
+        debug = true
       cinderBackup:
         networkAttachments:
           - storage

--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -30,6 +30,10 @@ spec:
         # Debug logs by default, jobs can override as needed.
         [DEFAULT]
         debug = true
+        # Necessary to prevent DB race conditions.
+        # Remove once jobs run b0747944394807862e4cdcfa7052f1f8d1febf94.
+        [database]
+        mysql_wsrep_sync_wait = 1
       cinderBackup:
         networkAttachments:
           - storage


### PR DESCRIPTION
In this PR we set 2 global defaults for all cinder services:

- Debug log levels
- Wait for DB writes on DB reads.

Without debug log levels it is usually very difficult to figure out Cinder
issues on jobs.

As for the DB changes, because we deploy the database in multi-master mode
we can have cases where a service writes something in the database and when
another one reads from the DB that data is not yet there.

This is a problem for Cinder, so we need to ensure that reads happen
after writes from other nodes are present.

The cinder operator already has this [1], but until jobs are using that
code we will be adding the configuration option manually.

In this PR we also set the debug logs

[1]: https://github.com/openstack-k8s-operators/cinder-operator/commit/b0747944394807862e4cdcfa7052f1f8d1febf94