### PR TITLE
alpha + zeta: Fix for node IPs starting from 10

### DIFF
--- a/examples/dt/uni01alpha/control-plane/nncp/values.yaml
+++ b/examples/dt/uni01alpha/control-plane/nncp/values.yaml
@@ -11,22 +11,22 @@ data:
 
   node_0:
     name: master-0
-    internalapi_ip: 172.17.0.5
-    tenant_ip: 172.19.0.5
+    internalapi_ip: 172.17.0.10
+    tenant_ip: 172.19.0.10
     ctlplane_ip: 192.168.122.10
-    storage_ip: 172.18.0.5
+    storage_ip: 172.18.0.10
   node_1:
     name: master-1
-    internalapi_ip: 172.17.0.6
-    tenant_ip: 172.19.0.6
+    internalapi_ip: 172.17.0.11
+    tenant_ip: 172.19.0.11
     ctlplane_ip: 192.168.122.11
-    storage_ip: 172.18.0.6
+    storage_ip: 172.18.0.11
   node_2:
     name: master-2
-    internalapi_ip: 172.17.0.7
-    tenant_ip: 172.19.0.7
+    internalapi_ip: 172.17.0.12
+    tenant_ip: 172.19.0.12
     ctlplane_ip: 192.168.122.12
-    storage_ip: 172.18.0.7
+    storage_ip: 172.18.0.12
 
   ctlplane:
     dnsDomain: ctlplane.openstack.lab

--- a/examples/dt/uni06zeta/control-plane/nncp/values.yaml
+++ b/examples/dt/uni06zeta/control-plane/nncp/values.yaml
@@ -11,22 +11,22 @@ data:
 
   node_0:
     name: master-0
-    internalapi_ip: 172.17.0.5
-    tenant_ip: 172.19.0.5
+    internalapi_ip: 172.17.0.10
+    tenant_ip: 172.19.0.10
     ctlplane_ip: 192.168.122.10
-    storage_ip: 172.18.0.5
+    storage_ip: 172.18.0.10
   node_1:
     name: master-1
-    internalapi_ip: 172.17.0.6
-    tenant_ip: 172.19.0.6
+    internalapi_ip: 172.17.0.11
+    tenant_ip: 172.19.0.11
     ctlplane_ip: 192.168.122.11
-    storage_ip: 172.18.0.6
+    storage_ip: 172.18.0.11
   node_2:
     name: master-2
-    internalapi_ip: 172.17.0.7
-    tenant_ip: 172.19.0.7
+    internalapi_ip: 172.17.0.12
+    tenant_ip: 172.19.0.12
     ctlplane_ip: 192.168.122.12
-    storage_ip: 172.18.0.7
+    storage_ip: 172.18.0.12
 
   ctlplane:
     dnsDomain: ctlplane.example.com

--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -23,8 +23,8 @@ data:
         target_port=4420
         target_prefix=nvme-subsystem-1
         nvmeof_conn_info_version=2
-        target_ip_address=172.18.0.5
-        target_secondary_ip_addresses = 172.19.0.5
+        target_ip_address=172.18.0.10
+        target_secondary_ip_addresses = 172.19.0.10
 
   cinderBackup:
     customServiceConfig: |


### PR DESCRIPTION
As per cifmw reproducers scenario network-definition node IP allocations start from 10 (not 05)

In uni06zeta the .0.5 IP is incorrectly used in cinder config, result in cinder volumes (and so also glance image uploading etc) not working.

With that also correct the IPs to start from 10 not 5 in both uni01alpha and uni06zeta nncp/values.yaml samples.

[OSPCIX-333](https://issues.redhat.com//browse/OSPCIX-333)