### PR TITLE
[Uni Eta] Set mtu same as Uni Zeta

### DIFF
--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -128,3 +128,4 @@ data:
       [ml2]
       type_drivers = geneve,vxlan,vlan,flat
       tenant_network_types = geneve,flat,vlan
+      path_mtu = 1400


### PR DESCRIPTION
Similar fix was done for Zeta in [1], applying same to to Uni Eta to resolve mtu specific test failures.

[1] https://github.com/openstack-k8s-operators/architecture/pull/271