### PR TITLE
Cherry-pick pull request #403 from gmarcian/add_worker_unidelta_ipv6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ examples/dt/uni*/control-plane/control-plane.yaml
 examples/dt/uni*/control-plane/nncp/nncp.yaml
 examples/dt/uni*/data-plane.yaml
 examples/dt/uni*/networker/edpm-networker.yaml
+.idea/

--- a/automation/net-env/uni04delta-ipv6.yaml
+++ b/automation/net-env/uni04delta-ipv6.yaml
@@ -428,6 +428,63 @@ instances:
         skip_nm: false
         trunk_parent: ctlplane
         vlan_id: 22
+  ocp-3:
+    hostname: worker-0
+    name: ocp-3
+    networks:
+      ctlplane:
+        interface_name: enp7s0
+        ip_v6: 2620:cf:cf:aaaa::13
+        is_trunk_parent: true
+        mac_addr: 52:54:02:18:86:bc
+        mtu: 1500
+        network_name: ctlplane
+        prefix_length_v6: 64
+        skip_nm: false
+      internalapi:
+        interface_name: enp7s0.20
+        ip_v6: 2620:cf:cf:bbbb::13
+        is_trunk_parent: false
+        mac_addr: 52:54:00:04:df:88
+        mtu: 1500
+        network_name: internalapi
+        parent_interface: enp7s0
+        prefix_length_v6: 64
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 20
+      ironic:
+        interface_name: enp8s0
+        ip_v6: 2620:cf:cf:ffff::13
+        mac_addr: 52:54:00:c2:32:a3
+        mtu: 1500
+        network_name: ironic
+        prefix_length_v6: 64
+        skip_nm: false
+      storage:
+        interface_name: enp7s0.21
+        ip_v6: 2620:cf:cf:cccc::13
+        is_trunk_parent: false
+        mac_addr: 52:54:00:7e:b2:1d
+        mtu: 1500
+        network_name: storage
+        parent_interface: enp7s0
+        prefix_length_v6: 64
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 21
+      tenant:
+        interface_name: enp7s0.22
+        ip_v6: 2620:cf:cf:eeee::13
+        is_trunk_parent: false
+        mac_addr: 52:54:00:12:d1:e2
+        mtu: 1500
+        network_name: tenant
+        parent_interface: enp7s0
+        prefix_length_v6: 64
+        skip_nm: false
+        trunk_parent: ctlplane
+        vlan_id: 22
 networks:
   ctlplane:
     dns_v4: []

--- a/dt/uni04delta-ipv6/nncp/kustomization.yaml
+++ b/dt/uni04delta-ipv6/nncp/kustomization.yaml
@@ -118,6 +118,7 @@ patches:
       name: master-2
     patch: *routes
 
+
 replacements:
 
   - source:

--- a/examples/dt/uni04delta-ipv6/control-plane/nncp/kustomization.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/nncp/kustomization.yaml
@@ -5,3 +5,277 @@ components:
   - ../../../../../dt/uni04delta-ipv6/nncp
 resources:
   - values.yaml
+  - ocp_worker_nodes.yaml
+
+patches:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: node-3
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Ironic bridge
+          ipv6:
+            enabled: true
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+          ipv4:
+             enabled: false
+          mtu: 1500
+          name: ironic
+          type: linux-bridge
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+              - name: _replaced_
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: node-3
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Ironic VRF
+          name: ironicvrf
+          type: vrf
+          state: up
+          vrf:
+            port:
+              - ironic
+            route-table-id: 10
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: node-3
+    patch: |-
+      - op: add
+        path: /spec/desiredState/routes/config/-
+        value:
+          destination: "::/0"
+          metric: 150
+          next-hop-address: _replaced_
+          next-hop-interface: ironic
+          table-id: 10
+      - op: add
+        path: /spec/desiredState/routes/config/-
+        value:
+          destination: _replaced_
+          metric: 150
+          next-hop-address: _replaced_
+          next-hop-interface: ospbr
+      - op: add
+        path: /spec/desiredState/routes/config/-
+        value:
+          destination: "::/0"
+          metric: 150
+          next-hop-address: _replaced_
+          next-hop-interface: ospbr
+
+  # master roles:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-0
+    patch: |-
+      - op: add
+        path: /spec/nodeSelector/node-role.kubernetes.io~1master
+        value: ""
+      - op: remove
+        path: /spec/nodeSelector/node-role.kubernetes.io~1worker
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-1
+    patch: |-
+      - op: add
+        path: /spec/nodeSelector/node-role.kubernetes.io~1master
+        value: ""
+      - op: remove
+        path: /spec/nodeSelector/node-role.kubernetes.io~1worker
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-2
+    patch: |-
+      - op: add
+        path: /spec/nodeSelector/node-role.kubernetes.io~1master
+        value: ""
+      - op: remove
+        path: /spec/nodeSelector/node-role.kubernetes.io~1worker
+
+replacements:
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ironic.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=ironic].bridge.port.0.name
+
+  # Static Node IPs: node-3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.internalapi_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv6.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.tenant_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv6.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv6.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.storage_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv6.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.ironic_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=ironic].ipv6.address.0.ip
+
+
+  # prefix-length: node-3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv6.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv6.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv6.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv6.address.0.prefix-length
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ironic.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name:
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=ironic].ipv6.address.0.prefix-length
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - metadata.name
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.node_name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ironic.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.routes.config.0.next-hop-address
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.subnets.0.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.routes.config.1.next-hop-address
+          - spec.desiredState.routes.config.2.next-hop-address
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ironic.cidr
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.routes.config.1.destination

--- a/examples/dt/uni04delta-ipv6/control-plane/nncp/ocp_worker_nodes.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/nncp/ocp_worker_nodes.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-3
+  labels:
+    osp/nncm-config-type: standard

--- a/examples/dt/uni04delta-ipv6/control-plane/nncp/values.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/nncp/values.yaml
@@ -32,6 +32,15 @@ data:
     ctlplane_ip: "2620:cf:cf:aaaa::12"
     storage_ip: "2620:cf:cf:cccc::12"
     ironic_ip: "2620:cf:cf:ffff::12"
+  node_3:
+    name: worker-0
+    node_name: worker-0.ocp.openstack.lab
+    internalapi_ip: "2620:cf:cf:bbbb::13"
+    tenant_ip: "2620:cf:cf:eeee::13"
+    ctlplane_ip: "2620:cf:cf:aaaa::13"
+    storage_ip: "2620:cf:cf:cccc::13"
+    ironic_ip: "2620:cf:cf:ffff::13"
+
   # networks
   ctlplane:
     dnsDomain: ctlplane.example.com


### PR DESCRIPTION
Add worker node to run test operator on uni04delta-ipv6 deployments

In order to run disruptive tests on the uni04delta env, We need to have a worker node dedicated for the test operator. Thus we can ensure that test pods won't be affected by the failures.

Running disruptive tests is part of HA testing of the system. Please see [OSPRH-7602](https://issues.redhat.com//browse/OSPRH-7602)

Reviewed-by: Andrew Bays <andrew.bays@gmail.com>
Reviewed-by: John Fulton <johfulto@redhat.com>