### PR TITLE
Defaults to 3-node galera

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -50,13 +50,11 @@ spec:
     enabled: true
     templates:
       openstack:
-        # TODO(dciabrin) revert back to 3 once OSPRH-7405 is fixed
-        replicas: 1
+        replicas: 3
         secret: osp-secret
         storageRequest: 5G
       openstack-cell1:
-        # TODO(dciabrin) revert back to 3 once OSPRH-7405 is fixed
-        replicas: 1
+        replicas: 3
         secret: osp-secret
         storageRequest: 5G
   glance:


### PR DESCRIPTION
Now that [1] has been merged and traffic to the galera cluster is configured as A/P, it is safe to deploy galera as a 3-node cluster service. Revert [2] accordingly.

[1] https://issues.redhat.com/browse/OSPRH-7405
[2] b1db41aee1d9a2fe8ee4134e525eeba05c47940a