### PR TITLE
Switch to 1500 MTU consistently

### DIFF
--- a/examples/dt/uni01alpha/control-plane/nncp/values.yaml
+++ b/examples/dt/uni01alpha/control-plane/nncp/values.yaml
@@ -44,7 +44,7 @@ data:
         name: subnet1
     prefix-length: 24
     iface: enp7s0
-    mtu: 9000
+    mtu: 1500
     lb_addresses:
       - 192.168.122.80-192.168.122.90
     endpoint_annotations:
@@ -108,7 +108,7 @@ data:
         cidr: 172.18.0.0/24
         name: subnet1
         vlan: 21
-    mtu: 9000
+    mtu: 1500
     prefix-length: 24
     iface: storage
     vlan: 21

--- a/examples/dt/uni02beta/control-plane/nncp/values.yaml
+++ b/examples/dt/uni02beta/control-plane/nncp/values.yaml
@@ -47,7 +47,7 @@ data:
         name: subnet1
     prefix-length: 24
     iface: enp6s0
-    mtu: 9000
+    mtu: 1500
     lb_addresses:
       - 192.168.122.80-192.168.122.90
     endpoint_annotations:
@@ -109,7 +109,7 @@ data:
         cidr: 172.18.0.0/24
         name: subnet1
         vlan: 21
-    mtu: 9000
+    mtu: 1500
     prefix-length: 24
     iface: storage
     vlan: 21
@@ -138,7 +138,7 @@ data:
         cidr: 172.20.0.0/24
         name: subnet1
         vlan: 23
-    mtu: 9000
+    mtu: 1500
 
   tenant:
     dnsDomain: tenant.example.com

--- a/examples/dt/uni06zeta/control-plane/nncp/values.yaml
+++ b/examples/dt/uni06zeta/control-plane/nncp/values.yaml
@@ -41,7 +41,7 @@ data:
         name: subnet1
     prefix-length: 24
     iface: enp6s0
-    mtu: 9000
+    mtu: 1500
     lb_addresses:
       - 192.168.122.80-192.168.122.90
     endpoint_annotations:
@@ -103,7 +103,7 @@ data:
         cidr: 172.18.0.0/24
         name: subnet1
         vlan: 21
-    mtu: 9000
+    mtu: 1500
     prefix-length: 24
     iface: storage
     vlan: 21

--- a/examples/dt/uni07eta/control-plane/nncp/values.yaml
+++ b/examples/dt/uni07eta/control-plane/nncp/values.yaml
@@ -42,7 +42,7 @@ data:
         name: subnet1
     prefix-length: 24
     iface: enp6s0
-    mtu: 9000
+    mtu: 1500
     lb_addresses:
       - 192.168.122.80-192.168.122.90
     endpoint_annotations:
@@ -106,7 +106,7 @@ data:
         cidr: 172.18.0.0/24
         name: subnet1
         vlan: 21
-    mtu: 9000
+    mtu: 1500
     prefix-length: 24
     iface: storage
     vlan: 21


### PR DESCRIPTION
We were having mixed values in some scenarios,
in some places specifying 9000 while in fact
1500 value was used in the deployed infrastructure.
This commit changes it consistently for related uni jobs
to stick with default 1500 MTU.

This change intentionally ommits uni04delta and uni03gamma
(va/hci scenario), as those involve Ceph, which probably
should still rely on MTU 9000, however it is not properly
configured so far as I noticed.