### PR TITLE
Add NFS network for Manila to uni04delta

### DIFF
--- a/automation/net-env/uni04delta.yaml
+++ b/automation/net-env/uni04delta.yaml
@@ -55,6 +55,16 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 123
+      nfs:
+        interface_name: eth1.124
+        ip_v4: 172.21.0.111
+        mac_addr: '52:54:00:1b:1c:e5'
+        mtu: 1500
+        network_name: nfs
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   ceph-1:
     hostname: ceph-1
     name: ceph-1
@@ -110,6 +120,16 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 123
+      nfs:
+        interface_name: eth1.124
+        ip_v4: 172.21.0.112
+        mac_addr: '52:54:00:1b:1c:e6'
+        mtu: 1500
+        network_name: nfs
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   ceph-2:
     hostname: ceph-2
     name: ceph-2
@@ -165,6 +185,16 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 123
+      nfs:
+        interface_name: eth1.124
+        ip_v4: 172.21.0.113
+        mac_addr: '52:54:00:1b:1c:e7'
+        mtu: 1500
+        network_name: nfs
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   controller-0:
     hostname: controller-0
     name: controller-0
@@ -235,6 +265,16 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 122
+      nfs:
+        interface_name: enp6s0.124
+        ip_v4: 172.21.0.10
+        mac_addr: '52:54:00:18:a1:f6'
+        mtu: 1500
+        network_name: nfs
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   ocp-1:
     hostname: osasinfra-master-1
     name: ocp-1
@@ -292,6 +332,16 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 122
+      nfs:
+        interface_name: enp6s0.124
+        ip_v4: 172.21.0.11
+        mac_addr: '52:54:00:18:a1:f7'
+        mtu: 1500
+        network_name: nfs
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   ocp-2:
     hostname: osasinfra-master-2
     name: ocp-2
@@ -349,6 +399,16 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 122
+      nfs:
+        interface_name: enp6s0.124
+        ip_v4: 172.21.0.12
+        mac_addr: '52:54:00:18:a1:f8'
+        mtu: 1500
+        network_name: nfs
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   networker-0:
     hostname: networker-0
     name: networker-0
@@ -447,6 +507,15 @@ instances:
         parent_interface: eth1
         skip_nm: false
         vlan_id: 22
+      nfs:
+        interface_name: eth1.24
+        ip_v4: 172.21.0.100
+        mac_addr: '52:54:00:1b:1c:e8'
+        mtu: 1500
+        network_name: nfs
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 24
   compute-1:
     hostname: compute-1
     name: compute-1
@@ -485,6 +554,15 @@ instances:
         parent_interface: eth1
         skip_nm: false
         vlan_id: 22
+      nfs:
+        interface_name: eth1.24
+        ip_v4: 172.21.0.101
+        mac_addr: '52:54:00:1b:1c:e9'
+        mtu: 1500
+        network_name: nfs
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 24
   compute-2:
     hostname: compute-2
     name: compute-2
@@ -523,6 +601,15 @@ instances:
         parent_interface: eth1
         skip_nm: false
         vlan_id: 22
+      nfs:
+        interface_name: eth1.24
+        ip_v4: 172.21.0.102
+        mac_addr: '52:54:00:1b:1c:e0'
+        mtu: 1500
+        network_name: nfs
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 24
 networks:
   ctlplane:
     dns_v4:
@@ -716,4 +803,37 @@ networks:
             start_host: 100
         ipv6_ranges: []
     vlan_id: 122
+  nfs:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1496
+    network_name: nfs
+    network_v4: 172.21.0.0/24
+    search_domain: nfs.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.21.0.90
+            end_host: 90
+            length: 11
+            start: 172.21.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.21.0.70
+            end_host: 70
+            length: 41
+            start: 172.21.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.21.0.250
+            end_host: 250
+            length: 151
+            start: 172.21.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 124
 routers: {}

--- a/dt/uni04delta/kustomization.yaml
+++ b/dt/uni04delta/kustomization.yaml
@@ -17,9 +17,9 @@ transformers:
         create: true
 
 components:
-  - ../../lib/networking/metallb
-  - ../../lib/networking/netconfig
-  - ../../lib/networking/nad
+  - networking/metallb
+  - networking/netconfig
+  - networking/nad
   - ../../lib/control-plane
 
 patches:

--- a/dt/uni04delta/networking/kustomization.yaml
+++ b/dt/uni04delta/networking/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+components:
+  - metallb
+  - nad
+  - netconfig

--- a/dt/uni04delta/networking/metallb/kustomization.yaml
+++ b/dt/uni04delta/networking/metallb/kustomization.yaml
@@ -1,0 +1,181 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - metallb_l2advertisement.yaml
+  - ocp_ip_pools.yaml
+
+patches:
+  - target:
+      kind: IPAddressPool
+      labelSelector: "osp/lb-addresses-type=standard"
+    path: ocp_ip_pool_template.yaml
+
+replacements:
+  # IPAddressPool addresses
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.lb_addresses
+    targets:
+      - select:
+          kind: IPAddressPool
+          name: ctlplane
+        fieldPaths:
+          - spec.addresses
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.lb_addresses
+    targets:
+      - select:
+          kind: IPAddressPool
+          name: internalapi
+        fieldPaths:
+          - spec.addresses
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.lb_addresses
+    targets:
+      - select:
+          kind: IPAddressPool
+          name: storage
+        fieldPaths:
+          - spec.addresses
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.lb_addresses
+    targets:
+      - select:
+          kind: IPAddressPool
+          name: tenant
+        fieldPaths:
+          - spec.addresses
+
+  # Loadbalancer address pools
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.lb_addresses
+    targets:
+      - select:
+          group: metallb.io
+          kind: IPAddressPool
+          name: ctlplane
+        fieldPaths:
+          - spec.addresses
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.lb_addresses
+    targets:
+      - select:
+          group: metallb.io
+          kind: IPAddressPool
+          name: internalapi
+        fieldPaths:
+          - spec.addresses
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.lb_addresses
+    targets:
+      - select:
+          group: metallb.io
+          kind: IPAddressPool
+          name: tenant
+        fieldPaths:
+          - spec.addresses
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.lb_addresses
+    targets:
+      - select:
+          group: metallb.io
+          kind: IPAddressPool
+          name: ctlplane
+        fieldPaths:
+          - spec.addresses
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.lb_addresses
+    targets:
+      - select:
+          group: metallb.io
+          kind: IPAddressPool
+          name: storage
+        fieldPaths:
+          - spec.addresses
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.lb_addresses
+    targets:
+      - select:
+          group: metallb.io
+          kind: IPAddressPool
+          name: nfs
+        fieldPaths:
+          - spec.addresses
+
+  # Loadbalancer interfaces
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bridgeName
+    targets:
+      - select:
+          group: metallb.io
+          kind: L2Advertisement
+          name: ctlplane
+        fieldPaths:
+          - spec.interfaces.0
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.iface
+    targets:
+      - select:
+          group: metallb.io
+          kind: L2Advertisement
+          name: tenant
+        fieldPaths:
+          - spec.interfaces.0
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.iface
+    targets:
+      - select:
+          group: metallb.io
+          kind: L2Advertisement
+          name: storage
+        fieldPaths:
+          - spec.interfaces.0
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.iface
+    targets:
+      - select:
+          group: metallb.io
+          kind: L2Advertisement
+          name: internalapi
+        fieldPaths:
+          - spec.interfaces.0
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.iface
+    targets:
+      - select:
+          group: metallb.io
+          kind: L2Advertisement
+          name: nfs
+        fieldPaths:
+          - spec.interfaces.0

--- a/dt/uni04delta/networking/metallb/metallb_l2advertisement.yaml
+++ b/dt/uni04delta/networking/metallb/metallb_l2advertisement.yaml
@@ -1,0 +1,59 @@
+#
+# Additional advertisements can be added here if needed for other networks
+#
+
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: ctlplane
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - ctlplane
+  interfaces:
+    - _replaced_
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: internalapi
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - internalapi
+  interfaces:
+    - _replaced_
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: storage
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - storage
+  interfaces:
+    - _replaced_
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: tenant
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - tenant
+  interfaces:
+    - _replaced_
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: nfs
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - nfs
+  interfaces:
+    - _replaced_

--- a/dt/uni04delta/networking/metallb/ocp_ip_pool_template.yaml
+++ b/dt/uni04delta/networking/metallb/ocp_ip_pool_template.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: _ignored_
+spec:
+  addresses: []

--- a/dt/uni04delta/networking/metallb/ocp_ip_pools.yaml
+++ b/dt/uni04delta/networking/metallb/ocp_ip_pools.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: ctlplane
+  labels:
+    osp/lb-addresses-type: standard
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: internalapi
+  labels:
+    osp/lb-addresses-type: standard
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: storage
+  labels:
+    osp/lb-addresses-type: standard
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: tenant
+  labels:
+    osp/lb-addresses-type: standard
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: nfs
+  labels:
+    osp/lb-addresses-type: standard

--- a/dt/uni04delta/networking/nad/kustomization.yaml
+++ b/dt/uni04delta/networking/nad/kustomization.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ocp_networks_netattach.yaml
+
+patches:
+  - target:
+      kind: NetworkAttachmentDefinition
+      labelSelector: "osp/net-attach-def-type=standard"
+    path: ocp_network_template.yaml
+
+replacements:
+  # NetworkAttachmentDefinition JSON config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: ctlplane
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: internalapi
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: storage
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: tenant
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.datacentre.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: datacentre
+        fieldPaths:
+          - spec.config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: nfs
+        fieldPaths:
+          - spec.config

--- a/dt/uni04delta/networking/nad/ocp_network_template.yaml
+++ b/dt/uni04delta/networking/nad/ocp_network_template.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: nmstate.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: _ignored_
+spec:
+  config: |
+    _replaced_

--- a/dt/uni04delta/networking/nad/ocp_networks_netattach.yaml
+++ b/dt/uni04delta/networking/nad/ocp_networks_netattach.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ctlplane
+  labels:
+    osp/net: ctlplane
+    osp/net-attach-def-type: standard
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: internalapi
+  labels:
+    osp/net: internalapi
+    osp/net-attach-def-type: standard
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: storage
+  labels:
+    osp/net: storage
+    osp/net-attach-def-type: standard
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: tenant
+  labels:
+    osp/net: tenant
+    osp/net-attach-def-type: standard
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: datacentre
+  labels:
+    osp/net: datacentre
+    osp/net-attach-def-type: standard
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: nfs
+  labels:
+    osp/net: nfs
+    osp/net-attach-def-type: standard

--- a/dt/uni04delta/networking/netconfig/kustomization.yaml
+++ b/dt/uni04delta/networking/netconfig/kustomization.yaml
@@ -1,0 +1,175 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - netconfig.yaml
+
+replacements:
+  # NetConfig dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=ctlplane].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=internalapi].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.external.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=external].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storage].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=tenant].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=nfs].dnsDomain
+
+  # NetConfig MTU
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=ctlplane].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=internalapi].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.external.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=external].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storage].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=tenant].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=nfs].mtu
+
+  # NetConfig subnets
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=ctlplane].subnets
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=internalapi].subnets
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.external.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=external].subnets
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storage].subnets
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=tenant].subnets
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=nfs].subnets

--- a/dt/uni04delta/networking/netconfig/netconfig.yaml
+++ b/dt/uni04delta/networking/netconfig/netconfig.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: network.openstack.org/v1beta1
+kind: NetConfig
+metadata:
+  name: netconfig
+  namespace: openstack
+spec:
+  networks:
+    - dnsDomain: _replaced_
+      name: ctlplane
+      subnets:
+        - _replaced_
+      mtu: 1500
+    - dnsDomain: _replaced_
+      name: internalapi
+      subnets:
+        - _replaced_
+      mtu: 1500
+    - dnsDomain: _replaced_
+      name: external
+      subnets:
+        - _replaced_
+      mtu: 1500
+    - dnsDomain: _replaced_
+      name: storage
+      subnets:
+        - _replaced_
+      mtu: 1500
+    - dnsDomain: _replaced_
+      name: tenant
+      subnets:
+        - _replaced_
+      mtu: 1500
+    - dnsDomain: _replaced_
+      name: nfs
+      subnets:
+        - _replaced_
+      mtu: 1500

--- a/dt/uni04delta/nncp/kustomization.yaml
+++ b/dt/uni04delta/nncp/kustomization.yaml
@@ -1,0 +1,522 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ocp_nodes_nncp.yaml
+
+patches:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      labelSelector: "osp/nncm-config-type=standard"
+    path: ocp_node_template.yaml
+
+replacements:
+  # Common network interfaces and vlans
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].vlan.base-iface
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].vlan.id
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.mtu
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].vlan.base-iface
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].vlan.id
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.mtu
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].vlan.base-iface
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].vlan.id
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.mtu
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].vlan.base-iface
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].vlan.id
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.mtu
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].mtu
+  # ctlplane type is ethernet (not vlan)
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=ethernet].name
+          - spec.desiredState.interfaces.[type=linux-bridge].bridge.port.0.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.mtu
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=ethernet].mtu
+          - spec.desiredState.interfaces.[type=linux-bridge].mtu
+
+  # Static Node IPs: node-0
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.internalapi_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.tenant_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.storage_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.nfs_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].ipv4.address.0.ip
+
+  # Static Node IPs: node-1
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.internalapi_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.tenant_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.storage_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.nfs_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].ipv4.address.0.ip
+
+  # Static Node IPs: node-2
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.internalapi_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.tenant_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.storage_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.nfs_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].ipv4.address.0.ip
+
+  # prefix-length: node-0
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].ipv4.address.0.prefix-length
+
+  # prefix-length: node-1
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].ipv4.address.0.prefix-length
+
+  # prefix-length: node-2
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].ipv4.address.0.prefix-length
+
+  # Node names
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  # DNS
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.dns-resolver.config
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.dns-resolver.config
+
+  # Routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bridgeName
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].name

--- a/dt/uni04delta/nncp/ocp_node_template.yaml
+++ b/dt/uni04delta/nncp/ocp_node_template.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: _ignored_
+spec:
+  desiredState:
+    dns-resolver:
+      config:
+        search: []
+        server: []
+    routes:
+      config: []
+    route-rules:
+      config: []
+    interfaces:
+      - description: internalapi vlan interface
+        ipv4:
+          address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+          enabled: true
+          dhcp: false
+        ipv6:
+          enabled: false
+        name: internalapi
+        state: up
+        type: vlan
+        vlan:
+          base-iface: _replaced_
+          id: _replaced_
+        mtu: 1500
+      - description: storage vlan interface
+        ipv4:
+          address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+          enabled: true
+          dhcp: false
+        ipv6:
+          enabled: false
+        name: storage
+        state: up
+        type: vlan
+        vlan:
+          base-iface: _replaced_
+          id: _replaced_
+        mtu: 1500
+      - description: tenant vlan interface
+        ipv4:
+          address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+          enabled: true
+          dhcp: false
+        ipv6:
+          enabled: false
+        name: tenant
+        state: up
+        type: vlan
+        vlan:
+          base-iface: _replaced_
+          id: _replaced_
+        mtu: 1500
+      - description: nfs vlan interface
+        ipv4:
+          address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+          enabled: true
+          dhcp: false
+        ipv6:
+          enabled: false
+        name: nfs
+        state: up
+        type: vlan
+        vlan:
+          base-iface: _replaced_
+          id: _replaced_
+        mtu: 1500
+      - description: ctlplane interface
+        name: _replaced_
+        state: up
+        type: ethernet
+        mtu: 1500
+      - description: linux-bridge over ctlplane interface
+        ipv4:
+          address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+          enabled: true
+          dhcp: false
+        ipv6:
+          enabled: false
+        name: _replaced_
+        state: up
+        type: linux-bridge
+        bridge:
+          options:
+            stp:
+              enabled: false
+          port:
+            - name: _replaced_
+              vlan: {}
+        mtu: 1500
+  nodeSelector:
+    kubernetes.io/hostname: _replaced_
+    node-role.kubernetes.io/worker: ""

--- a/dt/uni04delta/nncp/ocp_nodes_nncp.yaml
+++ b/dt/uni04delta/nncp/ocp_nodes_nncp.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-0
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-1
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-2
+  labels:
+    osp/nncm-config-type: standard

--- a/examples/dt/uni04delta/control-plane/nncp/kustomization.yaml
+++ b/examples/dt/uni04delta/control-plane/nncp/kustomization.yaml
@@ -17,7 +17,7 @@ transformers:
           create: true
 
 components:
-  - ../../../../../lib/nncp
+  - ../../../../../dt/uni04delta/nncp
 
 resources:
   - values.yaml

--- a/examples/dt/uni04delta/control-plane/nncp/values.yaml
+++ b/examples/dt/uni04delta/control-plane/nncp/values.yaml
@@ -11,23 +11,26 @@ data:
     "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
 
   node_0:
-    name: master-0
+    name: node-0
     internalapi_ip: 172.17.0.5
     tenant_ip: 172.19.0.5
     ctlplane_ip: 192.168.122.10
     storage_ip: 172.18.0.5
+    nfs_ip: 172.21.0.5
   node_1:
-    name: master-1
+    name: node-1
     internalapi_ip: 172.17.0.6
     tenant_ip: 172.19.0.6
     ctlplane_ip: 192.168.122.11
     storage_ip: 172.18.0.6
+    nfs_ip: 172.21.0.6
   node_2:
-    name: master-2
+    name: node-2
     internalapi_ip: 172.17.0.7
     tenant_ip: 172.19.0.7
     ctlplane_ip: 192.168.122.12
     storage_ip: 172.18.0.7
+    nfs_ip: 172.21.0.7
 
   ctlplane:
     dnsDomain: ctlplane.example.com
@@ -124,6 +127,37 @@ data:
           "range": "172.18.0.0/24",
           "range_start": "172.18.0.30",
           "range_end": "172.18.0.70"
+        }
+      }
+
+  nfs:
+    dnsDomain: nfs.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.21.0.250
+            start: 172.21.0.100
+        cidr: 172.21.0.0/24
+        gateway: 172.21.0.1
+        name: subnet1
+        vlan: 24
+    mtu: 1500
+    prefix-length: 24
+    iface: nfs
+    vlan: 24
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.21.0.80-172.21.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "nfs",
+        "type": "macvlan",
+        "master": "nfs",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.21.0.0/24",
+          "range_start": "172.21.0.100",
+          "range_end": "172.21.0.250"
         }
       }
 

--- a/examples/dt/uni04delta/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni04delta/edpm-pre-ceph/nodeset/values.yaml
@@ -96,6 +96,8 @@ data:
         subnetName: subnet1
       - name: storagemgmt
         subnetName: subnet1
+      - name: nfs
+        subnetName: subnet1
 
     nodes:
       edpm-ceph-0:
@@ -111,6 +113,8 @@ data:
             subnetName: subnet1
           - name: storageMgmt
             subnetName: subnet1
+          - name: nfs
+            subnetName: subnet1
       edpm-ceph-1:
         ansible:
           ansibleHost: 192.168.122.106
@@ -124,6 +128,8 @@ data:
             subnetName: subnet1
           - name: storageMgmt
             subnetName: subnet1
+          - name: nfs
+            subnetName: subnet1
       edpm-ceph-2:
         ansible:
           ansibleHost: 192.168.122.107
@@ -136,6 +142,8 @@ data:
           - name: storage
             subnetName: subnet1
           - name: storageMgmt
+            subnetName: subnet1
+          - name: nfs
             subnetName: subnet1
 
     services:

--- a/examples/dt/uni04delta/values.yaml
+++ b/examples/dt/uni04delta/values.yaml
@@ -102,6 +102,8 @@ data:
         subnetName: subnet1
       - name: storagemgmt
         subnetName: subnet1
+      - name: nfs
+        subnetName: subnet1
 
     nodes:
       edpm-compute-0:
@@ -119,6 +121,8 @@ data:
             subnetName: subnet1
           - name: tenant
             subnetName: subnet1
+          - name: nfs
+            subnetName: subnet1
       edpm-compute-1:
         ansible:
           ansibleHost: 192.168.122.101
@@ -133,6 +137,8 @@ data:
           - name: storage
             subnetName: subnet1
           - name: tenant
+            subnetName: subnet1
+          - name: nfs
             subnetName: subnet1
 
     services:


### PR DESCRIPTION
Manila Tempest tests need to connect to the share for Ganesha via a special (openstack) network [1].

This patch adds the NFS storage network with VLAN 24 and range 172.21.0.0/24 in uni04delta. The NFS network is connected to Ceph and Compute EDPM nodes. A NNCP, NAD, L2Advertisement and IPAddressPool are defined for the NFS network so that a pod in k8s can connect to it; such as the tempest pod which will perform the storage tests and the manilaShares pod(s).

In order to make these changes, uni04delta now keeps its own copy of the nncp and networking directories since they differ (by the new network) from the generic ones in the lib directory.

[1] https://opendev.org/openstack/manila-tempest-plugin/src/branch/master/manila_tempest_tests/config.py#L99

Jira: https://issues.redhat.com/browse/OSPRH-7417
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2273