### PR TITLE
DT - BMO deploy with preprovisioningNetworkData

### DIFF
--- a/.ci/automation-schema.yaml
+++ b/.ci/automation-schema.yaml
@@ -19,6 +19,8 @@ _hook:
   inventory: str(required=False)
   extra_vars: map(required=False)
   definition: map(required=False)
+  api_version: str(required=False)
+  namespace: str(required=False)
   resource_name: str(required=False)
   state: str(required=False)
   kind: str(required=False)

--- a/automation/mocks/bmo01.yaml
+++ b/automation/mocks/bmo01.yaml
@@ -1,0 +1,43 @@
+---
+cifmw_install_ca_url: http://example.com/example.pem
+cifmw_repo_setup_rhos_release_rpm: http://example.com/rhos-release.rpm
+cifmw_repo_setup_rhos_release_args: example-args
+cifmw_ci_gen_kustomize_values_remove_keys_expressions:
+  - ^node(_[0-9]+)?$
+cifmw_baremetal_hosts:
+  leaf0-0:
+    boot_mode: legacy
+    connection: redfish-virtualmedia+http://sushy.utility:8000/redfish/v1/Systems/3e8d850a-fed0-436e-a353-61328877c947
+    nics:
+      - mac: 52:54:04:58:1e:2a
+        network: trunk1
+    password: password
+    username: admin
+    uuid: 3e8d850a-fed0-436e-a353-61328877c947
+  leaf0-1:
+    boot_mode: legacy
+    connection: redfish-virtualmedia+http://sushy.utility:8000/redfish/v1/Systems/a208f619-46cb-4e72-815d-e8d3cf88b9ce
+    nics:
+      - mac: 52:54:05:17:94:6b
+        network: trunk1
+    password: password
+    username: admin
+    uuid: a208f619-46cb-4e72-815d-e8d3cf88b9ce
+  leaf1-0:
+    boot_mode: legacy
+    connection: redfish-virtualmedia+http://sushy.utility:8000/redfish/v1/Systems/a0c6bd33-9d30-440b-8d70-9784f6ff7378
+    nics:
+      - mac: 52:54:06:39:e4:4b
+        network: trunk2
+    password: password
+    username: admin
+    uuid: a0c6bd33-9d30-440b-8d70-9784f6ff7378
+  leaf1-1:
+    boot_mode: legacy
+    connection: redfish-virtualmedia+http://sushy.utility:8000/redfish/v1/Systems/0beaadd5-75bb-430a-b566-49e4f68208d5
+    nics:
+      - mac: 52:54:07:16:d9:8e
+        network: trunk2
+    password: password
+    username: admin
+    uuid: 0beaadd5-75bb-430a-b566-49e4f68208d5

--- a/automation/net-env/bmo01.yaml
+++ b/automation/net-env/bmo01.yaml
@@ -1,0 +1,788 @@
+---
+instances:
+  controller-0:
+    hostname: controller-0
+    name: controller-0
+    networks: {}
+  leaf0-0:
+    name: leaf0-0
+    networks:
+      ctlplane1:
+        ip_v4: 192.168.123.100
+        is_trunk_parent: true
+        mac_addr: 52:54:04:af:14:31
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane1
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi1:
+        ip_v4: 172.17.1.100
+        is_trunk_parent: false
+        mac_addr: 52:54:00:7c:54:48
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi1
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane1
+        vlan_id: 20
+      storage1:
+        ip_v4: 172.18.1.100
+        is_trunk_parent: false
+        mac_addr: 52:54:00:2a:83:9d
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage1
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane1
+        vlan_id: 21
+      tenant1:
+        ip_v4: 172.19.1.100
+        is_trunk_parent: false
+        mac_addr: 52:54:00:76:12:1a
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant1
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane1
+        vlan_id: 22
+  leaf0-1:
+    name: leaf0-1
+    networks:
+      ctlplane1:
+        ip_v4: 192.168.123.101
+        is_trunk_parent: true
+        mac_addr: 52:54:05:f6:af:dc
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane1
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi1:
+        ip_v4: 172.17.1.101
+        is_trunk_parent: false
+        mac_addr: 52:54:00:36:43:e6
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi1
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane1
+        vlan_id: 20
+      storage1:
+        ip_v4: 172.18.1.101
+        is_trunk_parent: false
+        mac_addr: 52:54:00:6a:4c:f6
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage1
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane1
+        vlan_id: 21
+      tenant1:
+        ip_v4: 172.19.1.101
+        is_trunk_parent: false
+        mac_addr: 52:54:00:31:d0:6a
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant1
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane1
+        vlan_id: 22
+  leaf1-0:
+    name: leaf1-0
+    networks:
+      ctlplane2:
+        ip_v4: 192.168.124.100
+        is_trunk_parent: true
+        mac_addr: 52:54:06:bc:de:3c
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane2
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi2:
+        ip_v4: 172.17.2.100
+        is_trunk_parent: false
+        mac_addr: 52:54:00:1a:4f:1c
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi2
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane2
+        vlan_id: 20
+      storage2:
+        ip_v4: 172.18.2.100
+        is_trunk_parent: false
+        mac_addr: 52:54:00:53:63:f8
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage2
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane2
+        vlan_id: 21
+      tenant2:
+        ip_v4: 172.19.2.100
+        is_trunk_parent: false
+        mac_addr: 52:54:00:08:e3:1c
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant2
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane2
+        vlan_id: 22
+  leaf1-1:
+    name: leaf1-1
+    networks:
+      ctlplane2:
+        ip_v4: 192.168.124.101
+        is_trunk_parent: true
+        mac_addr: 52:54:07:2e:32:e5
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane2
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi2:
+        ip_v4: 172.17.2.101
+        is_trunk_parent: false
+        mac_addr: 52:54:00:6f:18:6d
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi2
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane2
+        vlan_id: 20
+      storage2:
+        ip_v4: 172.18.2.101
+        is_trunk_parent: false
+        mac_addr: 52:54:00:36:ed:eb
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage2
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane2
+        vlan_id: 21
+      tenant2:
+        ip_v4: 172.19.2.101
+        is_trunk_parent: false
+        mac_addr: 52:54:00:4c:2f:2c
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant2
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane2
+        vlan_id: 22
+  ocp-master-0:
+    hostname: master-0
+    name: ocp-master-0
+    networks:
+      ctlplane:
+        interface_name: enp7s0
+        ip_v4: 192.168.122.10
+        is_trunk_parent: true
+        mac_addr: 52:54:00:d8:04:a9
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi:
+        interface_name: enp7s0.20
+        ip_v4: 172.17.0.10
+        is_trunk_parent: false
+        mac_addr: 52:54:00:68:4b:ce
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: enp7s0
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 20
+      storage:
+        interface_name: enp7s0.21
+        ip_v4: 172.18.0.10
+        is_trunk_parent: false
+        mac_addr: 52:54:00:05:23:2c
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: enp7s0
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 21
+      tenant:
+        interface_name: enp7s0.22
+        ip_v4: 172.19.0.10
+        is_trunk_parent: false
+        mac_addr: 52:54:00:06:80:f0
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant
+        parent_interface: enp7s0
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 22
+  ocp-master-1:
+    hostname: master-1
+    name: ocp-master-1
+    networks:
+      ctlplane:
+        interface_name: enp7s0
+        ip_v4: 192.168.122.11
+        is_trunk_parent: true
+        mac_addr: 52:54:01:80:72:86
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi:
+        interface_name: enp7s0.20
+        ip_v4: 172.17.0.11
+        is_trunk_parent: false
+        mac_addr: 52:54:00:71:78:e6
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: enp7s0
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 20
+      storage:
+        interface_name: enp7s0.21
+        ip_v4: 172.18.0.11
+        is_trunk_parent: false
+        mac_addr: 52:54:00:76:3d:ba
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: enp7s0
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 21
+      tenant:
+        interface_name: enp7s0.22
+        ip_v4: 172.19.0.11
+        is_trunk_parent: false
+        mac_addr: 52:54:00:7a:5d:1d
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant
+        parent_interface: enp7s0
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 22
+  ocp-master-2:
+    hostname: master-2
+    name: ocp-master-2
+    networks:
+      ctlplane:
+        interface_name: enp7s0
+        ip_v4: 192.168.122.12
+        is_trunk_parent: true
+        mac_addr: 52:54:02:18:f3:cb
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi:
+        interface_name: enp7s0.20
+        ip_v4: 172.17.0.12
+        is_trunk_parent: false
+        mac_addr: 52:54:00:66:a0:7c
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: enp7s0
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 20
+      storage:
+        interface_name: enp7s0.21
+        ip_v4: 172.18.0.12
+        is_trunk_parent: false
+        mac_addr: 52:54:00:09:45:3b
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: enp7s0
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 21
+      tenant:
+        interface_name: enp7s0.22
+        ip_v4: 172.19.0.12
+        is_trunk_parent: false
+        mac_addr: 52:54:00:22:70:9f
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant
+        parent_interface: enp7s0
+        prefix_length_v4: 24
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 22
+networks:
+  ctlplane:
+    dns_v4:
+      - 192.168.122.1
+    dns_v6: []
+    gw_v4: 192.168.122.1
+    mtu: 1500
+    network_name: ctlplane
+    network_v4: 192.168.122.0/24
+    search_domain: ctlplane.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 192.168.122.90
+            end_host: 90
+            length: 11
+            start: 192.168.122.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 192.168.122.70
+            end_host: 70
+            length: 41
+            start: 192.168.122.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 192.168.122.120
+            end_host: 120
+            length: 21
+            start: 192.168.122.100
+            start_host: 100
+          - end: 192.168.122.200
+            end_host: 200
+            length: 51
+            start: 192.168.122.150
+            start_host: 150
+        ipv6_ranges: []
+  ctlplane1:
+    dns_v4:
+      - 192.168.122.1
+    dns_v6: []
+    gw_v4: 192.168.123.1
+    mtu: 1500
+    network_name: ctlplane1
+    network_v4: 192.168.123.0/24
+    search_domain: ctlplane1.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 192.168.123.90
+            end_host: 90
+            length: 11
+            start: 192.168.123.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 192.168.123.70
+            end_host: 70
+            length: 41
+            start: 192.168.123.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 192.168.123.120
+            end_host: 120
+            length: 21
+            start: 192.168.123.100
+            start_host: 100
+          - end: 192.168.123.200
+            end_host: 200
+            length: 51
+            start: 192.168.123.150
+            start_host: 150
+        ipv6_ranges: []
+  ctlplane2:
+    dns_v4:
+      - 192.168.122.1
+    dns_v6: []
+    gw_v4: 192.168.124.1
+    mtu: 1500
+    network_name: ctlplane2
+    network_v4: 192.168.124.0/24
+    search_domain: ctlplane2.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 192.168.124.90
+            end_host: 90
+            length: 11
+            start: 192.168.124.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 192.168.124.70
+            end_host: 70
+            length: 41
+            start: 192.168.124.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 192.168.124.120
+            end_host: 120
+            length: 21
+            start: 192.168.124.100
+            start_host: 100
+          - end: 192.168.124.200
+            end_host: 200
+            length: 51
+            start: 192.168.124.150
+            start_host: 150
+        ipv6_ranges: []
+  internalapi:
+    dns_v4: []
+    dns_v6: []
+    gw_v4: 172.17.0.1
+    mtu: 1500
+    network_name: internalapi
+    network_v4: 172.17.0.0/24
+    search_domain: internalapi.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.17.0.90
+            end_host: 90
+            length: 11
+            start: 172.17.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.17.0.70
+            end_host: 70
+            length: 41
+            start: 172.17.0.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.17.0.250
+            end_host: 250
+            length: 151
+            start: 172.17.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 20
+  internalapi1:
+    dns_v4: []
+    dns_v6: []
+    gw_v4: 172.17.1.1
+    mtu: 1500
+    network_name: internalapi1
+    network_v4: 172.17.1.0/24
+    search_domain: internalapi1.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.17.1.90
+            end_host: 90
+            length: 11
+            start: 172.17.1.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.17.1.70
+            end_host: 70
+            length: 41
+            start: 172.17.1.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.17.1.250
+            end_host: 250
+            length: 151
+            start: 172.17.1.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 20
+  internalapi2:
+    dns_v4: []
+    dns_v6: []
+    gw_v4: 172.17.2.1
+    mtu: 1500
+    network_name: internalapi2
+    network_v4: 172.17.2.0/24
+    search_domain: internalapi2.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.17.2.90
+            end_host: 90
+            length: 11
+            start: 172.17.2.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.17.2.70
+            end_host: 70
+            length: 41
+            start: 172.17.2.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.17.2.250
+            end_host: 250
+            length: 151
+            start: 172.17.2.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 20
+  storage:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: storage
+    network_v4: 172.18.0.0/24
+    search_domain: storage.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.18.0.90
+            end_host: 90
+            length: 11
+            start: 172.18.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.18.0.70
+            end_host: 70
+            length: 41
+            start: 172.18.0.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.18.0.250
+            end_host: 250
+            length: 151
+            start: 172.18.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 21
+  storage1:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: storage1
+    network_v4: 172.18.1.0/24
+    search_domain: storage1.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.18.1.90
+            end_host: 90
+            length: 11
+            start: 172.18.1.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.18.1.70
+            end_host: 70
+            length: 41
+            start: 172.18.1.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.18.1.250
+            end_host: 250
+            length: 151
+            start: 172.18.1.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 21
+  storage2:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: storage2
+    network_v4: 172.18.2.0/24
+    search_domain: storage2.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.18.2.90
+            end_host: 90
+            length: 11
+            start: 172.18.2.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.18.2.70
+            end_host: 70
+            length: 41
+            start: 172.18.2.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.18.2.250
+            end_host: 250
+            length: 151
+            start: 172.18.2.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 21
+  tenant:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: tenant
+    network_v4: 172.19.0.0/24
+    search_domain: tenant.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.19.0.90
+            end_host: 90
+            length: 11
+            start: 172.19.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.19.0.70
+            end_host: 70
+            length: 41
+            start: 172.19.0.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.19.0.250
+            end_host: 250
+            length: 151
+            start: 172.19.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 22
+  tenant1:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: tenant1
+    network_v4: 172.19.1.0/24
+    search_domain: tenant1.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.19.1.90
+            end_host: 90
+            length: 11
+            start: 172.19.1.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.19.1.70
+            end_host: 70
+            length: 41
+            start: 172.19.1.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.19.1.250
+            end_host: 250
+            length: 151
+            start: 172.19.1.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 22
+  tenant2:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: tenant2
+    network_v4: 172.19.2.0/24
+    search_domain: tenant2.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.19.2.90
+            end_host: 90
+            length: 11
+            start: 172.19.2.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.19.2.70
+            end_host: 70
+            length: 41
+            start: 172.19.2.30
+            start_host: 30
+        ipv4_routes: []
+        ipv6_ranges: []
+        ipv6_routes: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.19.2.250
+            end_host: 250
+            length: 151
+            start: 172.19.2.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 22
+routers: {}

--- a/automation/vars/bmo01.yaml
+++ b/automation/vars/bmo01.yaml
@@ -1,0 +1,110 @@
+---
+vas:
+  bmo01:
+    stages:
+      - path: examples/dt/bmo01/control-plane/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - pre_stage_run:
+          - name: Apply cinder-lvm label on master-0
+            type: cr
+            definition:
+              metadata:
+                labels:
+                  openstack.org/cinder-lvm: ""
+            kind: Node
+            resource_name: master-0
+            state: patched
+        path: examples/dt/bmo01/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackcontrolplane
+            controlplane
+            --for condition=Ready
+            --timeout=60m
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+
+      - pre_stage_run:
+          - name: Patch Provisioning CR
+            type: cr
+            definition:
+              spec:
+                watchAllNamespaces: true
+                virtualMediaViaExternalNetwork: true
+            namespace: openshift-machine-api
+            api_version: metal3.io/v1alpha1
+            kind: Provisioning
+            resource_name: provisioning-configuration
+            state: patched
+        path: examples/dt/bmo01/dataplane/baremetalhosts
+        wait_conditions:
+          - >-
+            oc -n openstack wait baremetalhosts.metal3.io
+            -l app=openstack
+            --for jsonpath=status.provisioning.state=available
+            --timeout=10m
+        values:
+          - name: baremetalhost-values
+            src_file: values.yaml
+        build_output: baremetalhosts.yaml
+
+      - path: examples/dt/bmo01/dataplane/secrets
+        wait_conditions:
+          - >-
+            oc -n openstack wait secrets dataplane-ansible-ssh-private-key-secret
+            --for jsonpath=metadata.uid
+          - >-
+            oc -n openstack wait secrets nova-migration-ssh-key
+            --for jsonpath=metadata.uid
+        values:
+          - name: secret-values
+            src_file: values.yaml
+        build_output: dataplane-secrets.yaml
+
+      - path: examples/dt/bmo01/dataplane/nodesets
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodesets
+            nodeset-0
+            --for condition=NodeSetBaremetalProvisionReady
+            --timeout=40m
+          - >-
+            oc -n openstack wait openstackdataplanenodesets
+            nodeset-1
+            --for condition=NodeSetBaremetalProvisionReady
+            --timeout=40m
+        values:
+          - name: nodeset-values
+            src_file: values.yaml
+        build_output: dataplane-nodesets.yaml
+
+      - path: examples/dt/bmo01/dataplane
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodesets
+            nodeset-0
+            --for condition=Ready
+            --timeout=40m
+          - >-
+            oc -n openstack wait openstackdataplanenodesets
+            nodeset-1
+            --for condition=Ready
+            --timeout=40m
+        values:
+          - name: deployment-values
+            src_file: values.yaml
+        build_output: edpm.yaml

--- a/dt/bmo01/dataplane/baremetalhosts/baremetalhost_template.yaml
+++ b/dt/bmo01/dataplane/baremetalhosts/baremetalhost_template.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  labels: {}
+  name: _ignored_
+  namespace: openstack
+  annotations:
+    inspect.metal3.io: _replaced_
+spec:
+  architecture: x86_64
+  automatedCleaningMode: metadata
+  bmc:
+    address: _replaced_
+    credentialsName: _replaced_
+  bootMACAddress: _replaced_
+  bootMode: UEFI
+  rootDeviceHints: {}
+  online: false
+  preprovisioningNetworkDataName: _replaced_

--- a/dt/bmo01/dataplane/baremetalhosts/baremetalhosts.yaml
+++ b/dt/bmo01/dataplane/baremetalhosts/baremetalhosts.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: leaf0-0-preprovision-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  labels: {}
+  name: leaf0-0
+  namespace: openstack
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: leaf0-1-preprovision-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  labels: {}
+  name: leaf0-1
+  namespace: openstack
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: leaf1-0-preprovision-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  labels: {}
+  name: leaf1-0
+  namespace: openstack
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: leaf1-1-preprovision-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  labels: {}
+  name: leaf1-1
+  namespace: openstack

--- a/dt/bmo01/dataplane/baremetalhosts/kustomization.yaml
+++ b/dt/bmo01/dataplane/baremetalhosts/kustomization.yaml
@@ -1,0 +1,310 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - baremetalhosts.yaml
+
+patches:
+  - target:
+      kind: BareMetalHost
+    path: baremetalhost_template.yaml
+  - target:
+      kind: BareMetalHost
+    patch: |
+     - op: replace
+       path: /spec/bmc/credentialsName
+       value: bmc-secret
+  - target:
+      kind: BareMetalHost
+      name: leaf0-0
+    patch: |
+     - op: replace
+       path: /spec/preprovisioningNetworkDataName
+       value: leaf0-0-preprovision-network-data
+  - target:
+      kind: BareMetalHost
+      name: leaf0-1
+    patch: |
+     - op: replace
+       path: /spec/preprovisioningNetworkDataName
+       value: leaf0-1-preprovision-network-data
+  - target:
+      kind: BareMetalHost
+      name: leaf1-0
+    patch: |
+     - op: replace
+       path: /spec/preprovisioningNetworkDataName
+       value: leaf1-0-preprovision-network-data
+  - target:
+      kind: BareMetalHost
+      name: leaf1-1
+    patch: |
+     - op: replace
+       path: /spec/preprovisioningNetworkDataName
+       value: leaf1-1-preprovision-network-data
+
+replacements:
+
+  # Labels
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf0-0.labels
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf0-0
+        fieldPaths:
+          - metadata.labels
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf0-1.labels
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf0-1
+        fieldPaths:
+          - metadata.labels
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf1-0.labels
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf1-0
+        fieldPaths:
+          - metadata.labels
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf1-1.labels
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf1-1
+        fieldPaths:
+          - metadata.labels
+        options:
+          create: true
+
+  # Enable/Disable Metal3 Inspection
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.metal3_inspection
+    targets:
+      - select:
+          kind: BareMetalHost
+        fieldPaths:
+          - metadata.annotations.inspect\.metal3\.io
+        options:
+          create: true
+
+  # BMC Address
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf0-0.bmc.address
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf0-0
+        fieldPaths:
+          - spec.bmc.address
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf0-1.bmc.address
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf0-1
+        fieldPaths:
+          - spec.bmc.address
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf1-0.bmc.address
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf1-0
+        fieldPaths:
+          - spec.bmc.address
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf1-1.bmc.address
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf1-1
+        fieldPaths:
+          - spec.bmc.address
+        options:
+          create: true
+
+  # bootMACAddress
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf0-0.bootMACAddress
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf0-0
+        fieldPaths:
+          - spec.bootMACAddress
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf0-1.bootMACAddress
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf0-1
+        fieldPaths:
+          - spec.bootMACAddress
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf1-0.bootMACAddress
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf1-0
+        fieldPaths:
+          - spec.bootMACAddress
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf1-1.bootMACAddress
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf1-1
+        fieldPaths:
+          - spec.bootMACAddress
+        options:
+          create: true
+
+  # rootDeviceHints
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf0-0.rootDeviceHints
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf0-0
+        fieldPaths:
+          - spec.rootDeviceHints
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf0-1.rootDeviceHints
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf0-1
+        fieldPaths:
+          - spec.rootDeviceHints
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf1-0.rootDeviceHints
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf1-0
+        fieldPaths:
+          - spec.rootDeviceHints
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf1-1.rootDeviceHints
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: leaf1-1
+        fieldPaths:
+          - spec.rootDeviceHints
+        options:
+          create: true
+
+  # preprovisioningNetworkData
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf0-0.preprovisioningNetworkData
+    targets:
+      - select:
+          kind: Secret
+          name: leaf0-0-preprovision-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf0-1.preprovisioningNetworkData
+    targets:
+      - select:
+          kind: Secret
+          name: leaf0-1-preprovision-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf1-0.preprovisioningNetworkData
+    targets:
+      - select:
+          kind: Secret
+          name: leaf1-0-preprovision-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.leaf1-1.preprovisioningNetworkData
+    targets:
+      - select:
+          kind: Secret
+          name: leaf1-1-preprovision-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true

--- a/dt/bmo01/dataplane/kustomization.yaml
+++ b/dt/bmo01/dataplane/kustomization.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+components:
+  - ../../../lib/dataplane/deployment
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneDeployment
+      name: .*
+    patch: |-
+      - op: replace
+        path: /spec/nodeSets
+        value:
+          - nodeset-0
+          - nodeset-1

--- a/dt/bmo01/dataplane/nodesets/kustomization.yaml
+++ b/dt/bmo01/dataplane/nodesets/kustomization.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+resources:
+  - network-data-secrets.yaml
+  - openstackdataplanenodesets.yaml
+
+replacements:
+  # networkData
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.baremetalHostsNetworkData.edpm-compute-0-0
+    targets:
+      - select:
+          kind: Secret
+          name: edpm-compute-0-0-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.baremetalHostsNetworkData.edpm-compute-0-1
+    targets:
+      - select:
+          kind: Secret
+          name: edpm-compute-0-1-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.baremetalHostsNetworkData.edpm-compute-1-0
+    targets:
+      - select:
+          kind: Secret
+          name: edpm-compute-1-0-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.baremetalHostsNetworkData.edpm-compute-1-1
+    targets:
+      - select:
+          kind: Secret
+          name: edpm-compute-1-1-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true

--- a/dt/bmo01/dataplane/nodesets/network-data-secrets.yaml
+++ b/dt/bmo01/dataplane/nodesets/network-data-secrets.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edpm-compute-0-0-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edpm-compute-0-1-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edpm-compute-1-0-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edpm-compute-1-1-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}

--- a/dt/bmo01/dataplane/nodesets/openstackdataplanenodesets.yaml
+++ b/dt/bmo01/dataplane/nodesets/openstackdataplanenodesets.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: nodeset-0
+spec:
+  env:
+    - name: ANSIBLE_FORCE_COLOR
+      value: "True"
+  preProvisioned: false
+  baremetalSetTemplate:
+    deploymentSSHSecret: dataplane-ansible-ssh-private-key-secret
+    bmhNamespace: openstack
+    cloudUserName: cloud-user
+    bmhLabelSelector:
+      app: openstack
+      nodeset: leaf0
+    ctlplaneInterface: _replaced_
+
+  networkAttachments:
+    - ctlplane
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    managementNetwork: ctlplane
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet2
+      - name: internalapi
+        subnetName: subnet2
+      - name: storage
+        subnetName: subnet2
+      - name: tenant
+        subnetName: subnet2
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        timesync_ntp_servers: []
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_template: _replaced_
+        neutron_physical_bridge_name: _replaced_
+        neutron_public_interface_name: _replaced_
+        edpm_bootstrap_command: _replaced_
+
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+
+        edpm_sshd_configure_firewall: true
+        edpm_sshd_allowed_ranges: []
+
+        gather_facts: false
+  services:
+    - download-cache
+    - bootstrap
+    - configure-network
+    - validate-network
+    - install-os
+    - configure-os
+    - ssh-known-hosts
+    - run-os
+    - reboot-os
+    - install-certs
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: nodeset-1
+spec:
+  env:
+    - name: ANSIBLE_FORCE_COLOR
+      value: "True"
+  preProvisioned: false
+  baremetalSetTemplate:
+    deploymentSSHSecret: dataplane-ansible-ssh-private-key-secret
+    bmhNamespace: openstack
+    cloudUserName: cloud-user
+    bmhLabelSelector:
+      app: openstack
+      nodeset: leaf1
+    ctlplaneInterface: _replaced_
+  networkAttachments:
+    - ctlplane
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    managementNetwork: ctlplane
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet3
+      - name: internalapi
+        subnetName: subnet3
+      - name: storage
+        subnetName: subnet3
+      - name: tenant
+        subnetName: subnet3
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        timesync_ntp_servers: []
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_template: _replaced_
+        neutron_physical_bridge_name: _replaced_
+        neutron_public_interface_name: _replaced_
+        edpm_bootstrap_command: _replaced_
+
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+
+        edpm_sshd_configure_firewall: true
+        edpm_sshd_allowed_ranges: []
+
+        gather_facts: false
+  services:
+    - bootstrap
+    - download-cache
+    - configure-network
+    - validate-network
+    - install-os
+    - configure-os
+    - ssh-known-hosts
+    - run-os
+    - reboot-os
+    - install-certs
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova

--- a/dt/bmo01/dataplane/secrets/dataplane-ssh-secret.yaml
+++ b/dt/bmo01/dataplane/secrets/dataplane-ssh-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+data:
+  authorized_keys: _replaced_
+  ssh-privatekey: _replaced_
+  ssh-publickey: _replaced_
+kind: Secret
+metadata:
+  name: dataplane-ansible-ssh-private-key-secret
+  namespace: openstack
+type: Opaque

--- a/dt/bmo01/dataplane/secrets/kustomization.yaml
+++ b/dt/bmo01/dataplane/secrets/kustomization.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+resources:
+  - dataplane-ssh-secret.yaml
+  - nova-migration-ssh-secret.yaml
+
+secretGenerator:
+  - name: libvirt-secret
+    behavior: create
+    literals:
+      - LibvirtPassword=12345678
+    options:
+      disableNameSuffixHash: true
+
+# OpenStackDataPlaneNodeSet customizations
+replacements:
+  # Dataplane SSH access secret customizations
+  - source:
+      kind: ConfigMap
+      name: dataplane-secret-values
+      fieldPath: data.ssh_keys.authorized
+    targets:
+      - select:
+          kind: Secret
+          name: dataplane-ansible-ssh-private-key-secret
+        fieldPaths:
+          - data.authorized_keys
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: dataplane-secret-values
+      fieldPath: data.ssh_keys.private
+    targets:
+      - select:
+          kind: Secret
+          name: dataplane-ansible-ssh-private-key-secret
+        fieldPaths:
+          - data.ssh-privatekey
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: dataplane-secret-values
+      fieldPath: data.ssh_keys.public
+    targets:
+      - select:
+          kind: Secret
+          name: dataplane-ansible-ssh-private-key-secret
+        fieldPaths:
+          - data.ssh-publickey
+        options:
+          create: true
+
+  # Nova migration secret customizations
+  - source:
+      kind: ConfigMap
+      name: dataplane-secret-values
+      fieldPath: data.nova.migration.ssh_keys.private
+    targets:
+      - select:
+          kind: Secret
+          name: nova-migration-ssh-key
+        fieldPaths:
+          - data.ssh-privatekey
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: dataplane-secret-values
+      fieldPath: data.nova.migration.ssh_keys.public
+    targets:
+      - select:
+          kind: Secret
+          name: nova-migration-ssh-key
+        fieldPaths:
+          - data.ssh-publickey
+        options:
+          create: true

--- a/dt/bmo01/dataplane/secrets/nova-migration-ssh-secret.yaml
+++ b/dt/bmo01/dataplane/secrets/nova-migration-ssh-secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+data:
+  ssh-privatekey: _replaced_
+  ssh-publickey: _replaced_
+kind: Secret
+metadata:
+  name: nova-migration-ssh-key
+  namespace: openstack
+type: kubernetes.io/ssh-auth

--- a/dt/bmo01/kustomization.yaml
+++ b/dt/bmo01/kustomization.yaml
@@ -1,0 +1,180 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+      apiVersion: builtin
+      kind: NamespaceTransformer
+      metadata:
+        name: _ignored_
+        namespace: openstack
+      setRoleBindingSubjects: none
+      unsetOnly: true
+      fieldSpecs:
+        - path: metadata/name
+          kind: Namespace
+          create: true
+
+components:
+  - ../../lib/networking/metallb
+  - netconfig
+  - ../../lib/networking/nad
+  - ../../lib/control-plane
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderVolumes.lvm-iscsi.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderVolumes.lvm-iscsi.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderVolumes.lvm-iscsi.nodeSelector.openstack\.org/cinder-lvm
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderVolumes.lvm-iscsi.nodeSelector.openstack\.org/cinder-lvm
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderVolumes.lvm-iscsi.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderVolumes.lvm-iscsi.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.default.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.default.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.swift.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.swift.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.heat.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.heat.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.ovn.ovnController.nicMappings
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ovn.template.ovnController.nicMappings
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.neutron.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.neutron.template.customServiceConfig
+        options:
+          create: true

--- a/dt/bmo01/netconfig/kustomization.yaml
+++ b/dt/bmo01/netconfig/kustomization.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - netconfig.yaml
+
+replacements:
+  # NetConfig dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=ctlplane].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=internalapi].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storage].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=tenant].dnsDomain
+
+  # NetConfig MTU
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=ctlplane].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=internalapi].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storage].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=tenant].mtu
+
+  # NetConfig subnets
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=ctlplane].subnets
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=internalapi].subnets
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storage].subnets
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=tenant].subnets

--- a/dt/bmo01/netconfig/netconfig.yaml
+++ b/dt/bmo01/netconfig/netconfig.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: network.openstack.org/v1beta1
+kind: NetConfig
+metadata:
+  name: netconfig
+  namespace: openstack
+spec:
+  networks:
+    - dnsDomain: _replaced_
+      name: ctlplane
+      subnets:
+        - _replaced_
+      mtu: 1500
+    - dnsDomain: _replaced_
+      name: internalapi
+      subnets:
+        - _replaced_
+      mtu: 1500
+    - dnsDomain: _replaced_
+      name: storage
+      subnets:
+        - _replaced_
+      mtu: 1500
+    - dnsDomain: _replaced_
+      name: tenant
+      subnets:
+        - _replaced_
+      mtu: 1500

--- a/dt/bmo01/nncp/kustomization.yaml
+++ b/dt/bmo01/nncp/kustomization.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../lib/nncp
+
+replacements:
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.routes.config
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.routes.config
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.routes.config
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.routes.config

--- a/examples/dt/bmo01/README.md
+++ b/examples/dt/bmo01/README.md
@@ -1,0 +1,74 @@
+# Deployed Topology - BMO spine-and-leaf
+
+Spine and Leaf topology of Red Hat OpenStack Services on OpenShift, with
+dataplane nodes deployed with Baremetal Operator. It contains a collection
+of custom resources (CRs) for deploying the test environment.
+
+![Spine and Leaf conceptual diagram](osp-k8s-spine-leaf.svg)
+
+## Purpose
+
+This topology is used for testing Baremetal Operator node provisioning in a
+spine-and-leaf architecture.
+
+### Nodes
+
+| Role              | Machine Type | Count |
+| ----------------- | ------------ | ----- |
+| Compact OpenShift | vm           | 3     |
+| OpenStack Compute | vm           | 4     |
+
+### Networks
+
+| Name         | Type     | Interface | CIDR            |
+| ------------ | -------- | --------- | --------------- |
+| Provisioning | untagged | nic1      | 172.22.0.0/24   |
+| Machine      | untagged | nic2      | 192.168.32.0/20 |
+| RH OSP       | trunk    | nic3      |                 |
+| RH OSP       | trunk1               |                 |
+| RH OSP       | trunk1               |                 |
+
+#### Networks in RH OSP
+
+| Name        | Type        | CIDR                                                 |
+| ----------- | ----------- | ---------------------------------------------------- |
+| ctlplane    | untagged    | 192.168.122.0/24, 192.168.123.0/24, 192.168.123.0/24 |
+| internalapi | VLAN tagged | 172.17.0.0/24, 172.17.1.0/24, 172.17.1.0/24          |
+| storage     | VLAN tagged | 172.18.0.0/24, 172.18.0.0/24, 172.18.0.0/24          |
+| tenant      | VLAN tagged | 172.19.0.0/24, 172.19.0.0/24, 172.19.0.0/24          |
+
+#### Router addresses
+
+| Network     | leaf-0        | leaf-1        | leaf-2        |
+| ----------- | ------------- | ------------- | ------------- |
+| ctlplane    | 192.168.122.1 | 192.168.123.1 | 192.168.124.1 |
+| internalapi | 172.17.0.1    | 172.17.1.1    | 172.17.2.1    |
+| storage     | 172.18.0.1    | 172.18.1.1    | 172.18.2.1    |
+| tenant      | 172.19.0.1    | 172.19.1.1    | 172.19.2.1    |
+
+
+#### Dataplane node baremetal provisioning network
+
+The OCP external network (``machine network``) is used for provisioning, and 
+connections to the RH OSP ``ctlplane`` network is also on the OCP nodes. To
+avoid asymmetric routing during dataplane node provisioning, additional IP
+ranges (``192.168.130.0/24`` and ``192.168.131.0/24``) are used for the Metal3
+deploy ramdisk.
+
+### Services, enabled features and configurations
+
+| Service          | configuration    | Lock-in coverage?  |
+| ---------------- | ---------------- | ------------------ |
+| Cinder           | LVM/iSCSI/lioadm |                    |
+| Glance           | Swift            |                    |
+| Swift            | (default)        |                    |
+| Neutron          | OVN              |                    |
+| Nova             | (default)        |                    |
+| Keystone         | (default)        |                    |
+
+
+## Workflow
+
+1. [Install the OpenStack K8S operators and their dependencies](../../common/README.md)
+2. [Configure and deploy the OpenStack control plane](control-plane.md)
+3. [Configure and deploy the OpenStack data plane](data-plane.md)

--- a/examples/dt/bmo01/control-plane.md
+++ b/examples/dt/bmo01/control-plane.md
@@ -1,0 +1,60 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `local-storage` should already exist.
+
+## Initialize
+
+Switch to the "openstack" namespace
+
+```bash
+oc project openstack
+```
+
+Change to the bmo01 directory
+
+```bash
+cd architecture/examples/dt/bmo01
+```
+
+Edit [service-values.yaml](control-plane/service-values.yaml) and
+[control-plane/nncp/values.yaml](control-plane/nncp/values.yaml).
+
+Apply node network configuration
+
+```bash
+pushd control-plane/nncp
+kustomize build > nncp.yaml
+oc apply -f nncp.yaml
+oc wait nncp \
+    -l osp/nncm-config-type=standard \
+    --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured \
+    --timeout=300s
+popd
+```
+
+Generate the control-plane and networking CRs.
+
+```bash
+pushd control-plane
+kustomize build > control-plane.yaml
+```
+
+## Create CRs
+
+> **_NOTE:_** Since Cinder is using LVM backend, set
+> `openstack.org/cinder-lvm=` label on one of the nodes:
+>
+> `oc label node <nodename> openstack.org/cinder-lvm=`
+
+```bash
+oc apply -f control-plane.yaml
+popd
+```
+
+Wait for control plane to be available
+
+```bash
+oc wait osctlplane controlplane --for condition=Ready --timeout=600s
+```

--- a/examples/dt/bmo01/control-plane/kustomization.yaml
+++ b/examples/dt/bmo01/control-plane/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/bmo01
+
+resources:
+  - nncp/values.yaml
+  - service-values.yaml

--- a/examples/dt/bmo01/control-plane/nncp/kustomization.yaml
+++ b/examples/dt/bmo01/control-plane/nncp/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bmo01/nncp
+
+resources:
+  - values.yaml

--- a/examples/dt/bmo01/control-plane/nncp/values.yaml
+++ b/examples/dt/bmo01/control-plane/nncp/values.yaml
@@ -1,0 +1,394 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  openstack-operator-image: "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
+
+  ocp:
+    cluster_network_cidr: 192.168.16.0/20
+    service_network_cidr: 172.30.0.0/16
+
+  node_0:
+    name: master-0
+    internalapi_ip: 172.17.0.10
+    tenant_ip: 172.19.0.10
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.10
+  node_1:
+    name: master-1
+    internalapi_ip: 172.17.0.11
+    tenant_ip: 172.19.0.11
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.11
+  node_2:
+    name: master-2
+    internalapi_ip: 172.17.0.12
+    tenant_ip: 172.19.0.12
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.12
+
+  ctlplane:
+    dnsDomain: ctlplane.openstack.lab
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        routes:
+          - destination: 192.168.123.0/24
+            nexthop: 192.168.122.1
+          - destination: 192.168.124.0/24
+            nexthop: 192.168.122.1
+        name: subnet1
+      - allocationRanges:
+          - end: 192.168.123.120
+            start: 192.168.123.100
+          - end: 192.168.123.200
+            start: 192.168.123.150
+        cidr: 192.168.123.0/24
+        gateway: 192.168.123.1
+        routes:
+          - destination: 192.168.122.0/24
+            nexthop: 192.168.123.1
+          - destination: 192.168.124.0/24
+            nexthop: 192.168.123.1
+        name: subnet2
+      - allocationRanges:
+          - end: 192.168.124.120
+            start: 192.168.124.100
+          - end: 192.168.124.200
+            start: 192.168.124.150
+        cidr: 192.168.124.0/24
+        gateway: 192.168.124.1
+        routes:
+          - destination: 192.168.122.0/24
+            nexthop: 192.168.124.1
+          - destination: 192.168.123.0/24
+            nexthop: 192.168.124.1
+        name: subnet3
+    prefix-length: 24
+    iface: enp7s0
+    mtu: 1500
+    lb_addresses:
+      - 192.168.122.80-192.168.122.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "macvlan",
+        "master": "ospbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.122.0/24",
+          "range_start": "192.168.122.30",
+          "range_end": "192.168.122.70",
+          "routes": [
+            {
+              "dst": "192.168.123.0/24",
+              "gw": "192.168.122.1"
+            },
+            {
+              "dst": "192.168.124.0/24",
+              "gw": "192.168.122.1"
+            }
+          ]
+        }
+      }
+
+  internalapi:
+    dnsDomain: internalapi.openstack.lab
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        gateway: 172.17.0.1
+        routes:
+          - destination: 172.17.1.0/24
+            nexthop: 172.17.0.1
+          - destination: 172.17.2.0/24
+            nexthop: 172.17.0.1
+        name: subnet1
+        vlan: 20
+      - allocationRanges:
+          - end: 172.17.1.250
+            start: 172.17.1.100
+        cidr: 172.17.1.0/24
+        gateway: 172.17.1.1
+        routes:
+          - destination: 172.17.0.0/24
+            nexthop: 172.17.1.1
+          - destination: 172.17.2.0/24
+            nexthop: 172.17.1.1
+        name: subnet2
+        vlan: 30
+      - allocationRanges:
+          - end: 172.17.2.250
+            start: 172.17.2.100
+        cidr: 172.17.2.0/24
+        gateway: 172.17.2.1
+        routes:
+          - destination: 172.17.0.0/24
+            nexthop: 172.17.2.1
+          - destination: 172.17.1.0/24
+            nexthop: 172.17.2.1
+        name: subnet3
+        vlan: 40
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "macvlan",
+        "master": "internalapi",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70",
+          "routes": [
+            {
+              "dst": "172.17.1.0/24",
+              "gw": "172.17.0.1"
+            },
+            {
+              "dst": "172.17.2.0/24",
+              "gw": "172.17.0.1"
+            }
+          ]
+        }
+      }
+
+  storage:
+    dnsDomain: storage.openstack.lab
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        gateway: 172.18.0.1
+        routes:
+          - destination: 172.18.1.0/24
+            nexthop: 172.18.0.1
+          - destination: 172.18.2.0/24
+            nexthop: 172.18.0.1
+        name: subnet1
+        vlan: 21
+      - allocationRanges:
+          - end: 172.18.1.250
+            start: 172.18.1.100
+        cidr: 172.18.1.0/24
+        gateway: 172.18.1.1
+        routes:
+          - destination: 172.18.0.0/24
+            nexthop: 172.18.1.1
+          - destination: 172.18.2.0/24
+            nexthop: 172.18.1.1
+        name: subnet2
+        vlan: 31
+      - allocationRanges:
+          - end: 172.18.2.250
+            start: 172.18.2.100
+        cidr: 172.18.2.0/24
+        gateway: 172.18.2.1
+        routes:
+          - destination: 172.18.0.0/24
+            nexthop: 172.18.2.1
+          - destination: 172.18.1.0/24
+            nexthop: 172.18.2.1
+        name: subnet3
+        vlan: 41
+    mtu: 1500
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "macvlan",
+        "master": "storage",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70",
+          "routes": [
+            {
+              "dst": "172.18.1.0/24",
+              "gw": "172.18.0.1"
+            },
+            {
+              "dst": "172.18.2.0/24",
+              "gw": "172.18.0.1"
+            }
+          ]
+        }
+      }
+
+  tenant:
+    dnsDomain: tenant.openstack.lab
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        gateway: 172.19.0.1
+        routes:
+          - destination: 172.19.1.0/24
+            nexthop: 172.19.0.1
+          - destination: 172.19.2.0/24
+            nexthop: 172.19.0.1
+        name: subnet1
+        vlan: 22
+      - allocationRanges:
+          - end: 172.19.1.250
+            start: 172.19.1.100
+        cidr: 172.19.1.0/24
+        gateway: 172.19.1.1
+        routes:
+          - destination: 172.19.0.0/24
+            nexthop: 172.19.1.1
+          - destination: 172.19.2.0/24
+            nexthop: 172.19.1.1
+        name: subnet2
+        vlan: 32
+      - allocationRanges:
+          - end: 172.19.2.250
+            start: 172.19.2.100
+        cidr: 172.19.2.0/24
+        gateway: 172.19.2.1
+        routes:
+          - destination: 172.19.0.0/24
+            nexthop: 172.19.2.1
+          - destination: 172.19.1.0/24
+            nexthop: 172.19.2.1
+        name: subnet3
+        vlan: 42
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "macvlan",
+        "master": "tenant",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70",
+          "routes": [
+            {
+              "dst": "172.19.1.0/24",
+              "gw": "172.19.0.1"
+            },
+            {
+              "dst": "172.19.2.0/24",
+              "gw": "172.19.0.1"
+            }
+          ]
+        }
+      }
+
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config:
+      # ctlplane
+      - destination: 192.168.123.0/24
+        metric: 150
+        next-hop-address: 192.168.122.1
+        next-hop-interface: ospbr
+      - destination: 192.168.124.0/24
+        metric: 150
+        next-hop-address: 192.168.122.1
+        next-hop-interface: ospbr
+      # internalapi
+      - destination: 172.17.1.0/24
+        metric: 150
+        next-hop-address: 172.17.0.1
+        next-hop-interface: internalapi
+      - destination: 172.17.2.0/24
+        metric: 150
+        next-hop-address: 172.17.0.1
+        next-hop-interface: internalapi
+      # storage
+      - destination: 172.18.1.0/24
+        metric: 150
+        next-hop-address: 172.18.0.1
+        next-hop-interface: storage
+      - destination: 172.18.2.0/24
+        metric: 150
+        next-hop-address: 172.18.0.1
+        next-hop-interface: storage
+      # tenant
+      - destination: 172.19.1.0/24
+        metric: 150
+        next-hop-address: 172.19.0.1
+        next-hop-interface: tenant
+      - destination: 172.19.2.0/24
+        metric: 150
+        next-hop-address: 172.19.0.1
+        next-hop-interface: tenant
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  storageClass: lvms-local-storage
+  bridgeName: ospbr

--- a/examples/dt/bmo01/control-plane/service-values.yaml
+++ b/examples/dt/bmo01/control-plane/service-values.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  preserveJobs: false
+  cinderVolumes:
+    lvm-iscsi:
+      replicas: 1
+      nodeSelector:
+        openstack.org/cinder-lvm: ""
+      customServiceConfig: |
+        [lvm]
+        image_volume_cache_enabled = false
+        volume_driver = cinder.volume.drivers.lvm.LVMVolumeDriver
+        volume_group = cinder-volumes
+        target_protocol = iscsi
+        target_helper = lioadm
+        volume_backend_name = lvm_iscsi
+        target_ip_address=172.18.0.10
+        target_secondary_ip_addresses = 172.19.0.10
+
+  cinderBackup:
+    replicas: 0
+
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      debug = True
+      enabled_backends = default_backend:swift
+
+      [glance_store]
+      default_backend = default_backend
+
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+    default:
+      replicas: 3
+
+  swift:
+    enabled: true
+
+  octavia:
+    enabled: false
+
+  heat:
+    enabled: false
+
+  telemetry:
+    enabled: false
+
+  ovn:
+    ovnController:
+      nicMappings:
+        datacentre: ocpbr
+      external-ids:
+        enable-chassis-as-gateway: true
+
+  neutron:
+    customServiceConfig: |
+      [DEFAULT]
+      vlan_transparent = true
+      agent_down_time = 600
+      router_distributed = true
+      router_scheduler_driver = neutron.scheduler.l3_agent_scheduler.ChanceScheduler
+      allow_automatic_l3agent_failover = true
+      debug = true
+
+      [agent]
+      report_interval = 300
+
+      [database]
+      max_retries = -1
+      db_max_retries = -1
+
+      [keystone_authtoken]
+      region_name = regionOne
+      memcache_use_advanced_pool = True
+
+      [oslo_messaging_notifications]
+      driver = noop
+
+      [oslo_middleware]
+      enable_proxy_headers_parsing = true
+
+      [oslo_policy]
+      policy_file = /etc/neutron/policy.yaml
+
+      [ovs]
+      igmp_snooping_enable = true
+
+      [ovn]
+      ovsdb_probe_interval = 60000
+      ovn_emit_need_to_frag = true
+      enable_distributed_floating_ip=False
+
+      [ml2]
+      type_drivers = geneve,vxlan,vlan,flat,local
+      tenant_network_types = geneve,flat

--- a/examples/dt/bmo01/data-plane.md
+++ b/examples/dt/bmo01/data-plane.md
@@ -1,0 +1,143 @@
+# Deploying the OpenStack dataplane
+
+## Assumptions
+
+- The [control plane](control-plane.md) has been successfully deployed.
+
+## Initialize
+
+Switch to the "openstack" namespace
+
+```bash
+oc project openstack
+```
+
+Change to the dataplane directory
+
+```bash
+cd architecture/examples/dt/bmo01/dataplane
+```
+
+### Configure BMO - Provisioning to watch all namespaces
+
+```
+oc patch provisioning provisioning-configuration --type merge -p '{"spec":{"watchAllNamespaces": true }}'
+```
+
+### Configure BMO - Provisioning to use external network for virtual-media
+
+```
+oc patch provisioning provisioning-configuration --type merge -p '{"spec":{"virtualMediaViaExternalNetwork": true }}'
+```
+
+### Create the BareMetalHost CRs
+
+```
+pushd baremetalhosts
+```
+
+Modify the [values.yaml](dataplane/baremetalhosts/values.yaml), for each of the nodes (`leaf0-0`, `leaf0-1`, `leaf1-0` and `leaf1-1`) set:
+- `bmc.address`
+- `bootMACAddress`
+- `rootDeviceHints`
+- `preprovisioningNetworkData`
+
+Modify the [bmc-secret.env](dataplane/baremetalhosts/bmc-secret.env) *env* with the BMC `username` and `password`, for example:
+```
+username=root
+password=S3cr3t
+```
+
+```
+kustomize build > baremetalhosts.yaml
+oc apply -f baremetalhosts.yaml
+```
+
+Wait for BareMetalHosts to reach state: `active`
+
+```
+oc get bmh -w
+
+NAME      STATE        CONSUMER   ONLINE   ERROR   AGE
+leaf1-0   preparing               false            1m38s
+leaf1-1   preparing               false            1m38s
+leaf0-1   preparing               false            1m38s
+leaf0-0   preparing               false            1m38s
+leaf1-0   available               false            2m38s
+leaf0-1   available               false            2m38s
+leaf0-0   available               false            2m38s
+leaf1-1   available               false            2m38s
+```
+
+```
+popd
+```
+
+## Create the dataplane secrets
+
+```
+pushd secrets
+```
+
+Modify the [values.yaml](values.yaml) with the following information
+
+- SSH keys to be used for accessing the deployed compute nodes.
+- SSH keys to be use for Nova migration.
+
+> All values must be in base64 encoded format.
+
+### Compute access
+
+1. Set `data['authorized']` with the value of all OpenStack Compute host SSH
+  keys.
+2. Set `data['private']` with the contents of the SSH private key to be used
+  for accessing the dataplane compute nodes.
+3. Set `data['public']` with the contents of the SSH public key used for
+  accessing the dataplane compute nodes.
+
+### Nova migration
+
+1. Set `data['nova']['migration']['ssh_keys']['private']` with the content of
+  the SSH private key to be used for potential future migration.
+2. Set `data['nova']['migration']['ssh_keys']['public']` with the content of
+  the SSH public key to be used for potential future migration.
+
+### Generate the dataplane-secrets CRs.
+
+```bash
+kustomize build > dataplane-secrets.yaml
+```
+
+### Create CRs the dataplane-secrets CRs.
+
+```bash
+oc apply -f dataplane-secrets.yaml
+```
+
+```
+popd
+```
+
+## Create the dataplane-nodeset CRs
+
+Generate the dataplane CRs.
+
+```
+pushd nodesets
+```
+
+```bash
+kustomize build > dataplane-nodesets.yaml
+```
+
+## Create CRs
+
+```bash
+oc apply -f dataplane-nodesets.yaml
+```
+
+Wait for dataplane deployment to finish
+
+```bash
+oc wait osdpd edpm-deployment --for condition=Ready --timeout=1200s
+```

--- a/examples/dt/bmo01/dataplane/baremetalhosts/bmc-secret.env
+++ b/examples/dt/bmo01/dataplane/baremetalhosts/bmc-secret.env
@@ -1,0 +1,2 @@
+username=admin
+password=password

--- a/examples/dt/bmo01/dataplane/baremetalhosts/kustomization.yaml
+++ b/examples/dt/bmo01/dataplane/baremetalhosts/kustomization.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../dt/bmo01/dataplane/baremetalhosts
+
+resources:
+  - values.yaml
+
+secretGenerator:
+  - name: bmc-secret
+    behavior: create
+    envs:
+      - bmc-secret.env
+    options:
+      disableNameSuffixHash: true

--- a/examples/dt/bmo01/dataplane/baremetalhosts/values.yaml
+++ b/examples/dt/bmo01/dataplane/baremetalhosts/values.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: baremetalhost-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  metal3_inspection: disabled
+  leaf0-0:
+    name: leaf0-0
+    labels:
+      app: openstack
+      nodeset: leaf0
+    bmc:
+      address: redfish-virtualmedia+http://sushy.utility:8000/redfish/v1/Systems/df2bf92f-3e2c-47e1-b1fa-0d2e06bd1b1d
+    bootMACAddress: 52:54:04:15:a8:d9
+    rootDeviceHints:
+      deviceName: /dev/sda
+    preprovisioningNetworkData:
+      nmstate: |
+        interfaces:
+          - name: enp5s0
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              address:
+                - ip: 192.168.130.100
+                  prefix-length: 24
+        dns-resolver:
+          config:
+            server:
+              - 192.168.122.1
+        routes:
+          config:
+            - destination: 0.0.0.0/0
+              next-hop-address: 192.168.130.1
+              next-hop-interface: enp5s0
+  leaf0-1:
+    name: leaf0-1
+    labels:
+      app: openstack
+      nodeset: leaf0
+    bmc:
+      address: redfish-virtualmedia+http://sushy.utility:8000/redfish/v1/Systems/455a0036-11f9-4417-a150-9ee858cd7b3d
+    bootMACAddress: 52:54:05:59:03:e9
+    rootDeviceHints:
+      deviceName: /dev/sda
+    preprovisioningNetworkData:
+      nmstate: |
+        interfaces:
+          - name: enp5s0
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              address:
+                - ip: 192.168.130.101
+                  prefix-length: 24
+        dns-resolver:
+          config:
+            server:
+              - 192.168.122.1
+        routes:
+          config:
+            - destination: 0.0.0.0/0
+              next-hop-address: 192.168.130.1
+              next-hop-interface: enp5s0
+  leaf1-0:
+    name: leaf1-0
+    labels:
+      app: openstack
+      nodeset: leaf1
+    bmc:
+      address: redfish-virtualmedia+http://sushy.utility:8000/redfish/v1/Systems/adbcfb62-afe9-488d-8e67-c3fd711e46e8
+    bootMACAddress: 52:54:06:49:2a:d2
+    rootDeviceHints:
+      deviceName: /dev/sda
+    preprovisioningNetworkData:
+      nmstate: |
+        interfaces:
+          - name: enp5s0
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              address:
+                - ip: 192.168.131.100
+                  prefix-length: 24
+        dns-resolver:
+          config:
+            server:
+              - 192.168.122.1
+        routes:
+          config:
+            - destination: 0.0.0.0/0
+              next-hop-address: 192.168.131.1
+              next-hop-interface: enp5s0
+  leaf1-1:
+    name: leaf1-1
+    labels:
+      app: openstack
+      nodeset: leaf1
+    bmc:
+      address: redfish-virtualmedia+http://sushy.utility:8000/redfish/v1/Systems/f5da12a3-b71d-4b81-9805-ebd5a2cd7bdf
+    bootMACAddress: 52:54:07:5f:0c:f4
+    rootDeviceHints:
+      deviceName: /dev/sda
+    preprovisioningNetworkData:
+      nmstate: |
+        interfaces:
+          - name: enp5s0
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              address:
+                - ip: 192.168.131.101
+                  prefix-length: 24
+        dns-resolver:
+          config:
+            server:
+              - 192.168.122.1
+        routes:
+          config:
+            - destination: 0.0.0.0/0
+              next-hop-address: 192.168.131.1
+              next-hop-interface: enp5s0

--- a/examples/dt/bmo01/dataplane/kustomization.yaml
+++ b/examples/dt/bmo01/dataplane/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/bmo01/dataplane
+
+resources:
+  - values.yaml

--- a/examples/dt/bmo01/dataplane/nodesets/kustomization.yaml
+++ b/examples/dt/bmo01/dataplane/nodesets/kustomization.yaml
@@ -1,0 +1,230 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bmo01/dataplane/nodesets
+
+resources:
+  - values.yaml
+
+replacements:
+  # nodeset-0 values
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.ctlplaneInterface
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-0
+        fieldPaths:
+          - spec.baremetalSetTemplate.ctlplaneInterface
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.neutron_physical_bridge_name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-0
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.neutron_physical_bridge_name
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.neutron_public_interface_name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-0
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.neutron_public_interface_name
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.edpm_network_config_template
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-0
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.edpm_network_config_template
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.edpm_sshd_allowed_ranges
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-0
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.edpm_sshd_allowed_ranges
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.timesync_ntp_servers
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-0
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.timesync_ntp_servers
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.edpm_bootstrap_command
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-0
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.nodes
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-0
+        fieldPaths:
+          - spec.nodes
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset0.edpm_ovn_bridge_mappings
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-0
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.edpm_ovn_bridge_mappings
+        options:
+          create: true
+
+  # nodeset-1 values
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.ctlplaneInterface
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-1
+        fieldPaths:
+          - spec.baremetalSetTemplate.ctlplaneInterface
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.neutron_physical_bridge_name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-1
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.neutron_physical_bridge_name
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.neutron_public_interface_name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-1
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.neutron_public_interface_name
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.edpm_network_config_template
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-1
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.edpm_network_config_template
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.edpm_sshd_allowed_ranges
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-1
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.edpm_sshd_allowed_ranges
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.timesync_ntp_servers
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-1
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.timesync_ntp_servers
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.edpm_bootstrap_command
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-1
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.nodes
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-1
+        fieldPaths:
+          - spec.nodes
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: nodeset-values
+      fieldPath: data.nodeset1.edpm_ovn_bridge_mappings
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: nodeset-1
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.edpm_ovn_bridge_mappings
+        options:
+          create: true

--- a/examples/dt/bmo01/dataplane/nodesets/values.yaml
+++ b/examples/dt/bmo01/dataplane/nodesets/values.yaml
@@ -1,0 +1,235 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  network_config_template: &network_config_template |
+    ---
+    {% set mtu_list = [ctlplane_mtu] %}
+    {% for network in nodeset_networks %}
+    {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+    {%- endfor %}
+    {% set min_viable_mtu = mtu_list | max %}
+    network_config:
+      - type: ovs_bridge
+        name: {{ neutron_physical_bridge_name }}
+        mtu: {{ min_viable_mtu }}
+        use_dhcp: false
+        dns_servers: {{ ctlplane_dns_nameservers }}
+        domain: {{ dns_search_domains }}
+        addresses:
+          - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+        routes: {{ ctlplane_host_routes }}
+        members:
+          - type: interface
+            name: nic1
+            mtu: {{ min_viable_mtu }}
+            primary: true
+    {% for network in nodeset_networks %}
+          - type: vlan
+            mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+            vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+            addresses:
+              - ip_netmask: >-
+                  {{
+                    lookup('vars', networks_lower[network] ~ '_ip')
+                  }}/{{
+                    lookup('vars', networks_lower[network] ~ '_cidr')
+                  }}
+            routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+    {% endfor %}
+
+  nodeset0:
+    ctlplaneInterface: enp5s0
+    neutron_physical_bridge_name: br-ex
+    neutron_public_interface_name: enp5s0
+    edpm_ovn_bridge_mappings:
+      - "datacentre_leaf0:br-ex"
+    edpm_network_config_template: *network_config_template
+    edpm_sshd_allowed_ranges:
+      - 192.168.122.0/24
+      - 192.168.123.0/24
+      - 192.168.124.0/24
+      - 192.168.32.9/20
+    timesync_ntp_servers:
+      - hostname: pool.ntp.org
+    edpm_bootstrap_command: |
+      # _replace_
+      echo "Bootstrap script."
+    baremetalHostsNetworkData:
+      edpm-compute-0-0:
+        networkData: |
+          links:
+            - name: enp5s0
+              id: enp5s0
+              type: vif
+          networks:
+            - link: enp5s0
+              id: enp5s0
+              type: ipv4
+              network_id: enp5s0
+              ip_address: 192.168.123.100
+              netmask: 255.255.255.0
+              routes:
+                - network: 0.0.0.0
+                  netmask: 0.0.0.0
+                  gateway: 192.168.123.1
+          services:
+            - type: dns
+              address: 192.168.122.1
+      edpm-compute-0-1:
+        networkData: |
+          links:
+            - name: enp5s0
+              id: enp5s0
+              type: vif
+          networks:
+            - link: enp5s0
+              id: enp5s0
+              type: ipv4
+              network_id: enp5s0
+              ip_address: 192.168.123.101
+              netmask: 255.255.255.0
+              routes:
+                - network: 0.0.0.0
+                  netmask: 0.0.0.0
+                  gateway: 192.168.123.1
+          services:
+            - type: dns
+              address: 192.168.122.1
+    nodes:
+      edpm-compute-0-0:
+        networkData:
+          name: edpm-compute-0-0-network-data
+          namespace: openstack
+        ansible:
+          ansibleHost: 192.168.123.100
+        hostName: edpm-compute-0-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.123.100
+            name: ctlplane
+            subnetName: subnet2
+          - name: internalapi
+            subnetName: subnet2
+          - name: storage
+            subnetName: subnet2
+          - name: tenant
+            subnetName: subnet2
+      edpm-compute-0-1:
+        networkData:
+          name: edpm-compute-0-1-network-data
+          namespace: openstack
+        ansible:
+          ansibleHost: 192.168.123.101
+        hostName: edpm-compute-0-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.123.101
+            name: ctlplane
+            subnetName: subnet2
+          - name: internalapi
+            subnetName: subnet2
+          - name: storage
+            subnetName: subnet2
+          - name: tenant
+            subnetName: subnet2
+
+  nodeset1:
+    ctlplaneInterface: enp5s0
+    neutron_physical_bridge_name: br-ex
+    neutron_public_interface_name: enp5s0
+    edpm_ovn_bridge_mappings:
+      - "datacentre_leaf1:br-ex"
+    edpm_network_config_template: *network_config_template
+    edpm_sshd_allowed_ranges:
+      - 192.168.122.0/24
+      - 192.168.123.0/24
+      - 192.168.124.0/24
+      - 192.168.32.9/20
+    timesync_ntp_servers:
+      - hostname: pool.ntp.org
+    edpm_bootstrap_command: |
+      # _replace_
+      echo "Bootstrap script."
+    baremetalHostsNetworkData:
+      edpm-compute-1-0:
+        networkData: |
+          links:
+            - name: enp5s0
+              id: enp5s0
+              type: vif
+          networks:
+            - link: enp5s0
+              id: enp5s0
+              type: ipv4
+              network_id: enp5s0
+              ip_address: 192.168.124.100
+              netmask: 255.255.255.0
+              routes:
+                - network: 0.0.0.0
+                  netmask: 0.0.0.0
+                  gateway: 192.168.124.1
+          services:
+            - type: dns
+              address: 192.168.122.1
+      edpm-compute-1-1:
+        networkData: |
+          links:
+            - name: enp5s0
+              id: enp5s0
+              type: vif
+          networks:
+            - link: enp5s0
+              id: enp5s0
+              type: ipv4
+              network_id: enp5s0
+              ip_address: 192.168.124.101
+              netmask: 255.255.255.0
+              routes:
+                - network: 0.0.0.0
+                  netmask: 0.0.0.0
+                  gateway: 192.168.124.1
+          services:
+            - type: dns
+              address: 192.168.122.1
+    nodes:
+      edpm-compute-1-0:
+        networkData:
+          name: edpm-compute-1-0-network-data
+          namespace: openstack
+        ansible:
+          ansibleHost: 192.168.124.100
+        hostName: edpm-compute-1-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.124.100
+            name: ctlplane
+            subnetName: subnet3
+          - name: internalapi
+            subnetName: subnet3
+          - name: storage
+            subnetName: subnet3
+          - name: tenant
+            subnetName: subnet3
+      edpm-compute-1-1:
+        networkData:
+          name: edpm-compute-1-1-network-data
+          namespace: openstack
+        ansible:
+          ansibleHost: 192.168.124.101
+        hostName: edpm-compute-1-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.124.101
+            name: ctlplane
+            subnetName: subnet3
+          - name: internalapi
+            subnetName: subnet3
+          - name: storage
+            subnetName: subnet3
+          - name: tenant
+            subnetName: subnet3

--- a/examples/dt/bmo01/dataplane/secrets/kustomization.yaml
+++ b/examples/dt/bmo01/dataplane/secrets/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bmo01/dataplane/secrets
+
+resources:
+  - values.yaml

--- a/examples/dt/bmo01/dataplane/secrets/values.yaml
+++ b/examples/dt/bmo01/dataplane/secrets/values.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: dataplane-secret-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  ssh_keys:
+    authorized: _replaced_
+    private: _replaced_
+    public: _replaced_
+
+  nova:
+    migration:
+      ssh_keys:
+        private: _replaced_
+        public: _replaced_kustomization.yaml

--- a/examples/dt/bmo01/dataplane/values.yaml
+++ b/examples/dt/bmo01/dataplane/values.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data: {}

--- a/examples/dt/bmo01/osp-k8s-spine-leaf.svg
+++ b/examples/dt/bmo01/osp-k8s-spine-leaf.svg
@@ -1,0 +1,1057 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.2"
+   width="138mm"
+   height="100mm"
+   viewBox="0 0 13800 10000"
+   preserveAspectRatio="xMidYMid"
+   fill-rule="evenodd"
+   stroke-width="28.222"
+   stroke-linejoin="round"
+   xml:space="preserve"
+   id="svg89"
+   sodipodi:docname="osp-k8s-spine-leaf.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+   id="namedview89"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:document-units="mm"
+   inkscape:zoom="0.71713664"
+   inkscape:cx="397.4138"
+   inkscape:cy="561.25984"
+   inkscape:window-width="1920"
+   inkscape:window-height="1011"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg89" />
+ <defs
+   class="ClipPathGroup"
+   id="defs2"><clipPath
+     id="presentation_clip_path"
+     clipPathUnits="userSpaceOnUse">
+   <rect
+   x="0"
+   y="0"
+   width="21000"
+   height="29700"
+   id="rect1" />
+  </clipPath></defs>
+ <defs
+   id="defs19"><font
+     id="EmbeddedFont_1"
+     horiz-adv-x="2048"
+     horiz-origin-x="0"
+     horiz-origin-y="0"
+     vert-origin-x="512"
+     vert-origin-y="768"
+     vert-adv-y="1024">
+   <font-face
+   font-family="Liberation Sans embedded"
+   units-per-em="2048"
+   font-weight="normal"
+   font-style="normal"
+   ascent="1852"
+   descent="423"
+   id="font-face2" />
+   <missing-glyph
+   horiz-adv-x="2048"
+   d="M 0,0 L 2047,0 2047,2047 0,2047 0,0 Z"
+   id="missing-glyph2" />
+   <glyph
+   unicode="s"
+   horiz-adv-x="901"
+   d="M 950,299 C 950,197 912,118 835,63 758,8 650,-20 511,-20 376,-20 273,2 200,47 127,91 79,160 57,254 L 216,285 C 231,227 263,185 311,158 359,131 426,117 511,117 602,117 669,131 712,159 754,187 775,229 775,285 775,328 760,362 731,389 702,416 654,438 589,455 L 460,489 C 357,516 283,542 240,568 196,593 162,624 137,661 112,698 100,743 100,796 100,895 135,970 206,1022 276,1073 378,1099 513,1099 632,1099 727,1078 798,1036 868,994 912,927 931,834 L 769,814 C 759,862 732,899 689,925 645,950 586,963 513,963 432,963 372,951 333,926 294,901 275,864 275,814 275,783 283,758 299,738 315,718 339,701 370,687 401,673 467,654 568,629 663,605 732,583 774,563 816,542 849,520 874,495 898,470 917,442 930,410 943,377 950,340 950,299 Z"
+   id="glyph2" />
+   <glyph
+   unicode="p"
+   horiz-adv-x="953"
+   d="M 1053,546 C 1053,169 920,-20 655,-20 488,-20 376,43 319,168 L 314,168 C 317,163 318,106 318,-2 L 318,-425 138,-425 138,861 C 138,972 136,1046 132,1082 L 306,1082 C 307,1079 308,1070 309,1054 310,1037 312,1012 314,978 315,944 316,921 316,908 L 320,908 C 352,975 394,1024 447,1055 500,1086 569,1101 655,1101 788,1101 888,1056 954,967 1020,878 1053,737 1053,546 Z M 864,542 C 864,693 844,800 803,865 762,930 698,962 609,962 538,962 482,947 442,917 401,887 371,840 350,777 329,713 318,630 318,528 318,386 341,281 386,214 431,147 505,113 607,113 696,113 762,146 803,212 844,277 864,387 864,542 Z"
+   id="glyph3" />
+   <glyph
+   unicode="n"
+   horiz-adv-x="874"
+   d="M 825,0 L 825,686 C 825,757 818,813 804,852 790,891 768,920 737,937 706,954 661,963 602,963 515,963 447,933 397,874 347,815 322,732 322,627 L 322,0 142,0 142,851 C 142,977 140,1054 136,1082 L 306,1082 C 307,1079 307,1070 308,1055 309,1040 310,1024 311,1005 312,986 313,950 314,897 L 317,897 C 358,972 406,1025 461,1056 515,1087 582,1102 663,1102 782,1102 869,1073 924,1014 979,955 1006,857 1006,721 L 1006,0 825,0 Z"
+   id="glyph4" />
+   <glyph
+   unicode="m"
+   horiz-adv-x="1457"
+   d="M 768,0 L 768,686 C 768,791 754,863 725,903 696,943 645,963 570,963 493,963 433,934 388,875 343,816 321,734 321,627 L 321,0 142,0 142,851 C 142,977 140,1054 136,1082 L 306,1082 C 307,1079 307,1070 308,1055 309,1040 310,1024 311,1005 312,986 313,950 314,897 L 317,897 C 356,974 400,1027 450,1057 500,1087 561,1102 633,1102 715,1102 780,1086 828,1053 875,1020 908,968 927,897 L 930,897 C 967,970 1013,1022 1066,1054 1119,1086 1183,1102 1258,1102 1367,1102 1447,1072 1497,1013 1546,954 1571,856 1571,721 L 1571,0 1393,0 1393,686 C 1393,791 1379,863 1350,903 1321,943 1270,963 1195,963 1116,963 1055,934 1012,876 968,817 946,734 946,627 L 946,0 768,0 Z"
+   id="glyph5" />
+   <glyph
+   unicode="l"
+   horiz-adv-x="187"
+   d="M 138,0 L 138,1484 318,1484 318,0 138,0 Z"
+   id="glyph6" />
+   <glyph
+   unicode="i"
+   horiz-adv-x="187"
+   d="M 137,1312 L 137,1484 317,1484 317,1312 137,1312 Z M 137,0 L 137,1082 317,1082 317,0 137,0 Z"
+   id="glyph7" />
+   <glyph
+   unicode="f"
+   horiz-adv-x="557"
+   d="M 361,951 L 361,0 181,0 181,951 29,951 29,1082 181,1082 181,1204 C 181,1303 203,1374 246,1417 289,1460 356,1482 445,1482 495,1482 537,1478 572,1470 L 572,1333 C 542,1338 515,1341 492,1341 446,1341 413,1329 392,1306 371,1283 361,1240 361,1179 L 361,1082 572,1082 572,951 361,951 Z"
+   id="glyph8" />
+   <glyph
+   unicode="e"
+   horiz-adv-x="980"
+   d="M 276,503 C 276,379 302,283 353,216 404,149 479,115 578,115 656,115 719,131 766,162 813,193 844,233 861,281 L 1019,236 C 954,65 807,-20 578,-20 418,-20 296,28 213,123 129,218 87,360 87,548 87,727 129,864 213,959 296,1054 416,1102 571,1102 889,1102 1048,910 1048,527 L 1048,503 276,503 Z M 862,641 C 852,755 823,838 775,891 727,943 658,969 568,969 481,969 412,940 361,882 310,823 282,743 278,641 L 862,641 Z"
+   id="glyph9" />
+   <glyph
+   unicode="d"
+   horiz-adv-x="927"
+   d="M 821,174 C 788,105 744,55 689,25 634,-5 565,-20 484,-20 347,-20 247,26 183,118 118,210 86,349 86,536 86,913 219,1102 484,1102 566,1102 634,1087 689,1057 744,1027 788,979 821,914 L 823,914 821,1035 821,1484 1001,1484 1001,223 C 1001,110 1003,36 1007,0 L 835,0 C 833,11 831,35 829,74 826,113 825,146 825,174 L 821,174 Z M 275,542 C 275,391 295,282 335,217 375,152 440,119 530,119 632,119 706,154 752,225 798,296 821,405 821,554 821,697 798,802 752,869 706,936 633,969 532,969 441,969 376,936 336,869 295,802 275,693 275,542 Z"
+   id="glyph10" />
+   <glyph
+   unicode="a"
+   horiz-adv-x="1060"
+   d="M 414,-20 C 305,-20 224,9 169,66 114,123 87,202 87,302 87,414 124,500 198,560 271,620 390,652 554,656 L 797,660 797,719 C 797,807 778,870 741,908 704,946 645,965 565,965 484,965 426,951 389,924 352,897 330,853 323,793 L 135,810 C 166,1005 310,1102 569,1102 705,1102 807,1071 876,1009 945,946 979,856 979,738 L 979,272 C 979,219 986,179 1000,152 1014,125 1041,111 1080,111 1097,111 1117,113 1139,118 L 1139,6 C 1094,-5 1047,-10 1000,-10 933,-10 885,8 855,43 824,78 807,132 803,207 L 797,207 C 751,124 698,66 637,32 576,-3 501,-20 414,-20 Z M 455,115 C 521,115 580,130 631,160 682,190 723,231 753,284 782,336 797,390 797,445 L 797,534 600,530 C 515,529 451,520 408,504 364,488 330,463 307,430 284,397 272,353 272,299 272,240 288,195 320,163 351,131 396,115 455,115 Z"
+   id="glyph11" />
+   <glyph
+   unicode="P"
+   horiz-adv-x="1112"
+   d="M 1258,985 C 1258,852 1215,746 1128,667 1041,588 922,549 773,549 L 359,549 359,0 168,0 168,1409 761,1409 C 919,1409 1041,1372 1128,1298 1215,1224 1258,1120 1258,985 Z M 1066,983 C 1066,1165 957,1256 738,1256 L 359,1256 359,700 746,700 C 959,700 1066,794 1066,983 Z"
+   id="glyph12" />
+   <glyph
+   unicode="O"
+   horiz-adv-x="1430"
+   d="M 1495,711 C 1495,564 1467,435 1411,324 1354,213 1273,128 1168,69 1063,10 938,-20 795,-20 650,-20 526,9 421,68 316,127 235,212 180,323 125,434 97,563 97,711 97,936 159,1113 282,1240 405,1367 577,1430 797,1430 940,1430 1065,1402 1170,1345 1275,1288 1356,1205 1412,1096 1467,987 1495,859 1495,711 Z M 1300,711 C 1300,886 1256,1024 1169,1124 1081,1224 957,1274 797,1274 636,1274 511,1225 423,1126 335,1027 291,889 291,711 291,534 336,394 425,291 514,187 637,135 795,135 958,135 1083,185 1170,286 1257,386 1300,528 1300,711 Z"
+   id="glyph13" />
+   <glyph
+   unicode="C"
+   horiz-adv-x="1324"
+   d="M 792,1274 C 636,1274 515,1224 428,1124 341,1023 298,886 298,711 298,538 343,400 434,295 524,190 646,137 800,137 997,137 1146,235 1245,430 L 1401,352 C 1343,231 1262,138 1157,75 1052,12 930,-20 791,-20 649,-20 526,10 423,69 319,128 240,212 186,322 131,431 104,561 104,711 104,936 165,1112 286,1239 407,1366 575,1430 790,1430 940,1430 1065,1401 1166,1342 1267,1283 1341,1196 1388,1081 L 1207,1021 C 1174,1103 1122,1166 1050,1209 977,1252 891,1274 792,1274 Z"
+   id="glyph14" />
+   <glyph
+   unicode="3"
+   horiz-adv-x="1006"
+   d="M 1049,389 C 1049,259 1008,158 925,87 842,16 724,-20 571,-20 428,-20 315,12 230,77 145,141 94,236 78,362 L 264,379 C 288,212 390,129 571,129 662,129 733,151 785,196 836,241 862,307 862,395 862,472 833,532 774,575 715,618 629,639 518,639 L 416,639 416,795 514,795 C 613,795 689,817 744,860 798,903 825,962 825,1038 825,1113 803,1173 759,1217 714,1260 648,1282 561,1282 482,1282 418,1262 369,1221 320,1180 291,1123 283,1049 L 102,1063 C 115,1178 163,1268 246,1333 328,1398 434,1430 563,1430 704,1430 814,1397 893,1332 971,1266 1010,1174 1010,1057 1010,967 985,894 935,838 884,781 811,743 715,723 L 715,719 C 820,708 902,672 961,613 1020,554 1049,479 1049,389 Z"
+   id="glyph15" />
+   <glyph
+   unicode="2"
+   horiz-adv-x="954"
+   d="M 103,0 L 103,127 C 137,205 179,274 228,334 277,393 328,447 382,496 436,544 490,589 543,630 596,671 643,713 686,754 729,795 763,839 790,884 816,929 829,981 829,1038 829,1115 806,1175 761,1218 716,1261 653,1282 572,1282 495,1282 432,1261 383,1220 333,1178 304,1119 295,1044 L 111,1061 C 124,1174 172,1263 255,1330 337,1397 443,1430 572,1430 714,1430 823,1397 900,1330 976,1263 1014,1167 1014,1044 1014,989 1002,935 977,881 952,827 914,773 865,719 816,665 721,581 582,468 505,405 444,349 399,299 354,248 321,200 301,153 L 1036,153 1036,0 103,0 Z"
+   id="glyph16" />
+   <glyph
+   unicode="1"
+   horiz-adv-x="927"
+   d="M 156,0 L 156,153 515,153 515,1237 197,1010 197,1180 530,1409 696,1409 696,153 1039,153 1039,0 156,0 Z"
+   id="glyph17" />
+   <glyph
+   unicode="0"
+   horiz-adv-x="980"
+   d="M 1059,705 C 1059,470 1018,290 935,166 852,42 729,-20 567,-20 405,-20 283,42 202,165 121,288 80,468 80,705 80,947 120,1128 199,1249 278,1370 402,1430 573,1430 739,1430 862,1369 941,1247 1020,1125 1059,944 1059,705 Z M 876,705 C 876,908 853,1056 806,1147 759,1238 681,1284 573,1284 462,1284 383,1239 335,1149 286,1059 262,911 262,705 262,505 287,359 336,266 385,173 462,127 569,127 675,127 753,174 802,269 851,364 876,509 876,705 Z"
+   id="glyph18" />
+   <glyph
+   unicode="-"
+   horiz-adv-x="531"
+   d="M 91,464 L 91,624 591,624 591,464 91,464 Z"
+   id="glyph19" />
+  </font></defs>
+ <defs
+   class="TextShapeIndex"
+   id="defs20" />
+ <defs
+   class="EmbeddedBulletChars"
+   id="defs29" />
+ <g
+   id="g29">
+  <g
+   id="id2"
+   class="Master_Slide">
+   <g
+   id="bg-id2"
+   class="Background" />
+   <g
+   id="bo-id2"
+   class="BackgroundObjects" />
+  </g>
+ </g>
+ <g
+   class="SlideGroup"
+   id="g89"
+   transform="translate(-768.44136,-768.29725)">
+  <g
+   id="g88">
+   <g
+   id="container-id1">
+    <g
+   id="id1"
+   class="Slide"
+   clip-path="url(#presentation_clip_path)">
+     <g
+   class="Page"
+   id="g87">
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g31">
+       <g
+   id="id3">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="999"
+   y="999"
+   width="13253"
+   height="2253"
+   id="rect29" />
+        <path
+   fill="#355269"
+   stroke="none"
+   d="M 7625,3250 H 1000 V 1000 h 13250 v 2250 z"
+   id="path30" />
+        <path
+   fill="none"
+   stroke="#b2b2b2"
+   d="M 7625,3250 H 1000 V 1000 h 13250 v 2250 z"
+   id="path31" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g33">
+       <g
+   id="id4">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="9999"
+   y="4249"
+   width="4253"
+   height="6253"
+   id="rect31" />
+        <path
+   fill="#355269"
+   stroke="none"
+   d="M 12125,10500 H 10000 V 4250 h 4250 v 6250 z"
+   id="path32" />
+        <path
+   fill="none"
+   stroke="#b2b2b2"
+   d="M 12125,10500 H 10000 V 4250 h 4250 v 6250 z"
+   id="path33" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g35">
+       <g
+   id="id5">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="5499"
+   y="4249"
+   width="4253"
+   height="6253"
+   id="rect33" />
+        <path
+   fill="#355269"
+   stroke="none"
+   d="M 7625,10500 H 5500 V 4250 h 4250 v 6250 z"
+   id="path34" />
+        <path
+   fill="none"
+   stroke="#b2b2b2"
+   d="M 7625,10500 H 5500 V 4250 h 4250 v 6250 z"
+   id="path35" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g37">
+       <g
+   id="id6">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="999"
+   y="4249"
+   width="4253"
+   height="6253"
+   id="rect35" />
+        <path
+   fill="#355269"
+   stroke="none"
+   d="M 3125,10500 H 1000 V 4250 h 4250 v 6250 z"
+   id="path36" />
+        <path
+   fill="none"
+   stroke="#b2b2b2"
+   d="M 3125,10500 H 1000 V 4250 h 4250 v 6250 z"
+   id="path37" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g41">
+       <g
+   id="id7">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="1249"
+   y="6749"
+   width="3753"
+   height="1003"
+   id="rect37" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 3125,7750 H 1250 V 6750 h 3750 v 1000 z"
+   id="path38" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 3125,7750 H 1250 V 6750 h 3750 v 1000 z"
+   id="path39" />
+        <text
+   class="SVGTextShape"
+   id="text41"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan41"><tspan
+       class="TextPosition"
+       x="2477"
+       y="7398"
+       id="tspan40"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan39">OCP-0</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g44">
+       <g
+   id="id8">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="1249"
+   y="7999"
+   width="3753"
+   height="1003"
+   id="rect41" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 3125,9000 H 1250 V 8000 h 3750 v 1000 z"
+   id="path41" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 3125,9000 H 1250 V 8000 h 3750 v 1000 z"
+   id="path42" />
+        <text
+   class="SVGTextShape"
+   id="text44"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan44"><tspan
+       class="TextPosition"
+       x="2477"
+       y="8648"
+       id="tspan43"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan42">OCP-1</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g47">
+       <g
+   id="id9">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="1249"
+   y="9249"
+   width="3753"
+   height="1003"
+   id="rect44" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 3125,10250 H 1250 V 9250 h 3750 v 1000 z"
+   id="path44" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 3125,10250 H 1250 V 9250 h 3750 v 1000 z"
+   id="path45" />
+        <text
+   class="SVGTextShape"
+   id="text47"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan47"><tspan
+       class="TextPosition"
+       x="2477"
+       y="9898"
+       id="tspan46"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan45">OCP-2</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g50">
+       <g
+   id="id10">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="5749"
+   y="6749"
+   width="3753"
+   height="1003"
+   id="rect47" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 7625,7750 H 5750 V 6750 h 3750 v 1000 z"
+   id="path47" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 7625,7750 H 5750 V 6750 h 3750 v 1000 z"
+   id="path48" />
+        <text
+   class="SVGTextShape"
+   id="text50"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan50"><tspan
+       class="TextPosition"
+       x="6905"
+       y="7398"
+       id="tspan49"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan48">edpm-0</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g53">
+       <g
+   id="id11">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="5749"
+   y="7999"
+   width="3753"
+   height="1003"
+   id="rect50" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 7625,9000 H 5750 V 8000 h 3750 v 1000 z"
+   id="path50" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 7625,9000 H 5750 V 8000 h 3750 v 1000 z"
+   id="path51" />
+        <text
+   class="SVGTextShape"
+   id="text53"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan53"><tspan
+       class="TextPosition"
+       x="6905"
+       y="8648"
+       id="tspan52"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan51">edpm-1</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g56">
+       <g
+   id="id12">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="10249"
+   y="6749"
+   width="3753"
+   height="1003"
+   id="rect53" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 12125,7750 H 10250 V 6750 h 3750 v 1000 z"
+   id="path53" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 12125,7750 H 10250 V 6750 h 3750 v 1000 z"
+   id="path54" />
+        <text
+   class="SVGTextShape"
+   id="text56"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan56"><tspan
+       class="TextPosition"
+       x="11405"
+       y="7398"
+       id="tspan55"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan54">edpm-2</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g59">
+       <g
+   id="id13">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="10249"
+   y="7999"
+   width="3753"
+   height="1003"
+   id="rect56" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 12125,9000 H 10250 V 8000 h 3750 v 1000 z"
+   id="path56" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 12125,9000 H 10250 V 8000 h 3750 v 1000 z"
+   id="path57" />
+        <text
+   class="SVGTextShape"
+   id="text59"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan59"><tspan
+       class="TextPosition"
+       x="11405"
+       y="8648"
+       id="tspan58"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan57">edpm-3</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g62">
+       <g
+   id="id14">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="1249"
+   y="1249"
+   width="3753"
+   height="1753"
+   id="rect59" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 3125,3000 H 1250 V 1250 h 3750 v 1750 z"
+   id="path59" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 3125,3000 H 1250 V 1250 h 3750 v 1750 z"
+   id="path60" />
+        <text
+   class="SVGTextShape"
+   id="text62"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan62"><tspan
+       class="TextPosition"
+       x="2428"
+       y="2273"
+       id="tspan61"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan60">spine-0</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g65">
+       <g
+   id="id15">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="5749"
+   y="1249"
+   width="3753"
+   height="1753"
+   id="rect62" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 7625,3000 H 5750 V 1250 h 3750 v 1750 z"
+   id="path62" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 7625,3000 H 5750 V 1250 h 3750 v 1750 z"
+   id="path63" />
+        <text
+   class="SVGTextShape"
+   id="text65"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan65"><tspan
+       class="TextPosition"
+       x="6928"
+       y="2273"
+       id="tspan64"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan63">spine-1</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g68">
+       <g
+   id="id16">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="10249"
+   y="1249"
+   width="3753"
+   height="1753"
+   id="rect65" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 12125,3000 H 10250 V 1250 h 3750 v 1750 z"
+   id="path65" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 12125,3000 H 10250 V 1250 h 3750 v 1750 z"
+   id="path66" />
+        <text
+   class="SVGTextShape"
+   id="text68"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan68"><tspan
+       class="TextPosition"
+       x="11428"
+       y="2273"
+       id="tspan67"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan66">spine-2</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g71">
+       <g
+   id="id17">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="1249"
+   y="4499"
+   width="3753"
+   height="1753"
+   id="rect68" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 3125,6250 H 1250 V 4500 h 3750 v 1750 z"
+   id="path68" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 3125,6250 H 1250 V 4500 h 3750 v 1750 z"
+   id="path69" />
+        <text
+   class="SVGTextShape"
+   id="text71"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan71"><tspan
+       class="TextPosition"
+       x="2593"
+       y="5523"
+       id="tspan70"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan69">leaf-0</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g74">
+       <g
+   id="id18">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="10249"
+   y="4499"
+   width="3753"
+   height="1753"
+   id="rect71" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 12125,6250 H 10250 V 4500 h 3750 v 1750 z"
+   id="path71" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 12125,6250 H 10250 V 4500 h 3750 v 1750 z"
+   id="path72" />
+        <text
+   class="SVGTextShape"
+   id="text74"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan74"><tspan
+       class="TextPosition"
+       x="11593"
+       y="5523"
+       id="tspan73"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan72">leaf-2</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.CustomShape"
+   id="g77">
+       <g
+   id="id19">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="5749"
+   y="4499"
+   width="3753"
+   height="1753"
+   id="rect74" />
+        <path
+   fill="#729fcf"
+   stroke="none"
+   d="M 7625,6250 H 5750 V 4500 h 3750 v 1750 z"
+   id="path74" />
+        <path
+   fill="none"
+   stroke="#3465a4"
+   d="M 7625,6250 H 5750 V 4500 h 3750 v 1750 z"
+   id="path75" />
+        <text
+   class="SVGTextShape"
+   id="text77"><tspan
+     class="TextParagraph"
+     font-family="'Liberation Sans', sans-serif"
+     font-size="423px"
+     font-weight="400"
+     id="tspan77"><tspan
+       class="TextPosition"
+       x="7093"
+       y="5523"
+       id="tspan76"><tspan
+         fill="#000000"
+         stroke="none"
+         style="white-space:pre"
+         id="tspan75">leaf-1</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.ConnectorShape"
+   id="g78">
+       <g
+   id="id20">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="3107"
+   y="2982"
+   width="37"
+   height="1537"
+   id="rect77" />
+        <path
+   fill="none"
+   stroke="#999999"
+   stroke-width="35"
+   stroke-linejoin="round"
+   d="M 3125,3000 V 4500"
+   id="path77" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.ConnectorShape"
+   id="g79">
+       <g
+   id="id21">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="3107"
+   y="2982"
+   width="4537"
+   height="1537"
+   id="rect78" />
+        <path
+   fill="none"
+   stroke="#999999"
+   stroke-width="35"
+   stroke-linejoin="round"
+   d="M 3125,3000 7625,4500"
+   id="path78" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.ConnectorShape"
+   id="g80">
+       <g
+   id="id22">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="3107"
+   y="2982"
+   width="9037"
+   height="1537"
+   id="rect79" />
+        <path
+   fill="none"
+   stroke="#999999"
+   stroke-width="35"
+   stroke-linejoin="round"
+   d="m 3125,3000 9000,1500"
+   id="path79" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.ConnectorShape"
+   id="g81">
+       <g
+   id="id23">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="3107"
+   y="2982"
+   width="4537"
+   height="1537"
+   id="rect80" />
+        <path
+   fill="none"
+   stroke="#999999"
+   stroke-width="35"
+   stroke-linejoin="round"
+   d="M 7625,3000 3125,4500"
+   id="path80" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.ConnectorShape"
+   id="g82">
+       <g
+   id="id24">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="7607"
+   y="2982"
+   width="37"
+   height="1537"
+   id="rect81" />
+        <path
+   fill="none"
+   stroke="#999999"
+   stroke-width="35"
+   stroke-linejoin="round"
+   d="M 7625,3000 V 4500"
+   id="path81" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.ConnectorShape"
+   id="g83">
+       <g
+   id="id25">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="12107"
+   y="2982"
+   width="37"
+   height="1537"
+   id="rect82" />
+        <path
+   fill="none"
+   stroke="#999999"
+   stroke-width="35"
+   stroke-linejoin="round"
+   d="M 12125,3000 V 4500"
+   id="path82" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.ConnectorShape"
+   id="g84">
+       <g
+   id="id26">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="7607"
+   y="2982"
+   width="4537"
+   height="1537"
+   id="rect83" />
+        <path
+   fill="none"
+   stroke="#999999"
+   stroke-width="35"
+   stroke-linejoin="round"
+   d="m 7625,3000 4500,1500"
+   id="path83" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.ConnectorShape"
+   id="g85">
+       <g
+   id="id27">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="7607"
+   y="2982"
+   width="4537"
+   height="1537"
+   id="rect84" />
+        <path
+   fill="none"
+   stroke="#999999"
+   stroke-width="35"
+   stroke-linejoin="round"
+   d="M 12125,3000 7625,4500"
+   id="path84" />
+       </g>
+      </g>
+      <g
+   class="com.sun.star.drawing.ConnectorShape"
+   id="g86">
+       <g
+   id="id28">
+        <rect
+   class="BoundingBox"
+   stroke="none"
+   fill="none"
+   x="3107"
+   y="2982"
+   width="9037"
+   height="1537"
+   id="rect85" />
+        <path
+   fill="none"
+   stroke="#999999"
+   stroke-width="35"
+   stroke-linejoin="round"
+   d="M 12125,3000 3125,4500"
+   id="path85" />
+       </g>
+      </g>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -4,6 +4,7 @@
       - noop
       - rhoso-architecture-validate-bgp
       - rhoso-architecture-validate-bgp_dt01
+      - rhoso-architecture-validate-bmo01
       - rhoso-architecture-validate-dcn
       - rhoso-architecture-validate-hci
       - rhoso-architecture-validate-nfv-ovs-dpdk-sriov-hci

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -27,6 +27,23 @@
       cifmw_architecture_scenario: bgp_dt01
 - job:
     files:
+    - automation/mocks/bmo01.yaml
+    - automation/net-env/bmo01.yaml
+    - dt/bmo01
+    - examples/dt/bmo01/control-plane
+    - examples/dt/bmo01/control-plane/nncp
+    - examples/dt/bmo01/dataplane
+    - examples/dt/bmo01/dataplane/baremetalhosts
+    - examples/dt/bmo01/dataplane/nodesets
+    - examples/dt/bmo01/dataplane/secrets
+    - lib
+    name: rhoso-architecture-validate-bmo01
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: bmo01
+      cifmw_networking_env_def_file: automation/net-env/bmo01.yaml
+- job:
+    files:
     - automation/net-env/dcn.yaml
     - dt/dcn
     - examples/dt/dcn/control-plane


### PR DESCRIPTION
This DT ...

* Uses OCP Metal3 to provision the compute nodes over redfish-virtualmedia.
* Deploys the two pairs of compute nodes in separate networks - routed/spine-and-leaf architecture.


Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2425