### PR TITLE
epsilone: Do not force config drive

### DIFF
--- a/dt/uni05epsilon/edpm/nodeset/nova_custom.yaml
+++ b/dt/uni05epsilon/edpm/nodeset/nova_custom.yaml
@@ -5,6 +5,10 @@ metadata:
   name: nova-custom-config
 data:
   25-nova-custom.conf: |
+    [DEFAULT]
+    # Override our defaults in this dt to get coverage for metadata-api based
+    # cloud-init scenarios
+    force_config_drive = False
     # NOTE(gibi): We need to disable multipath as IPv6 is not fully
     # working in this job with NetApp.
     # Enable multipath when OSPRH-7393 is resolved.


### PR DESCRIPTION
The nova default in 18 is to force the usage of the config drive over
the metadata-api. But we still want a dt where cloud-init is using
the metadata-api to initialize the guest to have test coverage.

Related: OSPRH-7901
