### PR TITLE
Glance over cinder (iSCSI) backend

### DIFF
--- a/dt/uni07eta/kustomization.yaml
+++ b/dt/uni07eta/kustomization.yaml
@@ -113,7 +113,31 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
-      fieldPath: data.glance.default.replicas
+      fieldPath: data.glance.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.databaseInstance
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.databaseInstance
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.glanceAPIs.default.replicas
     targets:
       - select:
           kind: OpenStackControlPlane
@@ -125,12 +149,24 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
-      fieldPath: data.glance.customServiceConfig
+      fieldPath: data.glance.glanceAPIs.default.type
     targets:
       - select:
           kind: OpenStackControlPlane
         fieldPaths:
-          - spec.glance.template.customServiceConfig
+          - spec.glance.template.glanceAPIs.default.type
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.glanceAPIs.default.preserveJobs
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.preserveJobs
         options:
           create: true
 

--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -39,21 +39,29 @@ data:
     customServiceConfig: |
       [DEFAULT]
       debug=True
-      enabled_backends = default_backend:swift
-
+      enabled_backends = default_backend:cinder
       [glance_store]
       default_backend = default_backend
-
       [default_backend]
-      swift_store_create_container_on_put = True
-      swift_store_auth_version = 3
-      swift_store_auth_address = {{ .KeystoneInternalURL }}
-      swift_store_endpoint_type = internalURL
-      swift_store_user = service:glance
-      swift_store_key = {{ .ServicePassword }}
-
-    default:
-      replicas: 1
+      rootwrap_config = /etc/glance/rootwrap.conf
+      description = Default cinder backend
+      cinder_store_auth_address = {{ .KeystoneInternalURL }}
+      cinder_store_user_name = {{ .ServiceUser }}
+      cinder_store_password = {{ .ServicePassword }}
+      cinder_store_project_name = service
+      cinder_catalog_info = volumev3::internalURL
+      # TODO: Enable multipath when OSPRH-7393 is resolved
+      # cinder_use_multipath = true
+      [oslo_concurrency]
+      lock_path = /var/lib/glance/tmp
+    databaseInstance: openstack
+    glanceAPIs:
+      default:
+        preserveJobs: false
+        replicas: 1
+        type: split
+    storageClass: ""
+    storageRequest: 1G
 
   swift:
     enabled: true


### PR DESCRIPTION
According to
  https://github.com/openstack-k8s-operators/glance-operator/blob/e296d336e2d0ff0c7f0a5a41a1ba839532864e5e/config/samples/backends/cinder/glance-common/glance.yaml

[OSPRH-7710](https://issues.redhat.com//browse/OSPRH-7710)