### PR TITLE
Move manila config in uni04delta DT

### DIFF
--- a/dt/uni04delta/edpm/nodeset/kustomization.yaml
+++ b/dt/uni04delta/edpm/nodeset/kustomization.yaml
@@ -94,12 +94,12 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
-      fieldPath: data.manila.manilaShares.share1.customServiceConfig
+      fieldPath: data.manila.customServiceConfig
     targets:
       - select:
           kind: OpenStackControlPlane
         fieldPaths:
-          - spec.manila.template.manilaShares.share1.customServiceConfig
+          - spec.manila.template.customServiceConfig
         options:
           create: true
 

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -52,26 +52,20 @@ data:
 
   manila:
     enabled: true
-    manilaShares:
-      share1:
-        customServiceConfig: |
-          [DEFAULT]
-          enabled_share_backends = cephfs
-          enabled_share_protocols = cephfs
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_share_backends = cephfs
+      enabled_share_protocols = cephfs
 
-          [cephfs]
-          driver_handles_share_servers = False
-          share_backend_name = cephfs
-          share_driver = manila.share.drivers.cephfs.driver.CephFSDriver
-          cephfs_conf_path = /etc/ceph/ceph.conf
-          cephfs_cluster_name = ceph
-          cephfs_auth_id = openstack
-          cephfs_volume_mode = 0755
-          cephfs_protocol_helper_type = CEPHFS
-    manilaAPI:
-      customServiceConfig: |
-        [DEFAULT]
-        enabled_share_protocols=nfs,cephfs
+      [cephfs]
+      driver_handles_share_servers = False
+      share_backend_name = cephfs
+      share_driver = manila.share.drivers.cephfs.driver.CephFSDriver
+      cephfs_conf_path = /etc/ceph/ceph.conf
+      cephfs_cluster_name = ceph
+      cephfs_auth_id = openstack
+      cephfs_volume_mode = 0755
+      cephfs_protocol_helper_type = CEPHFS
 
   neutron:
     customServiceConfig: |


### PR DESCRIPTION
This patch adds the missing ConfigMap(s) in the uni04delta DT to allow to properly build manila and glance w/ the appropriate configuration.