### PR TITLE
Add NFS network for Manila to uni04delta

### DIFF
--- a/automation/net-env/uni04delta.yaml
+++ b/automation/net-env/uni04delta.yaml
@@ -55,6 +55,17 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 123
+      nfs:
+        interface_name: eth1.124
+        ip_v4: 172.21.0.111
+        mac_addr: "52:54:00:0e:e9:95"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: nfs
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   ceph-1:
     hostname: ceph-1
     name: ceph-1
@@ -110,6 +121,17 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 123
+      nfs:
+        interface_name: eth1.124
+        ip_v4: 172.21.0.112
+        mac_addr: "52:54:00:0e:e9:76"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: nfs
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   ceph-2:
     hostname: ceph-2
     name: ceph-2
@@ -165,6 +187,17 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 123
+      nfs:
+        interface_name: eth1.124
+        ip_v4: 172.21.0.113
+        mac_addr: "52:54:00:0e:e9:dc"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: nfs
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   controller-0:
     hostname: controller-0
     name: controller-0
@@ -235,6 +268,17 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 122
+      nfs:
+        interface_name: enp6s0.124
+        ip_v4: 172.21.0.10
+        mac_addr: "52:54:00:0e:be:0e"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: nfs
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   ocp-1:
     hostname: osasinfra-master-1
     name: ocp-1
@@ -292,6 +336,17 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 122
+      nfs:
+        interface_name: enp6s0.124
+        ip_v4: 172.21.0.11
+        mac_addr: "52:54:00:0e:be:25"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: nfs
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   ocp-2:
     hostname: osasinfra-master-2
     name: ocp-2
@@ -349,6 +404,17 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 122
+      nfs:
+        interface_name: enp6s0.124
+        ip_v4: 172.21.0.12
+        mac_addr: "52:54:00:0e:be:10"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: nfs
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
   networker-0:
     hostname: networker-0
     name: networker-0
@@ -447,6 +513,15 @@ instances:
         parent_interface: eth1
         skip_nm: false
         vlan_id: 22
+      nfs:
+        interface_name: eth1.24
+        ip_v4: 172.21.0.100
+        mac_addr: "52:54:00:0e:1c:d7"
+        mtu: 1500
+        network_name: nfs
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 24
   compute-1:
     hostname: compute-1
     name: compute-1
@@ -485,6 +560,15 @@ instances:
         parent_interface: eth1
         skip_nm: false
         vlan_id: 22
+      nfs:
+        interface_name: eth1.24
+        ip_v4: 172.21.0.101
+        mac_addr: "52:54:00:0e:1c:d5"
+        mtu: 1500
+        network_name: nfs
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 24
   compute-2:
     hostname: compute-2
     name: compute-2
@@ -523,6 +607,15 @@ instances:
         parent_interface: eth1
         skip_nm: false
         vlan_id: 22
+      nfs:
+        interface_name: eth1.24
+        ip_v4: 172.21.0.102
+        mac_addr: "52:54:00:0e:1c:d6"
+        mtu: 1500
+        network_name: nfs
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 24
 networks:
   ctlplane:
     dns_v4:
@@ -666,6 +759,39 @@ networks:
             start_host: 100
         ipv6_ranges: []
     vlan_id: 121
+  nfs:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: nfs
+    network_v4: 172.21.0.0/24
+    search_domain: nfs.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.21.0.90
+            end_host: 90
+            length: 11
+            start: 172.21.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.21.0.70
+            end_host: 70
+            length: 41
+            start: 172.21.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.21.0.250
+            end_host: 250
+            length: 151
+            start: 172.21.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 124
   storagemgmt:
     dns_v4: []
     dns_v6: []

--- a/dt/uni04delta/edpm-pre-ceph/nodeset/kustomization.yaml
+++ b/dt/uni04delta/edpm-pre-ceph/nodeset/kustomization.yaml
@@ -18,6 +18,7 @@ transformers:
 
 components:
   - ../../../../lib/dataplane/nodeset
+  - ../../../../dt/uni04delta/nodeset/ceph
 
 patches:
   - target:

--- a/dt/uni04delta/edpm/nodeset/kustomization.yaml
+++ b/dt/uni04delta/edpm/nodeset/kustomization.yaml
@@ -19,6 +19,7 @@ transformers:
 components:
   - ../../../../lib/control-plane
   - ../../../../lib/dataplane/nodeset
+  - ../../../../dt/uni04delta/nodeset/compute
 
 resources:
   - ceph_secret.yaml

--- a/dt/uni04delta/kustomization.yaml
+++ b/dt/uni04delta/kustomization.yaml
@@ -18,8 +18,10 @@ transformers:
 
 components:
   - ../../lib/networking/metallb
+  - networking/metallb
   - ../../lib/networking/netconfig
   - ../../lib/networking/nad
+  - networking/nad
   - ../../lib/control-plane
 
 patches:
@@ -33,6 +35,19 @@ patches:
         value:
           dnsDomain: _replaced_
           name: storagemgmt
+          subnets:
+            - _replaced_
+          mtu: 1500
+  - target:
+      version: v1beta1
+      kind: NetConfig
+      name: netconfig
+    patch: |-
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: nfs
           subnets:
             - _replaced_
           mtu: 1500
@@ -67,6 +82,36 @@ replacements:
           kind: NetConfig
         fieldPaths:
           - spec.networks.[name=storagemgmt].subnets
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=nfs].dnsDomain
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=nfs].mtu
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=nfs].subnets
 
   - source:
       kind: ConfigMap

--- a/dt/uni04delta/networking/metallb/kustomization.yaml
+++ b/dt/uni04delta/networking/metallb/kustomization.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - metallb_l2advertisement.yaml
+  - ocp_ip_pools.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.lb_addresses
+    targets:
+      - select:
+          group: metallb.io
+          kind: IPAddressPool
+          name: nfs
+        fieldPaths:
+          - spec.addresses
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.iface
+    targets:
+      - select:
+          group: metallb.io
+          kind: L2Advertisement
+          name: nfs
+        fieldPaths:
+          - spec.interfaces.0
+        options:
+          create: true

--- a/dt/uni04delta/networking/metallb/metallb_l2advertisement.yaml
+++ b/dt/uni04delta/networking/metallb/metallb_l2advertisement.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: nfs
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - nfs
+  interfaces:
+    - _replaced_

--- a/dt/uni04delta/networking/metallb/ocp_ip_pools.yaml
+++ b/dt/uni04delta/networking/metallb/ocp_ip_pools.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: nfs
+  labels:
+    osp/lb-addresses-type: standard

--- a/dt/uni04delta/networking/nad/kustomization.yaml
+++ b/dt/uni04delta/networking/nad/kustomization.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+resources:
+  - ocp_networks_netattach.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: nfs
+        fieldPaths:
+          - spec.config
+        options:
+          create: true

--- a/dt/uni04delta/networking/nad/ocp_networks_netattach.yaml
+++ b/dt/uni04delta/networking/nad/ocp_networks_netattach.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: nfs
+  labels:
+    osp/net: nfs
+    osp/net-attach-def-type: standard

--- a/dt/uni04delta/nncp/kustomization.yaml
+++ b/dt/uni04delta/nncp/kustomization.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../lib/nncp
+
+patches:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      labelSelector: "osp/nncm-config-type=standard"
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: nfs vlan interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          name: nfs
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+          mtu: 1500
+
+replacements:
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].vlan.id
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.nfs_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          labelSelector: "osp/nncm-node=0"
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.nfs_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          labelSelector: "osp/nncm-node=1"
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.nfs_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          labelSelector: "osp/nncm-node=2"
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.nfs.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=nfs].ipv4.address.0.prefix-length

--- a/dt/uni04delta/nodeset/ceph/kustomization.yaml
+++ b/dt/uni04delta/nodeset/ceph/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+    patch: |-
+      - op: add
+        path: /spec/nodeTemplate/networks/-
+        value:
+          name: nfs
+          subnetName: subnet1

--- a/dt/uni04delta/nodeset/compute/kustomization.yaml
+++ b/dt/uni04delta/nodeset/compute/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+    patch: |-
+      - op: add
+        path: /spec/nodeTemplate/networks/-
+        value:
+          name: nfs
+          subnetName: subnet1

--- a/examples/dt/uni04delta/control-plane/nncp/kustomization.yaml
+++ b/examples/dt/uni04delta/control-plane/nncp/kustomization.yaml
@@ -17,7 +17,7 @@ transformers:
           create: true
 
 components:
-  - ../../../../../lib/nncp
+  - ../../../../../dt/uni04delta/nncp
 
 resources:
   - values.yaml

--- a/examples/dt/uni04delta/control-plane/nncp/values.yaml
+++ b/examples/dt/uni04delta/control-plane/nncp/values.yaml
@@ -16,18 +16,21 @@ data:
     tenant_ip: 172.19.0.5
     ctlplane_ip: 192.168.122.10
     storage_ip: 172.18.0.5
+    nfs_ip: 172.21.0.5
   node_1:
     name: master-1
     internalapi_ip: 172.17.0.6
     tenant_ip: 172.19.0.6
     ctlplane_ip: 192.168.122.11
     storage_ip: 172.18.0.6
+    nfs_ip: 172.21.0.6
   node_2:
     name: master-2
     internalapi_ip: 172.17.0.7
     tenant_ip: 172.19.0.7
     ctlplane_ip: 192.168.122.12
     storage_ip: 172.18.0.7
+    nfs_ip: 172.21.0.7
 
   ctlplane:
     dnsDomain: ctlplane.example.com
@@ -124,6 +127,37 @@ data:
           "range": "172.18.0.0/24",
           "range_start": "172.18.0.30",
           "range_end": "172.18.0.70"
+        }
+      }
+
+  nfs:
+    dnsDomain: nfs.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.21.0.250
+            start: 172.21.0.100
+        cidr: 172.21.0.0/24
+        gateway: 172.21.0.1
+        name: subnet1
+        vlan: 24
+    mtu: 1500
+    prefix-length: 24
+    iface: nfs
+    vlan: 24
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.21.0.80-172.21.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "nfs",
+        "type": "macvlan",
+        "master": "nfs",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.21.0.0/24",
+          "range_start": "172.21.0.100",
+          "range_end": "172.21.0.250"
         }
       }
 

--- a/lib/nncp/ocp_nodes_nncp.yaml
+++ b/lib/nncp/ocp_nodes_nncp.yaml
@@ -5,6 +5,7 @@ metadata:
   name: node-0
   labels:
     osp/nncm-config-type: standard
+    osp/nncm-node: "0"
 ---
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
@@ -12,6 +13,7 @@ metadata:
   name: node-1
   labels:
     osp/nncm-config-type: standard
+    osp/nncm-node: "1"
 ---
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
@@ -19,3 +21,4 @@ metadata:
   name: node-2
   labels:
     osp/nncm-config-type: standard
+    osp/nncm-node: "2"


### PR DESCRIPTION
Manila Tempest tests need to connect to the share for Ganesha via a special (openstack) network [1].

This patch adds the NFS storage network with VLAN 24 and range 172.21.0.0/24 in uni04delta. The NFS network is connected to Ceph and Compute EDPM nodes. A NNCP, NAD, L2Advertisement and IPAddressPool are defined for the NFS network so that a pod in k8s can connect to it; such as the tempest pod which will perform the storage tests and the manilaShares pod(s).

[1] https://opendev.org/openstack/manila-tempest-plugin/src/branch/master/manila_tempest_tests/config.py#L99

Jira: https://issues.redhat.com/browse/OSPRH-7417
Depends-On: openstack-k8s-operators/ci-framework#2273