### PR TITLE
Enable telemetry in OSASINFRA DT

### DIFF
--- a/dt/osasinfra/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/osasinfra/edpm-post-ceph/nodeset/kustomization.yaml
@@ -310,3 +310,39 @@ replacements:
           - spec.ovn.template.ovnController.nicMappings
         options:
           create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.metricStorage.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.ceilometer.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.ceilometer.enabled
+        options:
+          create: true

--- a/examples/dt/osasinfra/control-plane.md
+++ b/examples/dt/osasinfra/control-plane.md
@@ -3,6 +3,7 @@
 ## Assumptions
 
 - A storage class called `local-storage` should already exist.
+- Cluster observability operator is already deployed.
 
 ## Initialize
 

--- a/examples/dt/osasinfra/service-values.yaml
+++ b/examples/dt/osasinfra/service-values.yaml
@@ -113,3 +113,10 @@ data:
       nicMappings:
         datacentre: ocpbr
         octavia: octbr
+
+  telemetry:
+    enabled: true
+    metricStorage:
+      enabled: true
+    ceilometer:
+      enabled: true

--- a/examples/dt/osasinfra/values.yaml
+++ b/examples/dt/osasinfra/values.yaml
@@ -15,6 +15,7 @@ data:
       - neutron-metadata
       - libvirt
       - nova
+      - telemetry
   ceph:
     conf: CHANGEME_CEPH_CONF
     keyring: CHANGEME_CEPH_KEYRING


### PR DESCRIPTION
Compared to uni01alpha that is the other DT to enable telemetry, we're not enabling autoscaling as it requires the additional heat service.

Depends on https://github.com/openstack-k8s-operators/ci-framework/pull/2449.