### PR TITLE
Remove unused params from pidone OSDPNS examples

### DIFF
--- a/examples/va/pidone/edpm/nodeset/values.yaml
+++ b/examples/va/pidone/edpm/nodeset/values.yaml
@@ -73,17 +73,12 @@ data:
           {% endfor %}
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
-        edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
-        enable_debug: false
         gather_facts: false
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth0
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
         storage_mtu: 9000
         storage_mgmt_mtu: 9000
         storage_mgmt_vlan_id: 23

--- a/examples/va/pidone/values.yaml
+++ b/examples/va/pidone/values.yaml
@@ -73,17 +73,12 @@ data:
           {% endfor %}
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
-        edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
-        enable_debug: false
         gather_facts: false
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth0
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
         storage_mtu: 9000
         storage_mgmt_mtu: 9000
         storage_mgmt_vlan_id: 23


### PR DESCRIPTION
This change removes unused parameters from the OpenStackDataPlaneNodeSet examples in the VA pidone files.

Specifically, we remove:

 - service_net_map;
 - enable_debug;
 - edpm_selinux_mode

We did a full project cleanup here:
https://github.com/openstack-k8s-operators/architecture/pull/250