### PR TITLE
Use pre/post Ceph servicesOverride in HCI deployments

### DIFF
--- a/examples/va/hci/dataplane-post-ceph.md
+++ b/examples/va/hci/dataplane-post-ceph.md
@@ -88,3 +88,12 @@ Ask Nova to discover all compute hosts
 ```bash
 oc rsh nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
 ```
+
+## Final OpenStackDataPlaneNodeSet services list
+
+The `OpenStackDataPlaneNodeSet` must contain the full `services` list
+so that during updates all required services are updated. Thus, the
+pre-ceph and post-ceph deployments used a `servicesOverride` so that
+only a subset of the services would be configured either before or
+after Ceph was deployed. Any subsequent deployments should not pass a
+`servicesOverride` unless necessary.

--- a/examples/va/hci/deployment/kustomization.yaml
+++ b/examples/va/hci/deployment/kustomization.yaml
@@ -11,3 +11,16 @@ components:
 
 resources:
   - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values-post-ceph
+      fieldPath: data.servicesOverride
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.servicesOverride
+        options:
+          create: true

--- a/examples/va/hci/deployment/values.yaml
+++ b/examples/va/hci/deployment/values.yaml
@@ -9,3 +9,10 @@ metadata:
 data:
   deployment:
     name: edpm-deployment-post-ceph
+  servicesOverride:
+    - install-certs
+    - ceph-client
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova-custom-ceph

--- a/examples/va/hci/edpm-pre-ceph/deployment/kustomization.yaml
+++ b/examples/va/hci/edpm-pre-ceph/deployment/kustomization.yaml
@@ -10,3 +10,16 @@ components:
 
 resources:
   - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.servicesOverride
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.servicesOverride
+        options:
+          create: true

--- a/examples/va/hci/edpm-pre-ceph/deployment/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/deployment/values.yaml
@@ -10,3 +10,13 @@ metadata:
 data:
   deployment:
     name: edpm-deployment-pre-ceph
+  servicesOverride:
+    - bootstrap
+    - configure-network
+    - validate-network
+    - install-os
+    - ceph-hci-pre
+    - configure-os
+    - ssh-known-hosts
+    - run-os
+    - reboot-os

--- a/examples/va/hci/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/nodeset/values.yaml
@@ -154,6 +154,9 @@ data:
             subnetName: subnet1
           - name: tenant
             subnetName: subnet1
+    # The nova-custom-ceph service is omitted since it is not yet
+    # defined. It will be defined and set after Ceph is deployed.
+    # See deployment servicesOverride for effective services list.
     services:
       - bootstrap
       - configure-network
@@ -164,6 +167,11 @@ data:
       - ssh-known-hosts
       - run-os
       - reboot-os
+      - install-certs
+      - ceph-client
+      - ovn
+      - neutron-metadata
+      - libvirt
   nova:
     migration:
       ssh_keys:

--- a/examples/va/hci/values.yaml
+++ b/examples/va/hci/values.yaml
@@ -9,6 +9,15 @@ metadata:
 data:
   nodeset:
     services:
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - ceph-hci-pre
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
       - install-certs
       - ceph-client
       - ovn


### PR DESCRIPTION
Prior to this patch the OpenStackDataPlaneNodeSet changed before and after Ceph was deployed. This resulted in an incomplete nodeset services definition which resulted in incomplete updates in future deployments.

With this change the NodeSet will have the full services list but the pre-ceph and post-ceph deployments each pass a different servicesOverride list so the desired subset of services can be run before or after Ceph is deployed but the NodeSet services list remains complete.

Note that the NodeSet does not have the `nova-custom-ceph` service when it's initially created since that service is not defined until after Ceph is deployed. However, When `kustomize build` is run in `examples/va/hci` the full services list is defined in the NodeSet. Regardless, only a subset of services are run for the pre and post Ceph deployments.

Jira: https://issues.redhat.com/browse/OSPRH-9172

(cherry picked from 3ebad70fd9488ff2995553e8acc5e4fc85f24f1e)