### PR TITLE
[DNM] Increase sriov controlplane timeout

### DIFF
--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -95,7 +95,7 @@ vas:
         wait_conditions:
           - >-
             oc -n openstack wait osctlplane controlplane --for condition=Ready
-            --timeout=600s
+            --timeout=60m
         values:
           - name: network-values
             src_file: nncp/values.yaml


### PR DESCRIPTION
Downstream SR-IOV deployments are not fully coming up in 10 minutes, increasing timeout to 30 minutes.