### PR TITLE
Add workarond for nova to support  galera multimaster

### DIFF
--- a/dt/bgp/kustomization.yaml
+++ b/dt/bgp/kustomization.yaml
@@ -280,3 +280,51 @@ replacements:
           name: octavia
         fieldPaths:
           - spec.config
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.apiServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.apiServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.schedulerServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.schedulerServiceTemplate.customServiceConfig
+        options:
+          create: true

--- a/dt/uni01alpha/kustomization.yaml
+++ b/dt/uni01alpha/kustomization.yaml
@@ -367,3 +367,51 @@ replacements:
           name: octavia
         fieldPaths:
           - spec.config
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.apiServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.apiServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.schedulerServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.schedulerServiceTemplate.customServiceConfig
+        options:
+          create: true

--- a/dt/uni02beta/kustomization.yaml
+++ b/dt/uni02beta/kustomization.yaml
@@ -238,3 +238,48 @@ replacements:
           - spec.manila.template.manilaShares.share1.replicas
         options:
           create: true
+  # Nova
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.apiServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.apiServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.schedulerServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.schedulerServiceTemplate.customServiceConfig
+        options:
+          create: true

--- a/dt/uni04delta/kustomization.yaml
+++ b/dt/uni04delta/kustomization.yaml
@@ -79,3 +79,51 @@ replacements:
           - spec.neutron.template.customServiceConfig
         options:
           create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.apiServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.apiServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.schedulerServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.schedulerServiceTemplate.customServiceConfig
+        options:
+          create: true

--- a/dt/uni05epsilon/kustomization.yaml
+++ b/dt/uni05epsilon/kustomization.yaml
@@ -386,3 +386,50 @@ replacements:
           - spec.swift.enabled
         options:
           create: true
+  #
+  # Nova
+  #
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.apiServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.apiServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.schedulerServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.schedulerServiceTemplate.customServiceConfig
+        options:
+          create: true

--- a/dt/uni06zeta/kustomization.yaml
+++ b/dt/uni06zeta/kustomization.yaml
@@ -154,3 +154,51 @@ replacements:
           - spec.neutron.template.customServiceConfig
         options:
           create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.apiServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.apiServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.schedulerServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.schedulerServiceTemplate.customServiceConfig
+        options:
+          create: true

--- a/examples/dt/bgp/bgp_dt01/control-plane/service-values.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/service-values.yaml
@@ -49,3 +49,32 @@ data:
         octavia: octbr
       external-ids:
         enable-chassis-as-gateway: false
+
+  nova:
+    apiServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1
+    cellTemplates:
+      cell0:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+      cell1:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+    schedulerServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1

--- a/examples/dt/bgp/control-plane/service-values.yaml
+++ b/examples/dt/bgp/control-plane/service-values.yaml
@@ -28,6 +28,35 @@ data:
   swift:
     enabled: true
 
+  nova:
+    apiServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1
+    cellTemplates:
+      cell0:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+      cell1:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+    schedulerServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1
+
   octavia:
     enabled: true
     amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image

--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -58,6 +58,35 @@ data:
   swift:
     enabled: true
 
+  nova:
+    apiServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1
+    cellTemplates:
+      cell0:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+      cell1:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+    schedulerServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1
+
   octavia:
     enabled: false
     amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image

--- a/examples/dt/uni02beta/control-plane/service-values.yaml
+++ b/examples/dt/uni02beta/control-plane/service-values.yaml
@@ -100,3 +100,32 @@ data:
                 nfs:
                   path: _replaced_
                   server: _replaced_
+
+  nova:
+    apiServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1
+    cellTemplates:
+      cell0:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+      cell1:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+    schedulerServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -132,3 +132,32 @@ data:
             - name: ceph
               mountPath: /etc/ceph
               readOnly: true
+
+  nova:
+    apiServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1
+    cellTemplates:
+      cell0:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+      cell1:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+    schedulerServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1

--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -122,3 +122,32 @@ data:
 
   swift:
     enabled: true
+
+  nova:
+    apiServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1
+    cellTemplates:
+      cell0:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+      cell1:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+    schedulerServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1

--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -121,3 +121,32 @@ data:
       max_header_size = 38
       [ml2_type_vlan]
       network_vlan_ranges = tenant:1000:2000,datacentre:218:218
+
+  nova:
+    apiServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1
+    cellTemplates:
+      cell0:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+      cell1:
+        conductorServiceTemplate:
+          customServiceConfig: |
+            [database]
+            mysql_wsrep_sync_wait = 1
+            [api_database]
+            mysql_wsrep_sync_wait = 1
+    schedulerServiceTemplate:
+      customServiceConfig: |
+        [database]
+        mysql_wsrep_sync_wait = 1
+        [api_database]
+        mysql_wsrep_sync_wait = 1


### PR DESCRIPTION
This WA merged in nova-operator https://github.com/openstack-k8s-operators/nova-operator/pull/776
but decided not to be backported to beta. Still beta needs the WA to
work so we are adding the WA here. These configs are used by the
downstream integration job. Note that even the downstream beta
integration job uses the architecture from the main branch.
