### PR TITLE
[OSPRH-12761] Support new OpenStack initialization resource for RHOSO install

### DIFF
--- a/examples/common/openstack/kustomization.yaml
+++ b/examples/common/openstack/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+components:
+  - ../../../lib/openstack

--- a/lib/openstack/kustomization.yaml
+++ b/lib/openstack/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - openstack_deploy.yaml

--- a/lib/openstack/openstack_deploy.yaml
+++ b/lib/openstack/openstack_deploy.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: operator.openstack.org/v1beta1
+kind: OpenStack
+metadata:
+  name: openstack
+  namespace: openstack-operators


### PR DESCRIPTION
We have a new upcoming way to install and deploy the OSP operators.  OLM will only install one CRD for OSP, which is an initialization resource.  A CR must be created for that CRD, which then, when created, causes all the remaining OSP CRDs to be installed and also deploys their respective operators.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1185