### PR TITLE
Revert "Re enable ovn_emit_need_to_frag"

### DIFF
--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -135,7 +135,7 @@ data:
 
       [ovn]
       ovsdb_probe_interval = 60000
-      ovn_emit_need_to_frag = true
+      ovn_emit_need_to_frag = false
 
       [ml2]
       type_drivers = geneve,vxlan,vlan,flat

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -97,7 +97,7 @@ data:
       [ovs]
       igmp_snooping_enable = true
       [ovn]
-      ovn_emit_need_to_frag = true
+      ovn_emit_need_to_frag = false
       [ml2]
       type_drivers = geneve,vlan,flat
       tenant_network_types = vlan,flat

--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -112,7 +112,7 @@ data:
       [ovs]
       igmp_snooping_enable = true
       [ovn]
-      ovn_emit_need_to_frag = true
+      ovn_emit_need_to_frag = false
       enable_distributed_floating_ip = false
       [ml2]
       type_drivers = geneve,vlan

--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -117,7 +117,7 @@ data:
 
       [ovn]
       ovsdb_probe_interval = 60000
-      ovn_emit_need_to_frag = true
+      ovn_emit_need_to_frag = false
 
       [ml2]
       type_drivers = geneve,vxlan,vlan,flat


### PR DESCRIPTION
The required neutron fixes are stuck to get into 18.0, until the
fixes are in for OSP 18.0, let's revert.

Reverts openstack-k8s-operators/architecture#295