### PR TITLE
Enable heat for zeta and eta env

### DIFF
--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -67,6 +67,9 @@ data:
   octavia:
     enabled: true
 
+  heat:
+    enabled: true
+
   ovn:
     ovnController:
       availability-zones:

--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -82,6 +82,9 @@ data:
       networkAttachments:
         - octavia
 
+  heat:
+    enabled: true
+
   ovn:
     ovnController:
       nicMappings:


### PR DESCRIPTION
Enable heat allows us to run tobiko tests.