### PR TITLE
Use DataPlaneService.DataSources

### DIFF
--- a/va/nfv/ovs-dpdk/edpm/nodeset/nova_ovs_dpdk.yaml
+++ b/va/nfv/ovs-dpdk/edpm/nodeset/nova_ovs_dpdk.yaml
@@ -13,11 +13,13 @@ metadata:
 spec:
   label: nova-custom-ovsdpdk
   edpmServiceType: nova
-  configMaps:
-    - ovs-dpdk-cpu-pinning-nova
-  secrets:
-    - nova-cell1-compute-config
-    - nova-migration-ssh-key
+  dataSources:
+    - configMapRef:
+        name: ovs-dpdk-cpu-pinning-nova
+    - secretRef:
+        name: nova-cell1-compute-config
+    - secretRef:
+        name: nova-migration-ssh-key
   playbook: osp.edpm.nova
   tlsCerts:
     default:


### PR DESCRIPTION
Instead of using DataPlaneService.ConfigMaps or
DataPlaneService.Secrets, use the newly added
DataPlaneService.DataSources. See
https://github.com/openstack-k8s-operators/dataplane-operator/pull/909

Signed-off-by: James Slagle <jslagle@redhat.com>
