### PR TITLE
Move automation default vars into seperate scenario files

### DIFF
--- a/automation/vars/hci.yaml
+++ b/automation/vars/hci.yaml
@@ -1,0 +1,78 @@
+---
+vas:
+  hci:
+    stages:
+      - path: examples/va/hci/control-plane/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - path: examples/va/hci/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane --for condition=Ready
+            --timeout=60m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: ../control-plane.yaml
+
+      - path: examples/va/hci/edpm-pre-ceph/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=10m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset-pre-ceph.yaml
+
+      - path: examples/va/hci/edpm-pre-ceph/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=30m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment-pre-ceph.yaml
+        post_stage_run:
+          - name: Deploy Ceph
+            type: playbook
+            source: "../../playbooks/ceph.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+
+      - path: examples/va/hci
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=10m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: edpm-nodeset-values-post-ceph
+            src_file: values.yaml
+        build_output: nodeset-post-ceph.yaml
+
+      - path: examples/va/hci/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=40m
+        values:
+          - name: edpm-deployment-values-post-ceph
+            src_file: values.yaml
+        build_output: deployment-post-ceph.yaml

--- a/automation/vars/nfv-ovs-dpdk-sriov-hci.yaml
+++ b/automation/vars/nfv-ovs-dpdk-sriov-hci.yaml
@@ -1,0 +1,78 @@
+---
+vas:
+  nfv-ovs-dpdk-sriov-hci:
+    stages:
+      - path: examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/control-plane/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - path: examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane --for condition=Ready
+            --timeout=60m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: ../control-plane.yaml
+
+      - path: examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=60m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset-pre-ceph.yaml
+
+      - path: examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=60m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment-pre-ceph.yaml
+        post_stage_run:
+          - name: Deploy Ceph
+            type: playbook
+            source: "../../playbooks/ceph.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+
+      - path: examples/dt/nfv/nfv-ovs-dpdk-sriov-hci
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=60m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: edpm-nodeset-values-post-ceph
+            src_file: values.yaml
+        build_output: nodeset-post-ceph.yaml
+
+      - path: examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=60m
+        values:
+          - name: edpm-deployment-values-post-ceph
+            src_file: values.yaml
+        build_output: deployment-post-ceph.yaml

--- a/automation/vars/ovs-dpdk-sriov.yaml
+++ b/automation/vars/ovs-dpdk-sriov.yaml
@@ -1,0 +1,49 @@
+---
+vas:
+  ovs-dpdk-sriov:
+    stages:
+      - path: examples/va/nfv/ovs-dpdk-sriov/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=60s
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - path: examples/va/nfv/ovs-dpdk-sriov
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane --for condition=Ready
+            --timeout=1200s
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+
+      - path: examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=60m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset.yaml
+
+      - path: examples/va/nfv/ovs-dpdk-sriov/edpm/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=60m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment.yaml

--- a/automation/vars/ovs-dpdk.yaml
+++ b/automation/vars/ovs-dpdk.yaml
@@ -1,0 +1,49 @@
+---
+vas:
+  ovs-dpdk:
+    stages:
+      - path: examples/va/nfv/ovs-dpdk/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=60s
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - path: examples/va/nfv/ovs-dpdk
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane --for condition=Ready
+            --timeout=600s
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+
+      - path: examples/va/nfv/ovs-dpdk/edpm/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=60m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset.yaml
+
+      - path: examples/va/nfv/ovs-dpdk/edpm/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=60m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment.yaml

--- a/automation/vars/sriov.yaml
+++ b/automation/vars/sriov.yaml
@@ -1,0 +1,49 @@
+---
+vas:
+  sriov:
+    stages:
+      - path: examples/va/nfv/sriov/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=60s
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - path: examples/va/nfv/sriov
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane --for condition=Ready
+            --timeout=600s
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+
+      - path: examples/va/nfv/sriov/edpm/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=60m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset.yaml
+
+      - path: examples/va/nfv/sriov/edpm/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=60m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment.yaml

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -5,11 +5,16 @@
       - rhoso-architecture-validate-bgp
       - rhoso-architecture-validate-bgp_dt01
       - rhoso-architecture-validate-hci
+      - rhoso-architecture-validate-hci
+      - rhoso-architecture-validate-nfv-ovs-dpdk-sriov-hci
       - rhoso-architecture-validate-nfv-ovs-dpdk-sriov-hci
       - rhoso-architecture-validate-osasinfra
       - rhoso-architecture-validate-ovs-dpdk
+      - rhoso-architecture-validate-ovs-dpdk
+      - rhoso-architecture-validate-ovs-dpdk-sriov
       - rhoso-architecture-validate-ovs-dpdk-sriov
       - rhoso-architecture-validate-pidone
+      - rhoso-architecture-validate-sriov
       - rhoso-architecture-validate-sriov
       - rhoso-architecture-validate-uni01alpha
       - rhoso-architecture-validate-uni02beta

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -41,6 +41,33 @@
       cifmw_architecture_scenario: hci
 - job:
     files:
+    - examples/va/hci
+    - examples/va/hci/control-plane
+    - examples/va/hci/control-plane/nncp
+    - examples/va/hci/deployment
+    - examples/va/hci/edpm-pre-ceph/deployment
+    - examples/va/hci/edpm-pre-ceph/nodeset
+    - lib
+    - va/hci
+    name: rhoso-architecture-validate-hci
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: hci
+- job:
+    files:
+    - examples/dt/nfv/nfv-ovs-dpdk-sriov-hci
+    - examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/control-plane
+    - examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/control-plane/nncp
+    - examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/deployment
+    - examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/deployment
+    - examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset
+    - lib
+    name: rhoso-architecture-validate-nfv-ovs-dpdk-sriov-hci
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: nfv-ovs-dpdk-sriov-hci
+- job:
+    files:
     - examples/dt/nfv/nfv-ovs-dpdk-sriov-hci
     - examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/control-plane
     - examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/control-plane/nncp
@@ -80,6 +107,30 @@
       cifmw_architecture_scenario: ovs-dpdk
 - job:
     files:
+    - automation/mocks/ovs-dpdk.yaml
+    - examples/va/nfv/ovs-dpdk
+    - examples/va/nfv/ovs-dpdk/edpm/deployment
+    - examples/va/nfv/ovs-dpdk/edpm/nodeset
+    - examples/va/nfv/ovs-dpdk/nncp
+    - lib
+    name: rhoso-architecture-validate-ovs-dpdk
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: ovs-dpdk
+- job:
+    files:
+    - automation/mocks/ovs-dpdk-sriov.yaml
+    - examples/va/nfv/ovs-dpdk-sriov
+    - examples/va/nfv/ovs-dpdk-sriov/edpm/deployment
+    - examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset
+    - examples/va/nfv/ovs-dpdk-sriov/nncp
+    - lib
+    name: rhoso-architecture-validate-ovs-dpdk-sriov
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: ovs-dpdk-sriov
+- job:
+    files:
     - automation/mocks/ovs-dpdk-sriov.yaml
     - examples/va/nfv/ovs-dpdk-sriov
     - examples/va/nfv/ovs-dpdk-sriov/edpm/deployment
@@ -104,6 +155,18 @@
     vars:
       cifmw_architecture_scenario: pidone
       cifmw_networking_env_def_file: automation/net-env/pidone.yaml
+- job:
+    files:
+    - automation/mocks/sriov.yaml
+    - examples/va/nfv/sriov
+    - examples/va/nfv/sriov/edpm/deployment
+    - examples/va/nfv/sriov/edpm/nodeset
+    - examples/va/nfv/sriov/nncp
+    - lib
+    name: rhoso-architecture-validate-sriov
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: sriov
 - job:
     files:
     - automation/mocks/sriov.yaml


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/architecture/pull/374 adds the trigger job which will run different Baremetal VA jobs downstream on different architecture file changes.

Currently automation/vars/default.yaml contains different multiple scenarios, stored in a single file. Trigger job may run unwanted jobs downstream without testing the proper architecture changes.

By moving automations vars into different scenario files allow us to run selective trigger job and test the proper prs.