### PR TITLE
Enable ironic on delta-ipv6

### DIFF
--- a/dt/uni04delta-ipv6/kustomization.yaml
+++ b/dt/uni04delta-ipv6/kustomization.yaml
@@ -82,7 +82,17 @@ replacements:
           - spec.neutron.template.customServiceConfig
         options:
           create: true
-
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.ironic.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ironic.enabled
+        options:
+          create: true
   - source:
       kind: ConfigMap
       name: network-values


### PR DESCRIPTION
The job currenly passing.
The ironic api test also can work after enabling.

According to examples/dt/uni04delta-ipv6/README.md 
The ironic service should be enabled here.