### PR TITLE
Revert "Revert "Re enable ovn_emit_need_to_frag""

### DIFF
--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -170,7 +170,7 @@ data:
 
       [ovn]
       ovsdb_probe_interval = 60000
-      ovn_emit_need_to_frag = false
+      ovn_emit_need_to_frag = true
 
       [ml2]
       type_drivers = geneve,vxlan,vlan,flat

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -98,7 +98,7 @@ data:
       [ovs]
       igmp_snooping_enable = true
       [ovn]
-      ovn_emit_need_to_frag = false
+      ovn_emit_need_to_frag = true
       [ml2]
       type_drivers = geneve,vlan,flat
       tenant_network_types = vlan,flat

--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -111,7 +111,7 @@ data:
       [ovs]
       igmp_snooping_enable = true
       [ovn]
-      ovn_emit_need_to_frag = false
+      ovn_emit_need_to_frag = true
       enable_distributed_floating_ip = false
       [ml2]
       type_drivers = geneve,vlan

--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -122,7 +122,7 @@ data:
 
       [ovn]
       ovsdb_probe_interval = 60000
-      ovn_emit_need_to_frag = false
+      ovn_emit_need_to_frag = true
 
       [ml2]
       type_drivers = geneve,vxlan,vlan,flat


### PR DESCRIPTION
Reverts openstack-k8s-operators/architecture#301

Fixes are available in OSP18.0 now so reverting.