### PR TITLE
DCN Workaround to set Cinder uniquePodNames false

### DIFF
--- a/dt/dcn/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/dcn/edpm-post-ceph/nodeset/kustomization.yaml
@@ -81,6 +81,17 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.cinder.uniquePodNames
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.uniquePodNames
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.cinderVolumes
     targets:
       - select:

--- a/examples/dt/dcn/service-values.yaml
+++ b/examples/dt/dcn/service-values.yaml
@@ -8,6 +8,8 @@ metadata:
     config.kubernetes.io/local-config: "true"
 data:
   preserveJobs: false
+  cinder:
+    uniquePodNames: false
   cinderAPI:
     replicas: 3
     customServiceConfig: |


### PR DESCRIPTION
As per the [OSPRH-11240](https://issues.redhat.com//browse/OSPRH-11240), set uniquePodNames false for Cinder so that extraMounts can be used to propagate secrets to pods by matching the instance AZ name in DCN deployments. This patch can be reverted after [OSPRH-11240](https://issues.redhat.com//browse/OSPRH-11240) is resolved.

Jira: https://issues.redhat.com/browse/OSPRH-11240