### PR TITLE
Set HAProxy timeout to 60 seconds for storage

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -24,7 +24,7 @@ spec:
       serviceUser: ceilometer
   cinder:
     apiOverride:
-      route: {}
+      route: {"haproxy.router.openshift.io/timeout": "60s"}
     template:
       customServiceConfig: |
         # Debug logs by default, jobs can override as needed.
@@ -63,7 +63,7 @@ spec:
   glance:
     apiOverrides:
       default:
-        route: {}
+        route: {"haproxy.router.openshift.io/timeout": "60s"}
     template:
       databaseInstance: openstack
       glanceAPIs:
@@ -115,7 +115,7 @@ spec:
       secret: osp-secret
   manila:
     apiOverride:
-      route: {}
+      route: {"haproxy.router.openshift.io/timeout": "60s"}
     enabled: false
     template:
       manilaAPI:


### PR DESCRIPTION
This patch sets the HAProxy timeout to 60 seconds for storage services (Cinder, Glance, and Manila).

This way it's in sync with the Apache default timeouts and matches what we have in OSP17.

This will be fixed in the operators themselves to have these same defaults, and this patch is compatible with that change.

When the operators code is merged and is run by the CI jobs the defaults in the operators will be ignored in favor of the defaults defined in this patch, so we'll want to revert this patch then.

These are the PRs that once their code is run on the CI we can revert this PR:
- https://github.com/openstack-k8s-operators/cinder-operator/pull/396
- https://github.com/openstack-k8s-operators/glance-operator/pull/550
- https://github.com/openstack-k8s-operators/manila-operator/pull/282
- https://github.com/openstack-k8s-operators/openstack-operator/pull/830

Jira: https://issues.redhat.com/browse/OSPRH-7393
Jira: https://issues.redhat.com/browse/OSPRH-7415