### PR TITLE
Add 'local' network type in the Control Plane CRs

### DIFF
--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -173,5 +173,5 @@ data:
       ovn_emit_need_to_frag = true
 
       [ml2]
-      type_drivers = geneve,vxlan,vlan,flat
+      type_drivers = geneve,vxlan,vlan,flat,local
       tenant_network_types = geneve,flat

--- a/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
@@ -100,7 +100,7 @@ data:
       [ovn]
       ovn_emit_need_to_frag = false
       [ml2]
-      type_drivers = geneve,vlan,flat
+      type_drivers = geneve,vlan,flat,local
       tenant_network_types = vlan,flat
       [ml2_type_vlan]
       network_vlan_ranges = datacentre:1000:2000

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -101,7 +101,7 @@ data:
       [ovn]
       ovn_emit_need_to_frag = true
       [ml2]
-      type_drivers = geneve,vlan,flat
+      type_drivers = geneve,vlan,flat,local
       tenant_network_types = vlan,flat
       [ml2_type_vlan]
       network_vlan_ranges = datacentre:1000:2000

--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -133,7 +133,7 @@ data:
       ovn_emit_need_to_frag = true
       enable_distributed_floating_ip = false
       [ml2]
-      type_drivers = geneve,vlan,flat
+      type_drivers = geneve,vlan,flat,local
       tenant_network_types = geneve,vlan
       extension_drivers = qos,port_security,dns_domain_ports
       path_mtu = 1400

--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -125,6 +125,6 @@ data:
       ovn_emit_need_to_frag = true
 
       [ml2]
-      type_drivers = geneve,vxlan,vlan,flat
+      type_drivers = geneve,vxlan,vlan,flat,local
       tenant_network_types = geneve,flat,vlan
       path_mtu = 1400


### PR DESCRIPTION
Lack of this 'local' network type breaks somehow some Horizon integration tests as this is first choice in the Horizon UI. From Neutron PoV there is no reason not to load this driver so lets enable that driver in the Neutron's config.