### PR TITLE
Update glance storageClass propagation

### DIFF
--- a/lib/control-plane/kustomization.yaml
+++ b/lib/control-plane/kustomization.yaml
@@ -112,7 +112,7 @@ replacements:
           kind: OpenStackControlPlane
         fieldPaths:
           - spec.storageClass
-          - spec.glance.template.storageClass
+          - spec.glance.template.storage.storageClass
           - spec.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageClass
   - source:
       kind: ConfigMap

--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -67,8 +67,9 @@ spec:
           replicas: 0
           networkAttachments:
             - storage
-      storageClass: _replaced_
-      storageRequest: 10G
+      storage:
+        storageClass: _replaced_
+        storageRequest: 10G
   heat:
     apiOverride:
       route: {}


### PR DESCRIPTION
We recently merged [1][2] and the Glance API have been updated to reflect the new storage interface.
This patch aligns architectures repo CRs with the new structure.

[1] https://github.com/openstack-k8s-operators/glance-operator/pull/554
[2] https://github.com/openstack-k8s-operators/openstack-operator/pull/843

Jira: https://issues.redhat.com/browse/OSPRH-6719