### PR TITLE
Deploy 2 replicas of DNS per default

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -45,7 +45,7 @@ spec:
   dns:
     template:
       options: []
-      replicas: 1
+      replicas: 2
   galera:
     enabled: true
     templates:


### PR DESCRIPTION
like for glance, cinder, nova and all the other services we test with recommended number of replicas. That's why we should also test with DNS to have redundant number of replicas.