### PR TITLE
Enable Heat for uni04delta-ipv6 DT

### DIFF
--- a/dt/uni04delta-ipv6/control-plane/kustomization.yaml
+++ b/dt/uni04delta-ipv6/control-plane/kustomization.yaml
@@ -143,3 +143,15 @@ replacements:
           - spec.nova.template.cellTemplates
         options:
           create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.heat.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.heat.enabled
+        options:
+          create: true

--- a/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
@@ -169,3 +169,6 @@ data:
         datacentre: ocpbr
         octavia: octbr
         ironic: ironic
+
+  heat:
+    enabled: true


### PR DESCRIPTION
Since Tobiko tf uses Heat, we need to enable it in order to run Tobiko tests.