### PR TITLE
Set UNI-Beta to replica: 1

### DIFF
--- a/examples/dt/uni02beta/control-plane/service-values.yaml
+++ b/examples/dt/uni02beta/control-plane/service-values.yaml
@@ -85,5 +85,7 @@ data:
     databaseInstance: openstack
     glanceAPIs:
       default:
-        replicas: 3
+        # NOTE: (fpantano) - replica here must be 1 because
+        # we removed NFS extraMounts via PR#288 due to OSPRH-7396
+        replicas: 1
         type: single


### PR DESCRIPTION
As per Jira [OSPRH-7396](https://issues.redhat.com//browse/OSPRH-7396) `extraMounts` have been removed from the current CR  via #288. For this reason increasing the replicas w/ a RWO PVC will cause issues.