### PR TITLE
Update timeouts for uni-jobs

### DIFF
--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -8,7 +8,7 @@ vas:
             oc -n openstack wait nncp
             -l osp/nncm-config-type=standard
             --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
-            --timeout=60s
+            --timeout=5m
         values:
           - name: network-values
             src_file: values.yaml
@@ -18,7 +18,7 @@ vas:
         wait_conditions:
           - >-
             oc -n openstack wait osctlplane controlplane --for condition=Ready
-            --timeout=30m
+            --timeout=60m
         values:
           - name: network-values
             src_file: nncp/values.yaml
@@ -29,7 +29,7 @@ vas:
           - >-
             oc -n openstack wait
             osdpns openstack-edpm --for condition=SetupReady
-            --timeout=600s
+            --timeout=10m
         values:
           - name: edpm-nodeset-values
             src_file: values.yaml
@@ -40,7 +40,7 @@ vas:
           - >-
             oc -n openstack wait
             osdpns openstack-edpm --for condition=Ready
-            --timeout=1500s
+            --timeout=30m
         values:
           - name: edpm-deployment-values
             src_file: values.yaml

--- a/automation/vars/uni01alpha.yaml
+++ b/automation/vars/uni01alpha.yaml
@@ -8,7 +8,7 @@ vas:
             oc -n openstack wait nncp
             -l osp/nncm-config-type=standard
             --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
-            --timeout=3m
+            --timeout=5m
         values:
           - name: network-values
             src_file: values.yaml
@@ -30,7 +30,7 @@ vas:
             oc -n openstack wait openstackcontrolplane
             controlplane
             --for condition=Ready
-            --timeout=45m
+            --timeout=60m
         values:
           - name: network-values
             src_file: nncp/values.yaml
@@ -44,7 +44,7 @@ vas:
             oc -n openstack wait openstackdataplanenodeset
             networker-nodes
             --for condition=SetupReady
-            --timeout=15m
+            --timeout=10m
         values:
           - name: edpm-nodeset-values
             src_file: values.yaml
@@ -56,7 +56,7 @@ vas:
             oc -n openstack wait openstackdataplanedeployment
             networker-deploy
             --for condition=Ready
-            --timeout=30m
+            --timeout=40m
         values:
           - name: edpm-deployment-values
             src_file: values.yaml
@@ -68,7 +68,7 @@ vas:
             oc -n openstack wait openstackdataplanenodeset
             openstack-edpm
             --for condition=SetupReady
-            --timeout=15m
+            --timeout=10m
         values:
           - name: edpm-nodeset-values
             src_file: values.yaml
@@ -80,7 +80,7 @@ vas:
             oc -n openstack wait openstackdataplanedeployment
             edpm-deployment
             --for condition=Ready
-            --timeout=30m
+            --timeout=40m
         values:
           - name: edpm-deployment-values
             src_file: values.yaml

--- a/automation/vars/uni02beta.yaml
+++ b/automation/vars/uni02beta.yaml
@@ -8,7 +8,7 @@ vas:
             oc -n openstack wait nncp
             -l osp/nncm-config-type=standard
             --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
-            --timeout=3m
+            --timeout=5m
         values:
           - name: network-values
             src_file: values.yaml
@@ -20,7 +20,7 @@ vas:
             oc -n openstack wait openstackcontrolplane
             controlplane
             --for condition=Ready
-            --timeout=30m
+            --timeout=60m
         values:
           - name: network-values
             src_file: nncp/values.yaml
@@ -34,7 +34,7 @@ vas:
             oc -n openstack wait openstackdataplanedeployment
             edpm-deployment
             --for condition=Ready
-            --timeout=1200s
+            --timeout=40m
         values:
           - name: edpm-nodeset-values
             src_file: values.yaml

--- a/automation/vars/uni04delta.yaml
+++ b/automation/vars/uni04delta.yaml
@@ -8,7 +8,7 @@ vas:
             oc -n openstack wait nncp
             -l osp/nncm-config-type=standard
             --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
-            --timeout=180s
+            --timeout=5m
         values:
           - name: network-values
             src_file: values.yaml
@@ -19,7 +19,7 @@ vas:
           - >-
             oc -n openstack wait osctlplane controlplane
             --for condition=Ready
-            --timeout=600s
+            --timeout=60m
         values:
           - name: network-values
             src_file: nncp/values.yaml
@@ -32,7 +32,7 @@ vas:
           - >-
             oc -n openstack wait
             osdpns ceph-nodes --for condition=SetupReady
-            --timeout=600s
+            --timeout=10m
         values:
           - name: edpm-nodeset-values
             src_file: values.yaml
@@ -43,7 +43,7 @@ vas:
           - >-
             oc -n openstack wait
             osdpd edpm-deployment-pre-ceph --for condition=Ready
-            --timeout=1500s
+            --timeout=30m
         values:
           - name: edpm-deployment-values
             src_file: values.yaml
@@ -60,7 +60,7 @@ vas:
             oc -n openstack wait osdpns
             openstack-edpm
             --for condition=SetupReady
-            --timeout=600s
+            --timeout=10m
         values:
           - name: service-values
             src_file: control-plane/service-values.yaml
@@ -74,7 +74,7 @@ vas:
             oc -n openstack wait osdpd
             edpm-deployment
             --for condition=Ready
-            --timeout=2400s
+            --timeout=40m
         values:
           - name: edpm-deployment-values-post-ceph
             src_file: values.yaml

--- a/automation/vars/uni05epsilon.yaml
+++ b/automation/vars/uni05epsilon.yaml
@@ -8,7 +8,7 @@ vas:
             oc -n openstack wait nncp
             -l osp/nncm-config-type=standard
             --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
-            --timeout=3m
+            --timeout=5m
         values:
           - name: network-values
             src_file: values.yaml
@@ -20,7 +20,7 @@ vas:
             oc -n openstack wait openstackcontrolplane
             controlplane
             --for condition=Ready
-            --timeout=30m
+            --timeout=60m
         values:
           - name: network-values
             src_file: nncp/values.yaml
@@ -34,7 +34,7 @@ vas:
             oc -n openstack wait osdpns
             openstack-edpm
             --for condition=SetupReady
-            --timeout=600s
+            --timeout=10m
         values:
           - name: service-values
             src_file: control-plane/service-values.yaml
@@ -48,7 +48,7 @@ vas:
             oc -n openstack wait osdpd
             edpm-deployment
             --for condition=Ready
-            --timeout=2400s
+            --timeout=40m
         values:
           - name: edpm-deployment-values
             src_file: values.yaml

--- a/automation/vars/uni06zeta.yaml
+++ b/automation/vars/uni06zeta.yaml
@@ -8,7 +8,7 @@ vas:
             oc -n openstack wait nncp
             -l osp/nncm-config-type=standard
             --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
-            --timeout=3m
+            --timeout=5m
 
         values:
           - name: network-values
@@ -21,7 +21,7 @@ vas:
             oc -n openstack wait openstackcontrolplane
             controlplane
             --for condition=Ready
-            --timeout=30m
+            --timeout=60m
 
         values:
           - name: network-values
@@ -36,7 +36,7 @@ vas:
             oc -n openstack wait openstackdataplanedeployment
             edpm-deployment
             --for condition=Ready
-            --timeout=2400s
+            --timeout=40m
         values:
           - name: edpm-nodeset-values
             src_file: values.yaml

--- a/automation/vars/uni07eta.yaml
+++ b/automation/vars/uni07eta.yaml
@@ -8,7 +8,7 @@ vas:
             oc -n openstack wait nncp
             -l osp/nncm-config-type=standard
             --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
-            --timeout=120s
+            --timeout=5m
         values:
           - name: network-values
             src_file: values.yaml
@@ -20,7 +20,7 @@ vas:
             oc -n openstack wait openstackcontrolplane
             controlplane
             --for condition=Ready
-            --timeout=45m
+            --timeout=60m
         values:
           - name: network-values
             src_file: nncp/values.yaml
@@ -34,7 +34,7 @@ vas:
             oc -n openstack wait openstackdataplanenodeset
             networker-nodes
             --for condition=SetupReady
-            --timeout=20m
+            --timeout=10m
         values:
           - name: edpm-nodeset-values
             src_file: values.yaml
@@ -58,11 +58,12 @@ vas:
             oc -n openstack wait openstackdataplanenodeset
             openstack-edpm
             --for condition=SetupReady
-            --timeout=20m
+            --timeout=10m
         values:
           - name: edpm-nodeset-values
             src_file: values.yaml
         build_output: edpm-nodeset.yaml
+
       - path: examples/dt/uni07eta
         wait_conditions:
           - >-


### PR DESCRIPTION
There are timeouts without any additional errors I observe on some CI nodes, probably with recent updates the deployment of dataplane takes slightly longer with LVM operator and newer OpenShift versions. This commit increases the timeouts and unifies them for all uni-jobs.