### PR TITLE
Do not use galera multi-master capability

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -51,11 +51,13 @@ spec:
     enabled: true
     templates:
       openstack:
-        replicas: 3
+        # TODO(dciabrin) revert back to 3 once OSPRH-7405 is fixed
+        replicas: 1
         secret: osp-secret
         storageRequest: 500M
       openstack-cell1:
-        replicas: 3
+        # TODO(dciabrin) revert back to 3 once OSPRH-7405 is fixed
+        replicas: 1
         secret: osp-secret
         storageRequest: 500M
   glance:


### PR DESCRIPTION
Configuring a 3-node galera cluster for high availability currently causes the database service CR to balance traffic to all galera pods, in effect making galera behave as multi-master.

This is causing side effects on Openstack clients, which is not desirable at this point in time.

An alternative deployment strategy for galera is (3 pods, A/P service) is currently being considered [1]. Until this becomes ready for review, let's temporarily revert the galera replicas to 1, to go back to A/P service behaviour and to prevent impact on Openstack clients.

[1] https://issues.redhat.com/browse/OSPRH-7405