### PR TITLE
Enable Downstream trigger job in the architecture repo

### DIFF
--- a/create-zuul-jobs.py
+++ b/create-zuul-jobs.py
@@ -53,7 +53,8 @@ with open('./zuul.d/validations.yaml', 'w+') as zuul_jobs:
 _PROJECTS.sort()
 with open('./zuul.d/projects.yaml', 'w+') as zuul_projects:
     struct = [{'project': {'github-check': {'jobs': _PROJECTS},
-                           'github-gate': {'jobs': _PROJECTS}
+                           'github-gate': {'jobs': _PROJECTS},
+                           'github-experimental-trigger': {'jobs': ['architecture-downstream-va-hci-trigger-job']}
                            }
                }
               ]

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -18,5 +18,8 @@
       - rhoso-architecture-validate-uni05epsilon
       - rhoso-architecture-validate-uni06zeta
       - rhoso-architecture-validate-uni07eta
+    github-experimental-trigger:
+      jobs:
+      - architecture-downstream-va-hci-trigger-job
     github-gate:
       jobs: *id001

--- a/zuul.d/trigger-jobs.yaml
+++ b/zuul.d/trigger-jobs.yaml
@@ -1,0 +1,14 @@
+- job:
+    name: architecture-downstream-va-hci-trigger-job
+    parent: downstream-va-hci-trigger-job
+    description: |
+      This job will trigger a VA HCI job downstream.
+      We can invoke this job by adding following comment
+      `\trigger github-experimental` in the github pull request comment.
+      These jobs runs in github-experimental-trigger pipeline.
+    files:
+      - ^automation/vars/hci.yaml
+      - ^lib
+      - ^examples/common
+      - ^examples/dt/hci
+      - ^va/hci


### PR DESCRIPTION
In order to test VA HCI related changes, we used to run testproject in the downstream.

downstream-va-hci-trigger-job drops the need of running testproject for VA HCI related changes.

An developer can trigger the job by adding `trigger github-experimental` in the pull request comment section. The trigger job will create a review on
https://review.rdoproject.org/r/q/project:tripleo-downstream-trigger-nested-virt repo with proper depends-on with the origin pr and dependendent change.

From tripleo-downstream-trigger-nested-virt gerrit review, it will start VA HCI job downstream in rdo-check pipeline. Once the job finishes, It will post the results on the gerrit review. Devs can verify the results before merging it.

Note: It modifies create-zuul-jobs.py to include experimental jobs.