### PR TITLE
[Uni02Beta] Install conntrack on EDPM nodes

### DIFF
--- a/examples/dt/uni02beta/values.yaml
+++ b/examples/dt/uni02beta/values.yaml
@@ -74,6 +74,10 @@ data:
 
         gather_facts: false
 
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+
     networks:
       - defaultRoute: true
         name: ctlplane


### PR DESCRIPTION
Some tobiko tests need the conntrack-tools package installed on the EDPM nodes.