### PR TITLE
Fix missing octavia-ca-passphrase secret

### DIFF
--- a/dt/uni06zeta/kustomization.yaml
+++ b/dt/uni06zeta/kustomization.yaml
@@ -2,6 +2,13 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+secretGenerator:
+  - name: octavia-ca-passphrase
+    literals:
+      - server-ca-passphrase=12345678
+    options:
+      disableNameSuffixHash: true
+
 transformers:
   - |-
       apiVersion: builtin


### PR DESCRIPTION
in uni06zeta.

Jira: [OSPRH-8311](https://issues.redhat.com//browse/OSPRH-8311)