### PR TITLE
[NFV] Update the osdpns timeout for SetupReady

### DIFF
--- a/automation/vars/default.yaml
+++ b/automation/vars/default.yaml
@@ -204,7 +204,7 @@ vas:
           - >-
             oc -n openstack wait
             osdpns openstack-edpm --for condition=SetupReady
-            --timeout=60m
+            --timeout=90m
         values:
           - name: edpm-nodeset-values
             src_file: values.yaml


### PR DESCRIPTION
This patch bumps the timeout we use for the `OpenStackDataPlaneNodeSet` to 90m.

The bump is needed because the NFV deploys to real baremetal, 30m is enough for virtual baremetal but real machines take way longer to provision.

90m was chosen as we saw a failed job that took 70m to get to SetupReady

Jira: [OSPRH-9348](https://issues.redhat.com//browse/OSPRH-9348)