### PR TITLE
[uni07eta] Bump edpm-deployment wait condition timout

### DIFF
--- a/automation/vars/uni07eta.yaml
+++ b/automation/vars/uni07eta.yaml
@@ -70,7 +70,7 @@ vas:
             oc -n openstack wait openstackdataplanedeployment
             edpm-deployment
             --for condition=Ready
-            --timeout=40m
+            --timeout=60m
         values:
           - name: edpm-deployment-values
             src_file: values.yaml


### PR DESCRIPTION
This patch is in response to the linked Jira card where we can see enabling FIPs in the uni07eta job causes the deployment to fail by a few minutes. This is due to the increased time enabling FIPs adds caused by the EDPM nodes requiring a reboot.

Jira: https://issues.redhat.com/browse/OSPRH-11095

---

This patch is to start the conversion, other uni jobs may also need to be bumped if they begin to enable FIPs as well but I started this patch conservative.

If there is another, better way to only bump the FIPs enabled jobs please let me know. 