### PR TITLE
Add 3cells to uni05 epsilon

### DIFF
--- a/automation/vars/uni05epsilon.yaml
+++ b/automation/vars/uni05epsilon.yaml
@@ -40,6 +40,18 @@ vas:
             src_file: values.yaml
         build_output: nodeset-pre-ceph.yaml
 
+      - path: examples/dt/uni05epsilon/nodeset2/edpm-pre-ceph
+        wait_conditions:
+          - >-
+            oc -n openstack wait osdpns
+            openstack-edpm-2
+            --for condition=SetupReady
+            --timeout=10m
+        values:
+          - name: edpm-nodeset2-values
+            src_file: values.yaml
+        build_output: nodeset2-pre-ceph.yaml
+
       - path: examples/dt/uni05epsilon/edpm-pre-ceph/deployment
         wait_conditions:
           - >-
@@ -71,6 +83,18 @@ vas:
             src_file: values.yaml
         build_output: nodeset-post-ceph.yaml
 
+      - path: examples/dt/uni05epsilon/nodeset2
+        wait_conditions:
+          - >-
+            oc -n openstack wait osdpns
+            openstack-edpm-2
+            --for condition=SetupReady
+            --timeout=10m
+        values:
+          - name: edpm-nodeset2-values-post-ceph
+            src_file: values.yaml
+        build_output: nodeset2-post-ceph.yaml
+
       - path: examples/dt/uni05epsilon/deployment
         wait_conditions:
           - >-
@@ -82,3 +106,15 @@ vas:
           - name: edpm-deployment-values-post-ceph
             src_file: values.yaml
         build_output: deployment-post-ceph.yaml
+
+      - path: examples/dt/uni05epsilon/nodeset2/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait osdpd
+            edpm-deployment-post-ceph-2
+            --for condition=Ready
+            --timeout=40m
+        values:
+          - name: edpm-deployment-values-post-ceph-2
+            src_file: values.yaml
+        build_output: deployment-post-ceph-2.yaml

--- a/dt/uni05epsilon/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset/kustomization.yaml
@@ -212,6 +212,66 @@ replacements:
         options:
           create: true
 
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.galera.templates.openstack-cell2
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.galera.templates.openstack-cell2
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-cell2.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-cell2.override.service.metadata.annotations
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.rabbitmq.templates.rabbitmq-cell2.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-cell2.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.lbServiceType
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-cell2.override.service.spec.type
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.template.cellTemplates.cell2
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell2
+        options:
+          create: true
+
   #
   # Dataplane services override
   #

--- a/dt/uni05epsilon/edpm-post-ceph/nodeset2/deployment/kustomization.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset2/deployment/kustomization.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../lib/dataplane/deployment
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values-post-ceph-2
+      fieldPath: data.deployment.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true

--- a/dt/uni05epsilon/edpm-post-ceph/nodeset2/kustomization.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset2/kustomization.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/dataplane/nodeset
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    path: resources/ceph-extra-mounts.yaml
+
+resources:
+  - resources/nova-custom-config.yaml
+  - resources/nova-custom-service.yaml
+
+replacements:
+  #
+  # Dataplane services override
+  #
+  # (overrides /lib/dataplane which is using edpm-nodeset-values ConfigMap)
+  #
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset2-values-post-ceph
+      fieldPath: data.nodeset.services
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - spec.services
+        options:
+          create: true

--- a/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/ceph-extra-mounts.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/ceph-extra-mounts.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm
+spec:
+  nodeTemplate:
+    extraMounts:
+      - extraVolType: Ceph
+        mounts:
+          - mountPath: /etc/ceph
+            name: ceph
+            readOnly: true
+        volumes:
+          - name: ceph
+            secret:
+              secretName: ceph-conf-files

--- a/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/ceph-secret.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/ceph-secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: ceph-conf-files
+  namespace: openstack
+data:
+  ceph.client.openstack.keyring: _replaced_
+  ceph.conf: _replaced_

--- a/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/cinder-volume-nfs-secrets.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/cinder-volume-nfs-secrets.yaml
@@ -1,0 +1,13 @@
+---
+# Define the "cinder-volume-nfs-secrets" Secret that contains sensitive
+# information pertaining to the [nfs] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-nfs-secrets
+type: Opaque
+stringData:
+  cinder-volume-nfs-secrets: _replaced_

--- a/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/cinder-volume-ontap-secrets.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/cinder-volume-ontap-secrets.yaml
@@ -1,0 +1,13 @@
+---
+# Define the "cinder-volume-ontap-secrets" Secret that contains sensitive
+# information pertaining to the [ontap] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-ontap-secrets
+type: Opaque
+stringData:
+  cinder-volume-ontap-secrets: _replaced_

--- a/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/nova-custom-config.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/nova-custom-config.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nova-custom-config
+data:
+  25-nova-custom.conf: |
+    [DEFAULT]
+    # Override our defaults in this dt to get coverage for metadata-api based
+    # cloud-init scenarios
+    force_config_drive = False
+  55-nova-extra.conf: |
+    # Additional overrides that can be set in environment-specific cases

--- a/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/nova-custom-service.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset2/resources/nova-custom-service.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: nova-custom
+spec:
+  label: dataplane-deployment-nova-custom
+  dataSources:
+    - configMapRef:
+        name: nova-custom-config
+    - secretRef:
+        name: nova-cell1-compute-config
+    - secretRef:
+        name: nova-migration-ssh-key
+  playbook: osp.edpm.nova
+  caCerts: combined-ca-bundle
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      networks:
+        - ctlplane
+      issuer: osp-rootca-issuer-internal
+      edpmRoleServiceName: nova
+  edpmServiceType: nova
+  containerImageFields:
+    - NovaComputeImage
+    - EdpmIscsidImage

--- a/dt/uni05epsilon/kustomization.yaml
+++ b/dt/uni05epsilon/kustomization.yaml
@@ -56,6 +56,66 @@ replacements:
 
   - source:
       kind: ConfigMap
+      name: service-values
+      fieldPath: data.galera.templates.openstack-cell2
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.galera.templates.openstack-cell2
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-cell2.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-cell2.override.service.metadata.annotations
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.rabbitmq.templates.rabbitmq-cell2.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-cell2.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.lbServiceType
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-cell2.override.service.spec.type
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.template.cellTemplates.cell2
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell2
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
       name: network-values
       fieldPath: data.storagemgmt.mtu
     targets:

--- a/examples/dt/uni05epsilon/control-plane/nncp/values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/nncp/values.yaml
@@ -226,6 +226,10 @@ data:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
       metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+  rabbitmq-cell2:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.87
 
   lbServiceType: LoadBalancer
   storageClass: local-storage

--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -9,3 +9,26 @@ metadata:
 
 data:
   preserveJobs: false
+
+  galera:
+    templates:
+      openstack-cell2:
+        storageRequest: 5G
+        secret: osp-secret
+        replicas: 3
+
+  nova:
+    template:
+      cellTemplates:
+        cell2:
+          cellDatabaseAccount: nova-cell2
+          cellDatabaseInstance: openstack-cell2
+          cellMessageBusInstance: rabbitmq-cell2
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+
+  rabbitmq:
+    templates:
+      rabbitmq-cell2:
+        replicas: 3

--- a/examples/dt/uni05epsilon/edpm-pre-ceph/deployment/kustomization.yaml
+++ b/examples/dt/uni05epsilon/edpm-pre-ceph/deployment/kustomization.yaml
@@ -8,6 +8,15 @@ components:
 resources:
   - values.yaml
 
+patches:
+  - target:
+      kind: OpenStackDataPlaneDeployment
+      name: edpm-deployment-pre-ceph
+    patch: |
+      - op: add
+        path: /spec/nodeSets/-
+        value: openstack-edpm-2
+
 replacements:
   - source:
       kind: ConfigMap

--- a/examples/dt/uni05epsilon/nodeset2/deployment/kustomization.yaml
+++ b/examples/dt/uni05epsilon/nodeset2/deployment/kustomization.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/uni05epsilon/edpm-post-ceph/nodeset2/deployment
+
+resources:
+  - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values-post-ceph-2
+      fieldPath: data.servicesOverride
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.servicesOverride
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values-post-ceph-2
+      fieldPath: data.deployment.spec.nodeSets
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.nodeSets
+        options:
+          create: true

--- a/examples/dt/uni05epsilon/nodeset2/deployment/values.yaml
+++ b/examples/dt/uni05epsilon/nodeset2/deployment/values.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values-post-ceph-2
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  deployment:
+    name: edpm-deployment-post-ceph-2
+    spec:
+      nodeSets:
+        - openstack-edpm-2
+  servicesOverride:
+    - install-certs
+    - ceph-client
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova-custom-cell2

--- a/examples/dt/uni05epsilon/nodeset2/edpm-pre-ceph/kustomization.yaml
+++ b/examples/dt/uni05epsilon/nodeset2/edpm-pre-ceph/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/uni05epsilon/edpm-pre-ceph/nodeset
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: openstack-edpm
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: openstack-edpm-2

--- a/examples/dt/uni05epsilon/nodeset2/edpm-pre-ceph/values.yaml
+++ b/examples/dt/uni05epsilon/nodeset2/edpm-pre-ceph/values.yaml
@@ -98,13 +98,13 @@ data:
         subnetName: subnet1
 
     nodes:
-      edpm-compute-0:
+      edpm-compute-2:
         ansible:
-          ansibleHost: 192.168.122.100
-        hostName: edpm-compute-0
+          ansibleHost: 192.168.122.102
+        hostName: edpm-compute-2
         networks:
           - defaultRoute: true
-            fixedIP: 192.168.122.100
+            fixedIP: 192.168.122.102
             name: ctlplane
             subnetName: subnet1
           - name: internalapi
@@ -115,25 +115,6 @@ data:
             subnetName: subnet1
           - name: tenant
             subnetName: subnet1
-
-      edpm-compute-1:
-        ansible:
-          ansibleHost: 192.168.122.101
-        hostName: edpm-compute-1
-        networks:
-          - defaultRoute: true
-            fixedIP: 192.168.122.101
-            name: ctlplane
-            subnetName: subnet1
-          - name: internalapi
-            subnetName: subnet1
-          - name: storage
-            subnetName: subnet1
-          - name: storagemgmt
-            subnetName: subnet1
-          - name: tenant
-            subnetName: subnet1
-
     # The nova-custom service is omitted since it is not yet
     # defined. It will be defined and set after Ceph is deployed.
     # See deployment servicesOverride for effective services list.

--- a/examples/dt/uni05epsilon/nodeset2/kustomization.yaml
+++ b/examples/dt/uni05epsilon/nodeset2/kustomization.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/uni05epsilon/edpm-post-ceph/nodeset2
+
+resources:
+  - edpm-pre-ceph/values.yaml
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: openstack-edpm
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: openstack-edpm-2
+  - target:
+      kind: OpenStackDataPlaneService
+      name: nova-custom
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: nova-custom-cell2
+      - op: replace
+        path: /spec/label
+        value: nova-custom-cell2
+      - op: replace
+        path: /spec/dataSources/1/secretRef/name
+        value: nova-cell2-compute-config

--- a/examples/dt/uni05epsilon/nodeset2/values.yaml
+++ b/examples/dt/uni05epsilon/nodeset2/values.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: edpm-nodeset2-values-post-ceph
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  ceph:
+    conf: _replaced_
+    keyring: _replaced_
+
+  nodeset:
+    services:
+      - bootstrap
+      - download-cache
+      - configure-network
+      - validate-network
+      - install-os
+      - ceph-hci-pre
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ceph-client
+      - ovn
+      - neutron-metadata
+      - libvirt
+      - nova-custom-cell2

--- a/examples/dt/uni05epsilon/service-values.yaml
+++ b/examples/dt/uni05epsilon/service-values.yaml
@@ -85,6 +85,13 @@ data:
                   - secret:
                       name: ceph-conf-files
 
+  galera:
+    templates:
+      openstack-cell2:
+        storageRequest: 5G
+        secret: osp-secret
+        replicas: 3
+
   glance:
     customServiceConfig: |
       [DEFAULT]
@@ -120,6 +127,22 @@ data:
       default:
         replicas: 3
         type: split
+
+  nova:
+    template:
+      cellTemplates:
+        cell2:
+          cellDatabaseAccount: nova-cell2
+          cellDatabaseInstance: openstack-cell2
+          cellMessageBusInstance: rabbitmq-cell2
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+
+  rabbitmq:
+    templates:
+      rabbitmq-cell2:
+        replicas: 3
 
   nova-extra-config: |
     # Additional overrides that can be set in environment-specific cases

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -284,6 +284,9 @@
     - examples/dt/uni05epsilon/deployment
     - examples/dt/uni05epsilon/edpm-pre-ceph/deployment
     - examples/dt/uni05epsilon/edpm-pre-ceph/nodeset
+    - examples/dt/uni05epsilon/nodeset2
+    - examples/dt/uni05epsilon/nodeset2/deployment
+    - examples/dt/uni05epsilon/nodeset2/edpm-pre-ceph
     - lib
     name: rhoso-architecture-validate-uni05epsilon
     parent: rhoso-architecture-base-job


### PR DESCRIPTION
Update uni05-epsilon to deploy with 3 cells instead of the standard two cell deployment.
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2545