### PR TITLE
DCN DT: Add multicells

### DIFF
--- a/dt/dcn/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/dcn/edpm-post-ceph/nodeset/kustomization.yaml
@@ -24,6 +24,7 @@ components:
 resources:
   - ceph_secret.yaml
   - nova_ceph.yaml
+  - neutron_metadata.yaml
 
 patches:
   - target:
@@ -54,6 +55,28 @@ replacements:
           kind: OpenStackControlPlane
         fieldPaths:
           - spec.nova.template.apiServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.metadataServiceTemplate
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.metadataServiceTemplate
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates
         options:
           create: true
   - source:
@@ -191,6 +214,28 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.galera.templates
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.galera.templates
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.rabbitmq.templates
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.extraMounts
     targets:
       - select:
@@ -244,6 +289,7 @@ replacements:
     targets:
       - select:
           kind: OpenStackDataPlaneService
+          name: nova-custom-ceph
         fieldPaths:
           - spec.dataSources
         options:
@@ -264,10 +310,35 @@ replacements:
   - source:
       kind: ConfigMap
       name: edpm-nodeset-values-post-ceph
-      fieldPath: data.customDataplanService.name
+      fieldPath: data.nova.customDataplaneService.name
     targets:
       - select:
           kind: OpenStackDataPlaneService
+          name: nova-custom-ceph
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.neutron-metadata.dataSources
+    targets:
+      - select:
+          kind: OpenStackDataPlaneService
+          name: neutron-metadata
+        fieldPaths:
+          - spec.dataSources
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.neutron-metadata.customDataplaneService.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneService
+          name: neutron-metadata
         fieldPaths:
           - metadata.name
         options:

--- a/dt/dcn/edpm-post-ceph/nodeset/neutron_metadata.yaml
+++ b/dt/dcn/edpm-post-ceph/nodeset/neutron_metadata.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: neutron-metadata
+  namespace: openstack
+spec:
+  addCertMounts: false
+  caCerts: combined-ca-bundle
+  containerImageFields:
+    - EdpmNeutronMetadataAgentImage
+  dataSources:
+    - secretRef:
+        name: neutron-ovn-metadata-agent-neutron-config
+    - secretRef:
+        name: nova-cell1-metadata-neutron-config
+  edpmServiceType: neutron-metadata
+  playbook: osp.edpm.neutron_metadata
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      issuer: osp-rootca-issuer-ovn
+      keyUsages:
+        - digital signature
+        - key encipherment
+        - client auth
+      networks:
+        - ctlplane

--- a/examples/dt/dcn/README.md
+++ b/examples/dt/dcn/README.md
@@ -9,6 +9,8 @@ This is a collection of CR templates that represent a Red Hat OpenStack Services
 - 3 master/worker combo-node OpenShift cluster
 - 3-replica Galera database
 - RabbitMQ
+- Multicells with a dedicated cell per DCN site
+    - Each cell uses dedicated rabbitmq, Galera and nova services 
 - Spine and leaf network architecture
 - Network isolation
 - OVN networking

--- a/examples/dt/dcn/service-values.yaml
+++ b/examples/dt/dcn/service-values.yaml
@@ -69,6 +69,24 @@ data:
         rbd_secret_uuid = CHANGEME
         rbd_cluster_name = az2
         backend_availability_zone = az2
+  galera:
+    templates:
+      openstack:
+        replicas: 1
+        secret: osp-secret
+        storageRequest: 5G
+      openstack-cell1:
+        replicas: 1
+        secret: osp-secret
+        storageRequest: 5G
+      openstack-cell2:
+        replicas: 1
+        secret: osp-secret
+        storageRequest: 5G
+      openstack-cell3:
+        replicas: 1
+        secret: osp-secret
+        storageRequest: 5G
   glance:
     keystoneEndpoint: az0
     glanceAPIs:
@@ -209,6 +227,111 @@ data:
     customServiceConfig: |
       [DEFAULT]
       default_schedule_zone=az0
+    metadataServiceTemplate:
+      enabled: false
+    cellTemplates:
+      cell0:
+        cellDatabaseAccount: nova-cell0
+        hasAPIAccess: true
+      cell1:
+        cellDatabaseInstance: openstack-cell1
+        cellDatabaseAccount: nova-cell1
+        cellMessageBusInstance: rabbitmq-cell1
+        conductorServiceTemplate:
+          replicas: 1
+        hasAPIAccess: true
+        metadataServiceTemplate:
+          enabled: true
+          override:
+            service:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.81
+              spec:
+                type: LoadBalancer
+          replicas: 3
+      cell2:
+        cellDatabaseInstance: openstack-cell2
+        cellDatabaseAccount: nova-cell2
+        cellMessageBusInstance: rabbitmq-cell2
+        conductorServiceTemplate:
+          replicas: 1
+        hasAPIAccess: true
+        metadataServiceTemplate:
+          enabled: true
+          override:
+            service:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.82
+              spec:
+                type: LoadBalancer
+          replicas: 3
+      cell3:
+        cellDatabaseInstance: openstack-cell3
+        cellDatabaseAccount: nova-cell3
+        cellMessageBusInstance: rabbitmq-cell3
+        conductorServiceTemplate:
+          replicas: 1
+        hasAPIAccess: true
+        metadataServiceTemplate:
+          enabled: true
+          override:
+            service:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.83
+              spec:
+                type: LoadBalancer
+          replicas: 3
+  rabbitmq:
+    templates:
+      rabbitmq:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+            spec:
+              type: LoadBalancer
+        replicas: 3
+      rabbitmq-cell1:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+            spec:
+              type: LoadBalancer
+        replicas: 3
+      rabbitmq-cell2:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.87
+            spec:
+              type: LoadBalancer
+        replicas: 3
+      rabbitmq-cell3:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.88
+            spec:
+              type: LoadBalancer
+        replicas: 3
   extraMounts:
     - name: v1
       region: r1

--- a/examples/dt/dcn/values.yaml
+++ b/examples/dt/dcn/values.yaml
@@ -1,8 +1,6 @@
 ---
 apiVersion: v1
 data:
-    customDataplanService:
-        name: nova-custom-ceph
     nodeset_name: computes-edpm
     ceph_conf:
         az0.client.openstack.keyring: CHANGEME_CEPH_CONF
@@ -29,6 +27,8 @@ data:
             - libvirt
             - nova-custom-ceph
     nova:
+        customDataplaneService:
+            name: nova-custom-ceph
         ceph:
             conf: CHANGEME_NOVA_CEPH_CONF
         name: ceph-nova
@@ -39,6 +39,14 @@ data:
               name: nova-cell1-compute-config
             - secretRef:
               name: nova-migration-ssh-key
+    neutron-metadata:
+        customDataplaneService:
+            name: neutron-metadata
+        dataSources:
+            - secretRef:
+              name: neutron-ovn-metadata-agent-neutron-config
+            - secretRef:
+              name: nova-cell1-metadata-neutron-config
 kind: ConfigMap
 metadata:
     annotations:


### PR DESCRIPTION
One dedicated cell per site is being deployed with dedicated rabbitmw, Galera and nova services. The nova service and neutron-metadata service are pointed to their dedicated cell per DCN site.