### PR TITLE
Enable heat for in uni02beta DT

### DIFF
--- a/dt/uni02beta/kustomization.yaml
+++ b/dt/uni02beta/kustomization.yaml
@@ -227,3 +227,26 @@ replacements:
           - spec.manila.template.manilaShares.share1.replicas
         options:
           create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.heat.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.heat.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.heat.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.heat.template.customServiceConfig
+        options:
+          create: true

--- a/dt/uni02beta/kustomization.yaml
+++ b/dt/uni02beta/kustomization.yaml
@@ -238,15 +238,3 @@ replacements:
           - spec.heat.enabled
         options:
           create: true
-
-  - source:
-      kind: ConfigMap
-      name: service-values
-      fieldPath: data.heat.customServiceConfig
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.heat.template.customServiceConfig
-        options:
-          create: true

--- a/examples/dt/uni02beta/control-plane/service-values.yaml
+++ b/examples/dt/uni02beta/control-plane/service-values.yaml
@@ -89,3 +89,6 @@ data:
         # we removed NFS extraMounts via PR#288 due to OSPRH-7396
         replicas: 1
         type: single
+
+  heat:
+    enabled: true


### PR DESCRIPTION
[DNM] Since Tobiko tf uses Heat, we need to enable it in order to run Tobiko tests.