### PR TITLE
Drop Redis

### DIFF
--- a/dt/uni01alpha/kustomization.yaml
+++ b/dt/uni01alpha/kustomization.yaml
@@ -252,18 +252,6 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
-      fieldPath: data.redis.enabled
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.redis.enabled
-        options:
-          create: true
-
-  - source:
-      kind: ConfigMap
-      name: service-values
       fieldPath: data.heat.enabled
     targets:
       - select:

--- a/dt/uni05epsilon/kustomization.yaml
+++ b/dt/uni05epsilon/kustomization.yaml
@@ -358,21 +358,6 @@ replacements:
           - spec.config
 
   #
-  # Redis
-  #
-  - source:
-      kind: ConfigMap
-      name: service-values
-      fieldPath: data.redis.enabled
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.redis.enabled
-        options:
-          create: true
-
-  #
   # Swift
   #
   - source:

--- a/examples/dt/uni01alpha/README.md
+++ b/examples/dt/uni01alpha/README.md
@@ -67,7 +67,7 @@ work properly and can be deployed with any/default configuration.
 | Ceilometer       | needed by Telemetry        |
 | Heat             | needed by Telemetry        |
 | Prometheus       | needed by Telemetry        |
-| Redis            | needed by Octavia          |
+
 
 ### Additional configuration
 

--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -80,9 +80,6 @@ data:
   heat:
     enabled: true
 
-  redis:
-    enabled: true
-
   telemetry:
     enabled: true
     metricStorage:

--- a/examples/dt/uni05epsilon/README.md
+++ b/examples/dt/uni05epsilon/README.md
@@ -66,7 +66,6 @@ to work properly and can be deployed with any/default configuration.
 | ---------------- |--------------------------- |
 | Nova             | needed by scenario testing |
 | Keystone         | needed by all services     |
-| Redis            | needed by Octavia          |
 
 
 ### Additional configuration

--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -117,8 +117,5 @@ data:
       nicMappings:
         - octavia: octbr
 
-  redis:
-    enabled: true
-
   swift:
     enabled: true

--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -183,8 +183,6 @@ spec:
         replicas: 3
       rabbitmq-cell1:
         replicas: 3
-  redis:
-    enabled: false
   secret: osp-secret
   storageClass: _replaced_
   swift:


### PR DESCRIPTION
As per [1] it is apparently no longer a thing,
hence removing all references from this repository.

[1] https://github.com/openstack-k8s-operators/openstack-operator/pull/748