### PR TITLE
Set neutron MTU according to actual value

### DIFF
--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -116,6 +116,7 @@ data:
       type_drivers = geneve,vlan
       tenant_network_types = geneve,vlan
       extension_drivers = qos,port_security,dns_domain_ports
+      path_mtu = 1400
       [ml2_type_geneve]
       vni_ranges = 1:65536
       max_header_size = 38


### PR DESCRIPTION
When deployed on OCP with default MTU settings actual MTU is limited to 1400 while neutron default is 1500. Wrong MTU setting causes failures during some tests execution.