### PR TITLE
Revert "Cinder wait for DB writes on reads"

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -30,10 +30,6 @@ spec:
         # Debug logs by default, jobs can override as needed.
         [DEFAULT]
         debug = true
-        # Necessary to prevent DB race conditions.
-        # Remove once jobs run b0747944394807862e4cdcfa7052f1f8d1febf94.
-        [database]
-        mysql_wsrep_sync_wait = 1
       cinderBackup:
         networkAttachments:
           - storage


### PR DESCRIPTION
The openstack-k8s-operators/mariadb-operator#229 switched the mariadb-operator to deploy in Active/Passive mode per default, instead of multimaster.

So we should no longer set `mysql_wsrep_sync_wait`.

Related PR: https://github.com/openstack-k8s-operators/cinder-operator/pull/401

This reverts commit cf4f3f6efe8d6f26277df9ffca82cd13869a6aa0.