### PR TITLE
explictly define nova cell templated instead of relying on defaulting

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -153,6 +153,21 @@ spec:
         replicas: 3
       schedulerServiceTemplate:
         replicas: 3
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          cellDatabaseInstance: openstack
+          cellMessageBusInstance: rabbitmq
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseAccount: nova-cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
   octavia:
     enabled: false
     template:


### PR DESCRIPTION
This change simply adds the cell0 and cell1 templates
to the openstackcontrolplane.yaml in the shared lib dir.

This change decouples the Architecture repo from the current defaulting
behaivor in the nova-operator.
