### PR TITLE
Remove mariadb from OpenStackControlPlane

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -129,13 +129,6 @@ spec:
           networkAttachments:
             - storage
           replicas: 1
-  mariadb:
-    enabled: false
-    templates:
-      openstack:
-        storageRequest: 500M
-      openstack-cell1:
-        storageRequest: 500M
   memcached:
     templates:
       memcached:


### PR DESCRIPTION
We are using galera not mariadb so remove mariadb. mariadb is disabled already but there is no need to leave it in our CR.