### PR TITLE
Re-enable cinder multipath in glance

### DIFF
--- a/dt/uni05epsilon/edpm/nodeset/nova_custom.yaml
+++ b/dt/uni05epsilon/edpm/nodeset/nova_custom.yaml
@@ -9,11 +9,6 @@ data:
     # Override our defaults in this dt to get coverage for metadata-api based
     # cloud-init scenarios
     force_config_drive = False
-    # NOTE(gibi): We need to disable multipath as IPv6 is not fully
-    # working in this job with NetApp.
-    # Enable multipath when OSPRH-7393 is resolved.
-    [libvirt]
-    volume_use_multipath = False
 
 ---
 apiVersion: dataplane.openstack.org/v1beta1

--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -67,8 +67,7 @@ data:
       cinder_store_password = {{ .ServicePassword }}
       cinder_store_project_name = service
       cinder_catalog_info = volumev3::internalURL
-      # TODO: Enable multipath when OSPRH-7393 is resolved
-      # cinder_use_multipath = true
+      cinder_use_multipath = true
       [secondary]
       swift_store_create_container_on_put = True
       swift_store_auth_version = 3

--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -54,8 +54,7 @@ data:
       cinder_store_password = {{ .ServicePassword }}
       cinder_store_project_name = service
       cinder_catalog_info = volumev3::internalURL
-      # TODO: Enable multipath when OSPRH-7393 is resolved
-      # cinder_use_multipath = true
+      cinder_use_multipath = true
       [oslo_concurrency]
       lock_path = /var/lib/glance/tmp
     default:

--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -50,8 +50,7 @@ data:
       cinder_store_password = {{ .ServicePassword }}
       cinder_store_project_name = service
       cinder_catalog_info = volumev3::internalURL
-      # TODO: Enable multipath when OSPRH-7393 is resolved
-      # cinder_use_multipath = true
+      cinder_use_multipath = true
       [oslo_concurrency]
       lock_path = /var/lib/glance/tmp
     databaseInstance: openstack


### PR DESCRIPTION
This patch removes the workaround introduced for `OSPRH-7393`. The patches landed on both openstack, glance and cinder operators, hence we might want to test this change to verify the bug and re-enable cinder multipath (which is what customers do).

Jira: https://issues.redhat.com/browse/OSPRH-7415