### PR TITLE
Change Galera PVC request from 500M to 5G

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -54,12 +54,12 @@ spec:
         # TODO(dciabrin) revert back to 3 once OSPRH-7405 is fixed
         replicas: 1
         secret: osp-secret
-        storageRequest: 500M
+        storageRequest: 5G
       openstack-cell1:
         # TODO(dciabrin) revert back to 3 once OSPRH-7405 is fixed
         replicas: 1
         secret: osp-secret
-        storageRequest: 500M
+        storageRequest: 5G
   glance:
     apiOverrides:
       default:


### PR DESCRIPTION
We recommend 5G, not 500M, for Galera.

The database runs out of space when testing with LVMS without this patch. We didn't see this when testing with ci-local-storage since the 500M request was received a 10G PV.

Closes https://issues.redhat.com/browse/OSPRH-7536