### PR TITLE
[DNM] Enable Octavia in Uni-Epsilon

### DIFF
--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -84,7 +84,7 @@ data:
         type: split
 
   octavia:
-    enabled: false  # TODO after healthmanager fixed
+    enabled: true
     amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image
     apacheContainerImage: registry.redhat.io/ubi9/httpd-24:latest
     octaviaAPI:


### PR DESCRIPTION
Octavia was initially disabled due to issues with the service deployment.
This pull requests enables it.

DO NOT MERGE – for now this PR is to be used with Depends-On mechanism test it