### PR TITLE
Do not quote ctlplane_dns_nameservers list in delta-ipv6

### DIFF
--- a/examples/dt/uni04delta-ipv6/values.yaml
+++ b/examples/dt/uni04delta-ipv6/values.yaml
@@ -49,7 +49,7 @@ data:
               name: {{ neutron_physical_bridge_name }}
               mtu: {{ min_viable_mtu }}
               use_dhcp: false
-              dns_servers: '{{ ctlplane_dns_nameservers }}'
+              dns_servers: {{ ctlplane_dns_nameservers | list }}
               domain: {{ dns_search_domains }}
               addresses:
                 - ip_netmask: '{{ ctlplane_ip }}/{{ ctlplane_cidr }}'


### PR DESCRIPTION
Only the IPv6 DT quotes the ctlplane_dns_nameservers list. These quotes make os-net-config fail. Removing the quotes result in a valid /etc/os-net-config/config.yaml which does not fail with:

```
expected <block end>, but found '<scalar>'
  in "<unicode string>", line 7, column 21:
        dns_servers: '['2620:cf:cf:aaaa::50']'
                        ^
```

Jira: https://issues.redhat.com/browse/OSPRH-8746