### PR TITLE
Revert mysql_wsrep_sync_wait config option

### DIFF
--- a/examples/dt/bgp/control-plane/service-values.yaml
+++ b/examples/dt/bgp/control-plane/service-values.yaml
@@ -10,7 +10,7 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
-      debug=True
+      debug = True
       enabled_backends = default_backend:swift
       [glance_store]
       default_backend = default_backend
@@ -21,8 +21,6 @@ data:
       swift_store_endpoint_type = internalURL
       swift_store_user = service:glance
       swift_store_key = {{ .ServicePassword }}
-      [database]
-      mysql_wsrep_sync_wait = 1
     default:
       replicas: 1
 

--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -34,7 +34,7 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
-      debug=True
+      debug = True
       enabled_backends = default_backend:swift
 
       [glance_store]
@@ -47,9 +47,6 @@ data:
       swift_store_endpoint_type = internalURL
       swift_store_user = service:glance
       swift_store_key = {{ .ServicePassword }}
-
-      [database]
-      mysql_wsrep_sync_wait = 1
     default:
       replicas: 1
 

--- a/examples/dt/uni02beta/control-plane/service-values.yaml
+++ b/examples/dt/uni02beta/control-plane/service-values.yaml
@@ -76,14 +76,12 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
-      debug=True
+      debug = True
       enabled_backends = default_backend:file
       [glance_store]
       default_backend = default_backend
       [default_backend]
       filesystem_store_datadir = /var/lib/glance/images/
-      [database]
-      mysql_wsrep_sync_wait = 1
     databaseInstance: openstack
     glanceAPIs:
       default:

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -34,7 +34,7 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
-      debug=True
+      debug = True
       enabled_backends = default_backend:rbd
 
       [glance_store]
@@ -45,8 +45,6 @@ data:
       store_description = "RBD backend"
       rbd_store_pool = images
       rbd_store_user = openstack
-      [database]
-      mysql_wsrep_sync_wait = 1
     glanceAPIs:
       default:
         replicas: 3

--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -55,7 +55,7 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
-      debug=True
+      debug = True
       enabled_backends = primary:cinder,secondary:swift
       [glance_store]
       default_backend = primary
@@ -78,8 +78,6 @@ data:
       swift_store_key = {{ .ServicePassword }}
       [oslo_concurrency]
       lock_path = /var/lib/glance/tmp
-      [database]
-      mysql_wsrep_sync_wait = 1
     databaseInstance: openstack
     glanceAPIs:
       default:

--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -42,8 +42,8 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
+      debug = True
       enabled_backends = default_backend:cinder
-      debug = true
       [glance_store]
       default_backend = default_backend
       [default_backend]
@@ -58,8 +58,6 @@ data:
       # cinder_use_multipath = true
       [oslo_concurrency]
       lock_path = /var/lib/glance/tmp
-      [database]
-      mysql_wsrep_sync_wait = 1
     default:
       replicas: 1
 


### PR DESCRIPTION
This is not a clean revert: we are removing `mysql_wsrep_sync_wait` because of the `galera` fix, but we would like to keep `debug=True` for CI troubleshooting purposes.