### PR TITLE
Disable extra mount in uni02beta

### DIFF
--- a/dt/uni02beta/kustomization.yaml
+++ b/dt/uni02beta/kustomization.yaml
@@ -81,6 +81,7 @@ replacements:
           - stringData.ontap-cinder-secrets\.conf
         options:
           create: true
+
   # Glance
   - source:
       kind: ConfigMap
@@ -126,17 +127,18 @@ replacements:
           - spec.glance.template.glanceAPIs.default.type
         options:
           create: true
-  - source:
-      kind: ConfigMap
-      name: service-values
-      fieldPath: data.glance.extraMounts
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.glance.template.extraMounts
-        options:
-          create: true
+  # - source:
+  #     kind: ConfigMap
+  #     name: service-values
+  #     fieldPath: data.glance.extraMounts
+  #   targets:
+  #     - select:
+  #         kind: OpenStackControlPlane
+  #       fieldPaths:
+  #         - spec.glance.template.extraMounts
+  #       options:
+  #         create: true
+
   # Manila
   - source:
       kind: ConfigMap


### PR DESCRIPTION
It fails again due to some NetApp issues (?).
In this change, we keep the configuration for it,
but just remove from kustomization the creation
of that extra mount, so it can be used as a workaround until the problem is resolved.