### PR TITLE
Always set glance replicas to 3

### DIFF
--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -48,7 +48,7 @@ data:
       swift_store_user = service:glance
       swift_store_key = {{ .ServicePassword }}
     default:
-      replicas: 1
+      replicas: 3
 
   ironic:
     enabled: true

--- a/examples/dt/uni02beta/control-plane/service-values.yaml
+++ b/examples/dt/uni02beta/control-plane/service-values.yaml
@@ -85,5 +85,5 @@ data:
     databaseInstance: openstack
     glanceAPIs:
       default:
-        replicas: 1
+        replicas: 3
         type: single

--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -81,7 +81,7 @@ data:
     databaseInstance: openstack
     glanceAPIs:
       default:
-        replicas: 1
+        replicas: 3
         type: split
 
   octavia:

--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -59,7 +59,7 @@ data:
       [oslo_concurrency]
       lock_path = /var/lib/glance/tmp
     default:
-      replicas: 1
+      replicas: 3
 
   swift:
     enabled: true

--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -58,10 +58,8 @@ data:
     glanceAPIs:
       default:
         preserveJobs: false
-        replicas: 1
+        replicas: 3
         type: split
-    storageClass: ""
-    storageRequest: 1G
 
   swift:
     enabled: true


### PR DESCRIPTION
rbac tests are failing and the root cause seems to have glance pods being restarted due to the large amount of requests coming from tempest. The same tests are not failing on unigamma and unidelta, where replica is set to 3.