### PR TITLE
Set mysql_wsrep_sync_wait for Glance and global debug option

### DIFF
--- a/examples/dt/bgp/control-plane/service-values.yaml
+++ b/examples/dt/bgp/control-plane/service-values.yaml
@@ -9,6 +9,7 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
+      debug=True
       enabled_backends = default_backend:swift
       [glance_store]
       default_backend = default_backend
@@ -19,6 +20,8 @@ data:
       swift_store_endpoint_type = internalURL
       swift_store_user = service:glance
       swift_store_key = {{ .ServicePassword }}
+      [database]
+      mysql_wsrep_sync_wait = 1
     default:
       replicas: 1
 

--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -33,6 +33,7 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
+      debug=True
       enabled_backends = default_backend:swift
 
       [glance_store]
@@ -45,6 +46,9 @@ data:
       swift_store_endpoint_type = internalURL
       swift_store_user = service:glance
       swift_store_key = {{ .ServicePassword }}
+
+      [database]
+      mysql_wsrep_sync_wait = 1
     default:
       replicas: 1
 

--- a/examples/dt/uni02beta/control-plane/service-values.yaml
+++ b/examples/dt/uni02beta/control-plane/service-values.yaml
@@ -75,11 +75,14 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
+      debug=True
       enabled_backends = default_backend:file
       [glance_store]
       default_backend = default_backend
       [default_backend]
       filesystem_store_datadir = /var/lib/glance/images/
+      [database]
+      mysql_wsrep_sync_wait = 1
     databaseInstance: openstack
     glanceAPIs:
       default:

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -33,6 +33,7 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
+      debug=True
       enabled_backends = default_backend:rbd
 
       [glance_store]
@@ -43,6 +44,8 @@ data:
       store_description = "RBD backend"
       rbd_store_pool = images
       rbd_store_user = openstack
+      [database]
+      mysql_wsrep_sync_wait = 1
     glanceAPIs:
       default:
         replicas: 3

--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -54,6 +54,7 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
+      debug=True
       enabled_backends = primary:cinder,secondary:swift
       [glance_store]
       default_backend = primary
@@ -76,6 +77,8 @@ data:
       swift_store_key = {{ .ServicePassword }}
       [oslo_concurrency]
       lock_path = /var/lib/glance/tmp
+      [database]
+      mysql_wsrep_sync_wait = 1
     databaseInstance: openstack
     glanceAPIs:
       default:

--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -41,6 +41,7 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
+      debug=True
       enabled_backends = default_backend:swift
 
       [glance_store]
@@ -53,6 +54,8 @@ data:
       swift_store_endpoint_type = internalURL
       swift_store_user = service:glance
       swift_store_key = {{ .ServicePassword }}
+      [database]
+      mysql_wsrep_sync_wait = 1
     default:
       replicas: 1
 


### PR DESCRIPTION
Until we get the patch [1] in a new version of the glance-operator, this patch allows to get the right default for the DTs. This patch can be partially reverted once the operator gets the new code.

[1] https://github.com/openstack-k8s-operators/glance-operator/pull/548