### PR TITLE
[Neutron][OVN]Increase Controller OVNDB SB NB replicas to 3

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -156,10 +156,12 @@ spec:
   ovn:
     template:
       ovnController:
+        replicas: 3
         networkAttachment: tenant
         nicMappings:
           datacentre: _replaced_
       ovnDBCluster:
+        replicas: 3
         ovndbcluster-nb:
           dbType: NB
           networkAttachment: internalapi


### PR DESCRIPTION
 Increase OVN controller pod to 3 replcias
 Increase OVNDB SB NB pod replicas to 3
 It increase tes coverage for integration/Arquitecture deployments