### PR TITLE
[uni02beta] Reenable file/NFS for glance

### DIFF
--- a/dt/uni02beta/kustomization.yaml
+++ b/dt/uni02beta/kustomization.yaml
@@ -126,6 +126,17 @@ replacements:
           - spec.glance.template.glanceAPIs.default.type
         options:
           create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.extraMounts
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.extraMounts
+        options:
+          create: true
   # Manila
   - source:
       kind: ConfigMap

--- a/examples/dt/uni02beta/control-plane/service-values.yaml
+++ b/examples/dt/uni02beta/control-plane/service-values.yaml
@@ -85,10 +85,19 @@ data:
     databaseInstance: openstack
     glanceAPIs:
       default:
-        # NOTE: (fpantano) - replica here must be 1 because
-        # we removed NFS extraMounts via PR#288 due to OSPRH-7396
-        replicas: 1
+        replicas: 3
         type: single
+    extraMounts:
+      - extraVol:
+          - extraVolType: Nfs
+            mounts:
+              - mountPath: /var/lib/glance/images
+                name: nfs
+            volumes:
+              - name: nfs
+                nfs:
+                  path: _replaced_
+                  server: _replaced_
 
   heat:
     enabled: true


### PR DESCRIPTION
Most of the issues described in https://issues.redhat.com/browse/OSPRH-7396 were addressed, at least on the controlplane side. As glance is mostly concerned with that part, it should work again.

This is a revert of
* b917c3129258d74bafe192454ee3f94097671b5e [uni02beta] Drop NFS from Glance
* 87d9931a9cf08be1b800fab6dd876d8a8ea5a191 Set UNI-Beta to replica: 1