### PR TITLE
Revert "Disable extra mount in uni02beta"

### DIFF
--- a/dt/uni02beta/kustomization.yaml
+++ b/dt/uni02beta/kustomization.yaml
@@ -81,7 +81,6 @@ replacements:
           - stringData.ontap-cinder-secrets\.conf
         options:
           create: true
-
   # Glance
   - source:
       kind: ConfigMap
@@ -127,18 +126,17 @@ replacements:
           - spec.glance.template.glanceAPIs.default.type
         options:
           create: true
-  # - source:
-  #     kind: ConfigMap
-  #     name: service-values
-  #     fieldPath: data.glance.extraMounts
-  #   targets:
-  #     - select:
-  #         kind: OpenStackControlPlane
-  #       fieldPaths:
-  #         - spec.glance.template.extraMounts
-  #       options:
-  #         create: true
-
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.extraMounts
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.extraMounts
+        options:
+          create: true
   # Manila
   - source:
       kind: ConfigMap


### PR DESCRIPTION
It seems glance/NFS (or better, the combination of glance/NFS and
cinder/NFS) is stable enough, at least when used with different shares,
so that it can be reenabled.

This reverts commit 43ba5f8f471a0bf24774b2bc89ac3cb25c843ac8.