### PR TITLE
Enable Manila in uni02beta

### DIFF
--- a/dt/uni02beta/kustomization.yaml
+++ b/dt/uni02beta/kustomization.yaml
@@ -141,6 +141,17 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.manila.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.manila.netapp-secrets\.conf
     targets:
       - select:


### PR DESCRIPTION
Manila is disabled in uni02beta because of the missing enabled parameter replacement. This patch is supposed to enable it.