### PR TITLE
Enable Horizon in delta-ipv6

### DIFF
--- a/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
@@ -9,7 +9,7 @@ data:
   preserveJobs: false
 
   horizon:
-    enabled: false
+    enabled: true
 
   cinderBackup:
     customServiceConfig: |


### PR DESCRIPTION
Effectively everts commit 95e301f58fc066c3dc40a01426985f66dede49f6 while keeping option to change it in the kustomization file.