### PR TITLE
Disable multipath in Nova for uni05epsilon

### DIFF
--- a/dt/uni05epsilon/edpm/nodeset/kustomization.yaml
+++ b/dt/uni05epsilon/edpm/nodeset/kustomization.yaml
@@ -18,3 +18,7 @@ transformers:
 
 components:
   - ../../../../lib/dataplane/nodeset
+
+
+resources:
+  - nova_custom.yaml

--- a/dt/uni05epsilon/edpm/nodeset/nova_custom.yaml
+++ b/dt/uni05epsilon/edpm/nodeset/nova_custom.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nova-custom-config
+data:
+  25-nova-custom.conf: |
+    # NOTE(gibi): We need to disable multipath as IPv6 is not fully
+    # working in this job with NetApp.
+    # Enable multipath when OSPRH-7393 is resolved.
+    [libvirt]
+    volume_use_multipath = False
+
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: nova-custom
+spec:
+  label: dataplane-deployment-nova-custom
+  configMaps:
+    - nova-custom-config
+  secrets:
+    - nova-cell1-compute-config
+    - nova-migration-ssh-key
+  playbook: osp.edpm.nova
+  caCerts: combined-ca-bundle
+  edpmServiceType: nova
+  containerImageFields:
+    - NovaComputeImage
+    - EdpmIscsidImage

--- a/examples/dt/uni05epsilon/values.yaml
+++ b/examples/dt/uni05epsilon/values.yaml
@@ -148,4 +148,4 @@ data:
       - ovn
       - neutron-metadata
       - libvirt
-      - nova
+      - nova-custom


### PR DESCRIPTION
IPv6 and NetApp in the epsilon job does not work well with multipath
enabled. It leads to repeated errors in the nova-compute log during
volume mount that leads to slow VM boot that leads to tempest timeouts.

This PR disables multipath in nova in the job until the linked Jira is
resolved.

Related: https://issues.redhat.com/browse/OSPRH-7393
