### PR TITLE
[BGP] Set edpm_ovn_encap_ip value to bgpmainnet_ip

### DIFF
--- a/automation/vars/bgp.yaml
+++ b/automation/vars/bgp.yaml
@@ -124,7 +124,7 @@ vas:
             oc -n openstack wait openstackdataplanedeployment
             edpm-deployment
             --for condition=Ready
-            --timeout=2400s
+            --timeout=3800s
         values:
           - name: edpm-deployment-values
             src_file: values.yaml

--- a/examples/dt/bgp/bgp_dt01/edpm/computes/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/values.yaml
@@ -20,6 +20,7 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
         edpm_ovn_bgp_agent_expose_tenant_networks: false
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/values.yaml
@@ -20,6 +20,7 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
         edpm_ovn_bgp_agent_expose_tenant_networks: false
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6


### PR DESCRIPTION
In order to route traffic from geneve tunnels through BGP networks, the OVN encap IP should be set to the loopback IPs whose routes are advertized via BGP.