### PR TITLE
uni-delta: really enable cinder-backup

### DIFF
--- a/dt/uni04delta-ipv6/edpm/nodeset/kustomization.yaml
+++ b/dt/uni04delta-ipv6/edpm/nodeset/kustomization.yaml
@@ -46,6 +46,18 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.cinderBackup.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.cinderVolumes.ceph
     targets:
       - select:

--- a/dt/uni04delta/edpm/nodeset/kustomization.yaml
+++ b/dt/uni04delta/edpm/nodeset/kustomization.yaml
@@ -46,6 +46,18 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.cinderBackup.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.cinderVolumes.ceph
     targets:
       - select:

--- a/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
@@ -17,6 +17,7 @@ data:
       backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
       backup_ceph_pool = backups
       backup_ceph_user = openstack
+    replicas: 3
 
   cinderVolumes:
     ceph:

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -15,6 +15,7 @@ data:
       backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
       backup_ceph_pool = backups
       backup_ceph_user = openstack
+    replicas: 3
 
   cinderVolumes:
     ceph:


### PR DESCRIPTION
The default replica of cinder-backup is 0: like cinder-volumes, it requires a backend to be configured).

Both variants of uni-delta (base and IPv6) configure the service but don't set the replice, so it is not started.

Set replica 3 to test its HA mode (the old behavior in the last tripleo releases).