### PR TITLE
Changing ntp to ci-framework default

### DIFF
--- a/examples/dt/bgp/bgp_dt01/edpm/computes/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/values.yaml
@@ -29,7 +29,7 @@ data:
           - nic3
           - nic4
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests
         edpm_bootstrap_command: |
           dnf -y install conntrack-tools

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/values.yaml
@@ -29,7 +29,7 @@ data:
           - nic3
           - nic4
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests
         edpm_bootstrap_command: |
           dnf -y install conntrack-tools

--- a/examples/dt/bgp/edpm/nodeset/values.yaml
+++ b/examples/dt/bgp/edpm/nodeset/values.yaml
@@ -28,7 +28,7 @@ data:
           - nic3
           - nic4
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # CHANGEME -- see https://access.redhat.com/solutions/253273
         # edpm_bootstrap_command: |
         #       subscription-manager register --username <subscription_manager_username> \

--- a/examples/dt/osasinfra/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/osasinfra/edpm-pre-ceph/nodeset/values.yaml
@@ -21,7 +21,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # CHANGEME -- see https://access.redhat.com/solutions/253273
         # edpm_bootstrap_command: |
         #       subscription-manager register --username <subscription_manager_username> \

--- a/examples/dt/pidone/edpm/nodeset/values.yaml
+++ b/examples/dt/pidone/edpm/nodeset/values.yaml
@@ -21,7 +21,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # CHANGEME -- see https://access.redhat.com/solutions/253273
         # edpm_bootstrap_command: |
         #       subscription-manager register --username <subscription_manager_username> \

--- a/examples/dt/pidone/values.yaml
+++ b/examples/dt/pidone/values.yaml
@@ -21,7 +21,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # CHANGEME -- see https://access.redhat.com/solutions/253273
         # edpm_bootstrap_command: |
         #       subscription-manager register --username <subscription_manager_username> \

--- a/examples/dt/uni01alpha/edpm/values.yaml
+++ b/examples/dt/uni01alpha/edpm/values.yaml
@@ -25,7 +25,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
           ---

--- a/examples/dt/uni01alpha/networker/nodeset/values.yaml
+++ b/examples/dt/uni01alpha/networker/nodeset/values.yaml
@@ -25,7 +25,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
 
         gather_facts: false
 

--- a/examples/dt/uni02beta/values.yaml
+++ b/examples/dt/uni02beta/values.yaml
@@ -25,7 +25,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
           ---

--- a/examples/dt/uni04delta-ipv6/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni04delta-ipv6/edpm-pre-ceph/nodeset/values.yaml
@@ -21,7 +21,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # CHANGEME -- see https://access.redhat.com/solutions/253273
         # edpm_bootstrap_command: |
         #       subscription-manager register --username <subscription_manager_username> \

--- a/examples/dt/uni04delta-ipv6/values.yaml
+++ b/examples/dt/uni04delta-ipv6/values.yaml
@@ -31,7 +31,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
 
         edpm_iscsid_image: '{{ registry_url }}/openstack-iscsid:{{ image_tag }}'
         edpm_logrotate_crond_image: '{{ registry_url }}/openstack-cron:{{ image_tag }}'

--- a/examples/dt/uni04delta/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni04delta/edpm-pre-ceph/nodeset/values.yaml
@@ -21,7 +21,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # CHANGEME -- see https://access.redhat.com/solutions/253273
         # edpm_bootstrap_command: |
         #       subscription-manager register --username <subscription_manager_username> \

--- a/examples/dt/uni04delta/values.yaml
+++ b/examples/dt/uni04delta/values.yaml
@@ -31,7 +31,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
 
         edpm_iscsid_image: '{{ registry_url }}/openstack-iscsid:{{ image_tag }}'
         edpm_logrotate_crond_image: '{{ registry_url }}/openstack-cron:{{ image_tag }}'

--- a/examples/dt/uni05epsilon/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni05epsilon/edpm-pre-ceph/nodeset/values.yaml
@@ -25,7 +25,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
           ---

--- a/examples/dt/uni06zeta/values.yaml
+++ b/examples/dt/uni06zeta/values.yaml
@@ -25,7 +25,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
           ---

--- a/examples/dt/uni07eta/edpm/values.yaml
+++ b/examples/dt/uni07eta/edpm/values.yaml
@@ -28,7 +28,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
           ---

--- a/examples/dt/uni07eta/networker/nodeset/values.yaml
+++ b/examples/dt/uni07eta/networker/nodeset/values.yaml
@@ -25,7 +25,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
 
         gather_facts: false
 

--- a/examples/va/hci/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/nodeset/values.yaml
@@ -21,7 +21,7 @@ data:
       ansiblePort: 22
       ansibleVars:
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # CHANGEME -- see https://access.redhat.com/solutions/253273
         # edpm_bootstrap_command: |
         #       subscription-manager register --username <subscription_manager_username> \

--- a/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
@@ -38,7 +38,7 @@ data:
         #         --password <subscription_manager_password>
         #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # CPU pinning settings
         # edpm nfv ovs dpdk config
         # CHANGEME

--- a/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
@@ -37,7 +37,7 @@ data:
         #         --password <subscription_manager_password>
         #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # CPU pinning settings
         # edpm nfv ovs dpdk config
         # CHANGEME

--- a/examples/va/nfv/sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/sriov/edpm/nodeset/values.yaml
@@ -36,7 +36,7 @@ data:
         #       subscription-manager register --username <subscription_manager_username> --password <subscription_manager_password>
         #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
-          - hostname: clock.redhat.com
+          - hostname: pool.ntp.org
         # CPU pinning settings
         edpm_kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=16 intel_iommu=on iommu=pt isolcpus=4-23,28-47"
         edpm_tuned_profile: "cpu-partitioning-powersave"


### PR DESCRIPTION
This parameter is excepted to be overriden with
cifmw_ci_gen_kustomize_values_ntp_srv to your own
clock infra.