### PR TITLE
Change tlsCert to tlsCerts

### DIFF
--- a/dt/bgp/edpm/nodeset/nova_custom.yaml
+++ b/dt/bgp/edpm/nodeset/nova_custom.yaml
@@ -8,11 +8,12 @@ spec:
     - nova-cell1-compute-config
     - nova-migration-ssh-key
   playbook: osp.edpm.nova
-  tlsCert:
-    contents:
-      - dnsnames
-      - ips
-    networks:
-      - ctlplane
-    issuer: osp-rootca-issuer-internal
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      networks:
+        - ctlplane
+      issuer: osp-rootca-issuer-internal
   caCerts: combined-ca-bundle

--- a/va/hci/edpm-post-ceph/nodeset/nova_ceph.yaml
+++ b/va/hci/edpm-post-ceph/nodeset/nova_ceph.yaml
@@ -18,13 +18,14 @@ spec:
     - nova-cell1-compute-config
     - nova-migration-ssh-key
   playbook: osp.edpm.nova
-  tlsCert:
-    contents:
-      - dnsnames
-      - ips
-    networks:
-      - ctlplane
-    issuer: osp-rootca-issuer-internal
-    edpmRoleServiceName: nova
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      networks:
+        - ctlplane
+      issuer: osp-rootca-issuer-internal
+      edpmRoleServiceName: nova
   caCerts: combined-ca-bundle
   edpmServiceType: nova

--- a/va/nfv/ovs-dpdk-sriov/edpm/nodeset/neutron_igmp.yaml
+++ b/va/nfv/ovs-dpdk-sriov/edpm/nodeset/neutron_igmp.yaml
@@ -19,14 +19,15 @@ spec:
   playbook: osp.edpm.neutron_ovn
   secrets:
     - neutron-ovn-agent-neutron-config
-  tlsCert:
-    contents:
-      - dnsnames
-      - ips
-    issuer: osp-rootca-issuer-ovn
-    keyUsages:
-      - digital signature
-      - key encipherment
-      - client auth
-    networks:
-      - ctlplane
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      issuer: osp-rootca-issuer-ovn
+      keyUsages:
+        - digital signature
+        - key encipherment
+        - client auth
+      networks:
+        - ctlplane

--- a/va/nfv/ovs-dpdk-sriov/edpm/nodeset/nova_ovs_dpdk_sriov.yaml
+++ b/va/nfv/ovs-dpdk-sriov/edpm/nodeset/nova_ovs_dpdk_sriov.yaml
@@ -27,11 +27,12 @@ spec:
     - nova-cell1-compute-config
     - nova-migration-ssh-key
   playbook: osp.edpm.nova
-  tlsCert:
-    contents:
-      - dnsnames
-      - ips
-    networks:
-      - ctlplane
-    issuer: osp-rootca-issuer-internal
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      networks:
+        - ctlplane
+      issuer: osp-rootca-issuer-internal
   caCerts: combined-ca-bundle

--- a/va/nfv/ovs-dpdk/edpm/nodeset/nova_ovs_dpdk.yaml
+++ b/va/nfv/ovs-dpdk/edpm/nodeset/nova_ovs_dpdk.yaml
@@ -19,11 +19,12 @@ spec:
     - nova-cell1-compute-config
     - nova-migration-ssh-key
   playbook: osp.edpm.nova
-  tlsCert:
-    contents:
-      - dnsnames
-      - ips
-    networks:
-      - ctlplane
-    issuer: osp-rootca-issuer-internal
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      networks:
+        - ctlplane
+      issuer: osp-rootca-issuer-internal
   caCerts: combined-ca-bundle

--- a/va/nfv/sriov/edpm/nodeset/nova_sriov.yaml
+++ b/va/nfv/sriov/edpm/nodeset/nova_sriov.yaml
@@ -27,11 +27,12 @@ spec:
     - nova-cell1-compute-config
     - nova-migration-ssh-key
   playbook: osp.edpm.nova
-  tlsCert:
-    contents:
-      - dnsnames
-      - ips
-    networks:
-      - ctlplane
-    issuer: osp-rootca-issuer-internal
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      networks:
+        - ctlplane
+      issuer: osp-rootca-issuer-internal
   caCerts: combined-ca-bundle


### PR DESCRIPTION
A change was recently made to allow specification of multiple certs in a dataplane service.  We need to update our definitions to get the new definition whenever the new changes land.

See: https://github.com/openstack-k8s-operators/dataplane-operator/pull/875
and https://github.com/openstack-k8s-operators/openstack-operator/pull/834 