### PR TITLE
[DCN] Explicitly set network availability zone parameters

### DIFF
--- a/dt/dcn/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/dcn/edpm-post-ceph/nodeset/kustomization.yaml
@@ -93,6 +93,17 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.ovn.template.ovnController.external-ids
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ovn.template.ovnController.external-ids
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.cinderBackup.customServiceConfig
     targets:
       - select:

--- a/examples/dt/dcn/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/dcn/edpm-pre-ceph/nodeset/values.yaml
@@ -88,6 +88,8 @@ data:
         gather_facts: false
         neutron_physical_bridge_name: br-ctl
         neutron_public_interface_name: eth0
+        edpm_enable_chassis_gw: false
+        edpm_ovn_availability_zones: []
         edpm_ceph_hci_pre_enabled_services:
           - ceph_mon
           - ceph_mgr

--- a/examples/dt/dcn/service-values.yaml
+++ b/examples/dt/dcn/service-values.yaml
@@ -223,6 +223,15 @@ data:
         network_vlan_ranges = datacentre:1:1000,leaf1:1:1000,leaf2:1:1000
         [neutron]
         physnets = datacentre,leaf1,leaf2
+  ovn:
+    template:
+      ovnController:
+        external-ids:
+          availability-zones: []
+          enable-chassis-as-gateway: true
+          ovn-bridge: br-int
+          ovn-encap-type: geneve
+          system-id: random
   nova:
     customServiceConfig: |
       [DEFAULT]


### PR DESCRIPTION
This patch explicitly sets the network availability zone parameters to their default values, enabling the configuration of availability zones for DCN sites if needed.