### PR TITLE
Ensure we have one scenario per automation file

### DIFF
--- a/.ci/automation-schema.yaml
+++ b/.ci/automation-schema.yaml
@@ -4,7 +4,7 @@
 # We are using yamale to validate files
 # https://github.com/23andMe/Yamale
 ---
-vas: map(include('_architecture'), key=str())
+vas: map(include('_architecture'), key=str(), min=1, max=1)
 
 ---
 # Define various nested types

--- a/.ci/validate-schema-paths.py
+++ b/.ci/validate-schema-paths.py
@@ -24,6 +24,8 @@ class TestSchema():
             content = yaml.safe_load(fh)
         for scenario in content['vas']:
             print(f'  Checking scenario: {scenario}')
+            assert (rel.name == f'{scenario}.yaml'), \
+            f'!! {rel.name} does not match {scenario}.yaml'
             self.__validate(content['vas'][scenario])
 
     def __validate(self, scenario):


### PR DESCRIPTION
This is in addition to a coming PR, #383. This change here is allowing
to ensure we follow those practices:
- only one scenario per file
- filename matches "scenario_name.yaml" pattern

