### PR TITLE
Allow setting Nova Compute extra config

### DIFF
--- a/dt/uni05epsilon/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset/kustomization.yaml
@@ -296,6 +296,22 @@ replacements:
           create: true
 
   #
+  # Nova
+  #
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova-extra-config
+    targets:
+      - select:
+          kind: ConfigMap
+          name: nova-custom-config
+        fieldPaths:
+          - data.55-nova-extra\.conf
+        options:
+          create: true
+
+  #
   # Swift
   #
   - source:

--- a/dt/uni07eta/edpm/nodeset/kustomization.yaml
+++ b/dt/uni07eta/edpm/nodeset/kustomization.yaml
@@ -18,3 +18,24 @@ transformers:
 
 components:
   - ../../../../lib/dataplane/nodeset
+
+resources:
+  - resources/nova-custom-config.yaml
+  - resources/nova-custom-service.yaml
+
+replacements:
+  #
+  # Nova
+  #
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.nova-extra-config
+    targets:
+      - select:
+          kind: ConfigMap
+          name: nova-custom-config
+        fieldPaths:
+          - data.55-nova-extra\.conf
+        options:
+          create: true

--- a/dt/uni07eta/edpm/nodeset/resources/nova-custom-config.yaml
+++ b/dt/uni07eta/edpm/nodeset/resources/nova-custom-config.yaml
@@ -4,10 +4,5 @@ kind: ConfigMap
 metadata:
   name: nova-custom-config
 data:
-  25-nova-custom.conf: |
-    [DEFAULT]
-    # Override our defaults in this dt to get coverage for metadata-api based
-    # cloud-init scenarios
-    force_config_drive = False
   55-nova-extra.conf: |
     # Additional overrides that can be set in environment-specific cases

--- a/dt/uni07eta/edpm/nodeset/resources/nova-custom-service.yaml
+++ b/dt/uni07eta/edpm/nodeset/resources/nova-custom-service.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: nova-custom
+spec:
+  label: dataplane-deployment-nova-custom
+  dataSources:
+    - configMapRef:
+        name: nova-custom-config
+    - secretRef:
+        name: nova-cell1-compute-config
+    - secretRef:
+        name: nova-migration-ssh-key
+  playbook: osp.edpm.nova
+  caCerts: combined-ca-bundle
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      networks:
+        - ctlplane
+      issuer: osp-rootca-issuer-internal
+      edpmRoleServiceName: nova
+  edpmServiceType: nova
+  containerImageFields:
+    - NovaComputeImage
+    - EdpmIscsidImage

--- a/examples/dt/uni05epsilon/service-values.yaml
+++ b/examples/dt/uni05epsilon/service-values.yaml
@@ -121,5 +121,8 @@ data:
         replicas: 3
         type: split
 
+  nova-extra-config: |
+    # Additional overrides that can be set in environment-specific cases
+
   swift:
     enabled: true

--- a/examples/dt/uni07eta/edpm/values.yaml
+++ b/examples/dt/uni07eta/edpm/values.yaml
@@ -19,6 +19,9 @@ data:
         private: _replaced_
         public: _replaced_
 
+  nova-extra-config: |
+    # Additional overrides that can be set in environment-specific cases
+
   nodeset:
     ansible:
       ansibleUser: cloud-admin
@@ -132,4 +135,4 @@ data:
       - ovn
       - neutron-metadata
       - libvirt
-      - nova
+      - nova-custom


### PR DESCRIPTION
This change allows to pass additional environment-specific values to Nova Compute service in the uni05epsilon and uni07eta scenarios. If not overwritten in values.yaml, the default dummy config is added.