### PR TITLE
Increase osctlplane controlplane waiting time for Ready condition

### DIFF
--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -191,7 +191,7 @@ vas:
         wait_conditions:
           - >-
             oc -n openstack wait osctlplane controlplane --for condition=Ready
-            --timeout=600s
+            --timeout=900s
         values:
           - name: network-values
             src_file: nncp/values.yaml


### PR DESCRIPTION
The waiting time for OpenStack ControlPlane to be Ready needs to be increased from 600 to 900 seconds to avoids spurious timeouts since sometimes 10 minutes is not enough to reach the Ready condition.