### PR TITLE
Use pre/post Ceph servicesOverride in uni05epsilon HCI

### DIFF
--- a/examples/dt/uni05epsilon/dataplane-post-ceph.md
+++ b/examples/dt/uni05epsilon/dataplane-post-ceph.md
@@ -114,3 +114,12 @@ Wait for post-Ceph dataplane deployment to finish.
 ```bash
 oc wait osdpd edpm-deployment-post-ceph --for condition=Ready --timeout=40m
 ```
+
+## Final OpenStackDataPlaneNodeSet services list
+
+The `OpenStackDataPlaneNodeSet` must contain the full `services` list
+so that during updates all required services are updated. Thus, the
+pre-ceph and post-ceph deployments used a `servicesOverride` so that
+only a subset of the services would be configured either before or
+after Ceph was deployed. Any subsequent deployments should not pass a
+`servicesOverride` unless necessary.

--- a/examples/dt/uni05epsilon/deployment/kustomization.yaml
+++ b/examples/dt/uni05epsilon/deployment/kustomization.yaml
@@ -7,3 +7,16 @@ components:
 
 resources:
   - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values-post-ceph
+      fieldPath: data.servicesOverride
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.servicesOverride
+        options:
+          create: true

--- a/examples/dt/uni05epsilon/deployment/values.yaml
+++ b/examples/dt/uni05epsilon/deployment/values.yaml
@@ -9,3 +9,10 @@ metadata:
 data:
   deployment:
     name: edpm-deployment-post-ceph
+  servicesOverride:
+    - install-certs
+    - ceph-client
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova-custom

--- a/examples/dt/uni05epsilon/edpm-pre-ceph/deployment/kustomization.yaml
+++ b/examples/dt/uni05epsilon/edpm-pre-ceph/deployment/kustomization.yaml
@@ -7,3 +7,16 @@ components:
 
 resources:
   - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.servicesOverride
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.servicesOverride
+        options:
+          create: true

--- a/examples/dt/uni05epsilon/edpm-pre-ceph/deployment/values.yaml
+++ b/examples/dt/uni05epsilon/edpm-pre-ceph/deployment/values.yaml
@@ -9,3 +9,14 @@ metadata:
 data:
   deployment:
     name: edpm-deployment-pre-ceph
+  servicesOverride:
+    - bootstrap
+    - download-cache
+    - configure-network
+    - validate-network
+    - install-os
+    - ceph-hci-pre
+    - configure-os
+    - ssh-known-hosts
+    - run-os
+    - reboot-os

--- a/examples/dt/uni05epsilon/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni05epsilon/edpm-pre-ceph/nodeset/values.yaml
@@ -151,7 +151,9 @@ data:
             subnetName: subnet1
           - name: tenant
             subnetName: subnet1
-
+    # The nova-custom service is omitted since it is not yet
+    # defined. It will be defined and set after Ceph is deployed.
+    # See deployment servicesOverride for effective services list.
     services:
       - bootstrap
       - download-cache
@@ -163,3 +165,8 @@ data:
       - ssh-known-hosts
       - run-os
       - reboot-os
+      - install-certs
+      - ceph-client
+      - ovn
+      - neutron-metadata
+      - libvirt

--- a/examples/dt/uni05epsilon/values.yaml
+++ b/examples/dt/uni05epsilon/values.yaml
@@ -14,6 +14,16 @@ data:
 
   nodeset:
     services:
+      - bootstrap
+      - download-cache
+      - configure-network
+      - validate-network
+      - install-os
+      - ceph-hci-pre
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
       - install-certs
       - ceph-client
       - ovn


### PR DESCRIPTION
This patch applies very similar changes as the commit below for the same reasons but to uni05epsilon.

commit 3ebad70fd9488ff2995553e8acc5e4fc85f24f1e

Jira: https://issues.redhat.com/browse/OSPRH-9222