### PR TITLE
Unique pod names for cinder and glance

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -23,6 +23,7 @@ spec:
       secret: osp-secret
       serviceUser: ceilometer
   cinder:
+    uniquePodNames: true
     apiOverride:
       route: {"haproxy.router.openshift.io/timeout": "60s"}
     template:
@@ -57,6 +58,7 @@ spec:
         secret: osp-secret
         storageRequest: 5G
   glance:
+    uniquePodNames: true
     apiOverrides:
       default:
         route: {"haproxy.router.openshift.io/timeout": "60s"}


### PR DESCRIPTION
Cinder pods need to be uniquely name across all jobs that use the same storage backend.

Glance also needs unique names when using Cinder as a backend.

From a CI point of view there is no downside to having unique names, since all that changes are the CR and pod names for cinder and glance, so we make the change permanent for all jobs.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/847
Depends-On: https://github.com/openstack-k8s-operators/cinder-operator/pull/400
Depends-On: https://github.com/openstack-k8s-operators/glance-operator/pull/555
Jira: [OSPRH-7396](https://issues.redhat.com//browse/OSPRH-7396)