### PR TITLE
Add telemetry metricStorage for NFV

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
@@ -56,6 +56,8 @@ data:
     template:
       ceilometer:
         enabled: true
+      metricStorage:
+        enabled: true
   extraMounts:
     - name: v1
       region: r1

--- a/va/nfv/ovs-dpdk-sriov/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-sriov/kustomization.yaml
@@ -109,6 +109,17 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.telemetry.template.metricStorage
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.extraMounts
     targets:
       - select:


### PR DESCRIPTION
metricStorage is required for enabling power monitoring feature that is planned in the next feature release of RHOSO. The feature is intended for NFV workloads power monitoring.