### PR TITLE
Epsilon: Re-enable multipath

### DIFF
--- a/dt/uni05epsilon/edpm/nodeset/nova_custom.yaml
+++ b/dt/uni05epsilon/edpm/nodeset/nova_custom.yaml
@@ -9,11 +9,6 @@ data:
     # Override our defaults in this dt to get coverage for metadata-api based
     # cloud-init scenarios
     force_config_drive = False
-    # NOTE(gibi): We need to disable multipath as IPv6 is not fully
-    # working in this job with NetApp.
-    # Enable multipath when OSPRH-7393 is resolved.
-    [libvirt]
-    volume_use_multipath = False
 
 ---
 apiVersion: dataplane.openstack.org/v1beta1


### PR DESCRIPTION
Previously we disabled multipath in Epsilon jobs, but now that we are using the webhook to change iSCSI login timeouts [1] they can be re-enabled.

As a side note, and for future reference, disabling multipathing should not have been in this architecture repo, because it's not an architecture specific thing, it's a deployment specific issue.

The right place to change this would be in the job specific repo.

[1]: https://github.com/openstack-k8s-operators/ci-framework/pull/2060