### PR TITLE
[BGP_DT01] Enable IGMP Snooping

### DIFF
--- a/examples/dt/bgp/bgp_dt01/control-plane/service-values.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/service-values.yaml
@@ -54,3 +54,5 @@ data:
       [DEFAULT]
       vlan_transparent = true
       debug = true
+      [ovs]
+      igmp_snooping_enable = true


### PR DESCRIPTION
This neutron feature needs to be enabled in order to test some multicast scenarios on BGP DT01.