### PR TITLE
Add Swift network for RGW to HCI scenario

### DIFF
--- a/examples/va/hci/control-plane/nncp/kustomization.yaml
+++ b/examples/va/hci/control-plane/nncp/kustomization.yaml
@@ -18,7 +18,7 @@ transformers:
         create: true
 
 components:
-  - ../../../../../lib/nncp
+  - ../../../../../va/hci/nncp
 
 resources:
   - values.yaml

--- a/examples/va/hci/control-plane/nncp/values.yaml
+++ b/examples/va/hci/control-plane/nncp/values.yaml
@@ -14,18 +14,21 @@ data:
     tenant_ip: 172.19.0.5
     ctlplane_ip: 192.168.122.10
     storage_ip: 172.18.0.5
+    swift_ip: 172.22.0.5
   node_1:
     name: ostest-master-1
     internalapi_ip: 172.17.0.6
     tenant_ip: 172.19.0.6
     ctlplane_ip: 192.168.122.11
     storage_ip: 172.18.0.6
+    swift_ip: 172.22.0.6
   node_2:
     name: ostest-master-2
     internalapi_ip: 172.17.0.7
     tenant_ip: 172.19.0.7
     ctlplane_ip: 192.168.122.12
     storage_ip: 172.18.0.7
+    swift_ip: 172.22.0.7
 
   # networks
   ctlplane:
@@ -172,6 +175,36 @@ data:
         gateway: 10.0.0.1
         name: subnet1
     mtu: 1500
+  swift:
+    dnsDomain: swift.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.22.0.250
+            start: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
+        name: subnet1
+        vlan: 25
+    mtu: 1500
+    prefix-length: 24
+    iface: swift
+    vlan: 25
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.22.0.80-172.22.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "swift",
+        "type": "macvlan",
+        "master": "swift",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.22.0.0/24",
+          "range_start": "172.22.0.100",
+          "range_end": "172.22.0.250"
+        }
+      }
   datacentre:
     net-attach-def: |
       {

--- a/lib/nncp/ocp_nodes_nncp.yaml
+++ b/lib/nncp/ocp_nodes_nncp.yaml
@@ -5,6 +5,7 @@ metadata:
   name: node-0
   labels:
     osp/nncm-config-type: standard
+    osp/nncm-node: "0"
 ---
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
@@ -12,6 +13,7 @@ metadata:
   name: node-1
   labels:
     osp/nncm-config-type: standard
+    osp/nncm-node: "1"
 ---
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
@@ -19,3 +21,4 @@ metadata:
   name: node-2
   labels:
     osp/nncm-config-type: standard
+    osp/nncm-node: "2"

--- a/va/hci/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/va/hci/edpm-post-ceph/nodeset/kustomization.yaml
@@ -20,6 +20,7 @@ transformers:
 components:
   - ../../../../lib/control-plane
   - ../../../../lib/dataplane/nodeset
+  - ../../../../va/hci/nodeset
 
 resources:
   - ceph_secret.yaml

--- a/va/hci/kustomization.yaml
+++ b/va/hci/kustomization.yaml
@@ -19,8 +19,11 @@ transformers:
 
 components:
   - ../../lib/networking/metallb
+  - networking/metallb
   - ../../lib/networking/netconfig
+  - networking/netconfig
   - ../../lib/networking/nad
+  - networking/nad
   - ../../lib/control-plane
 
 # Add storagemgmt network template, as it is needed for CephHCI

--- a/va/hci/networking/metallb/kustomization.yaml
+++ b/va/hci/networking/metallb/kustomization.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - metallb_l2advertisement.yaml
+  - ocp_ip_pools.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.swift.lb_addresses
+    targets:
+      - select:
+          group: metallb.io
+          kind: IPAddressPool
+          name: swift
+        fieldPaths:
+          - spec.addresses
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.swift.iface
+    targets:
+      - select:
+          group: metallb.io
+          kind: L2Advertisement
+          name: swift
+        fieldPaths:
+          - spec.interfaces.0
+        options:
+          create: true

--- a/va/hci/networking/metallb/metallb_l2advertisement.yaml
+++ b/va/hci/networking/metallb/metallb_l2advertisement.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: swift
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - swift
+  interfaces:
+    - _replaced_

--- a/va/hci/networking/metallb/ocp_ip_pools.yaml
+++ b/va/hci/networking/metallb/ocp_ip_pools.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: swift
+  labels:
+    osp/lb-addresses-type: standard

--- a/va/hci/networking/nad/kustomization.yaml
+++ b/va/hci/networking/nad/kustomization.yaml
@@ -17,6 +17,19 @@ transformers:
         kind: Namespace
         create: true
 
-components:
-  - ../../../../lib/dataplane/nodeset
-  - ../../../../va/hci/nodeset
+resources:
+  - ocp_networks_netattach.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.swift.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: swift
+        fieldPaths:
+          - spec.config
+        options:
+          create: true

--- a/va/hci/networking/nad/ocp_networks_netattach.yaml
+++ b/va/hci/networking/nad/ocp_networks_netattach.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: swift
+  labels:
+    osp/net: swift
+    osp/net-attach-def-type: standard

--- a/va/hci/networking/netconfig/kustomization.yaml
+++ b/va/hci/networking/netconfig/kustomization.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      kind: NetConfig
+    patch: |-
+      - op: add
+        path: /spec/networks/-
+        value:
+          name: swift
+          mtu: 1500
+          dnsDomain: _replaced_
+          subnets:
+            - _replaced_
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.swift.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=swift].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.swift.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=swift].subnets

--- a/va/hci/nncp/kustomization.yaml
+++ b/va/hci/nncp/kustomization.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../lib/nncp
+
+patches:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      labelSelector: "osp/nncm-config-type=standard"
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: swift vlan interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          name: swift
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+          mtu: 1500
+
+replacements:
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.swift.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=swift].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.swift.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=swift].vlan.id
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.swift_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          labelSelector: "osp/nncm-node=0"
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=swift].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.swift_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          labelSelector: "osp/nncm-node=1"
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=swift].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.swift_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          labelSelector: "osp/nncm-node=2"
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=swift].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.swift.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=swift].ipv4.address.0.prefix-length

--- a/va/hci/nodeset/kustomization.yaml
+++ b/va/hci/nodeset/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+    patch: |-
+      - op: add
+        path: /spec/nodeTemplate/networks/-
+        value:
+          name: swift
+          subnetName: subnet1


### PR DESCRIPTION
When Ceph RGW is used, an endpoint for Swift storage is hosted not in a pod on k8s but on an EDPM node. Thus, a service hosted on an EDPM node will need to be accessed by cloud users from a separate network.

This patch adds the Swift storage network (swift) with VLAN 25 and range 172.22.0.0/24 in the HCI values example. The Swift network is configured on the HCI EDPM nodes and an NNCP, NAD, L2Advertisement and IPAddressPool are defined so that a pod in k8s can connect to it; such as the tempest pod which will perform object storage tests.

Jira: https://issues.redhat.com/browse/OSPRH-6675