### PR TITLE
Allow to customize operators subscription channel

### DIFF
--- a/examples/common/olm/values.yaml
+++ b/examples/common/olm/values.yaml
@@ -8,3 +8,4 @@ metadata:
     config.kubernetes.io/local-config: "true"
 data:
   openstack-operator-image: "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
+  openstack-operator-channel: "alpha"

--- a/lib/olm-openstack/kustomization.yaml
+++ b/lib/olm-openstack/kustomization.yaml
@@ -18,3 +18,13 @@ replacements:
           kind: CatalogSource
         fieldPaths:
           - spec.image
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-channel
+    targets:
+      - select:
+          kind: Subscription
+          name: openstack-operator
+        fieldPaths:
+          - spec.channel


### PR DESCRIPTION
Adds a new variable called openstack-operator-channel that allow to customize the default channel name. It continues to default to 'alpha'.