### PR TITLE
Enable ceph-nfs for uni04delta

### DIFF
--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -54,18 +54,17 @@ data:
     enabled: true
     customServiceConfig: |
       [DEFAULT]
-      enabled_share_backends = cephfs
-      enabled_share_protocols = cephfs
+      enabled_share_backends = cephfsnfs
+      enabled_share_protocols = nfs
 
-      [cephfs]
-      driver_handles_share_servers = False
-      share_backend_name = cephfs
-      share_driver = manila.share.drivers.cephfs.driver.CephFSDriver
-      cephfs_conf_path = /etc/ceph/ceph.conf
-      cephfs_cluster_name = ceph
-      cephfs_auth_id = openstack
-      cephfs_volume_mode = 0755
-      cephfs_protocol_helper_type = CEPHFS
+      [cephfsnfs]
+      driver_handles_share_servers=False
+      share_backend_name=cephfs
+      share_driver=manila.share.drivers.cephfs.driver.CephFSDriver
+      cephfs_auth_id=openstack
+      cephfs_cluster_name=ceph
+      cephfs_nfs_cluster_id=cephfs
+      cephfs_protocol_helper_type=NFS
 
   neutron:
     customServiceConfig: |


### PR DESCRIPTION
uni04delta DT has `native_cephfs` backend while it should be configured w/ `ceph_nfs`.