### PR TITLE
Va nvidia mdev

### DIFF
--- a/automation/vars/nvidia-mdev.yaml
+++ b/automation/vars/nvidia-mdev.yaml
@@ -1,0 +1,81 @@
+---
+vas:
+  nvidia-mdev:
+    stages:
+      - path: examples/va/nvidia-mdev/control-plane/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=60s
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - path: examples/va/nvidia-mdev/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane --for condition=Ready
+            --timeout=1200s
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+
+      - path: examples/va/nvidia-mdev/edpm/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=60m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset.yaml
+
+      - path: examples/va/nvidia-mdev/edpm/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=60m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment.yaml
+        post_stage_run:
+          - name: Run phase 1 playbook
+            type: playbook
+            # As a reminder, the job needs to set the nvidia driver URL
+            source: "../../playbooks/nvidia-mdev-phase1.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+          - name: Run phase 2 playbook
+            type: playbook
+            source: "../../playbooks/nvidia-mdev-phase2.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+
+      - path: examples/va/nvidia-mdev/edpm-post-driver/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=10m
+        values:
+          - name: edpm-provider-values
+            src_file: values.yaml
+        build_output: compute-provider-service.yaml
+
+      - path: examples/va/nvidia-mdev/edpm-post-driver/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpd edpm-deployment-post-driver --for condition=Ready
+            --timeout=20m
+        values:
+          - name: edpm-deployment-post-driver
+            src_file: values.yaml
+        build_output: post-driver-deployment.yaml

--- a/examples/va/nvidia-mdev/.gitignore
+++ b/examples/va/nvidia-mdev/.gitignore
@@ -1,0 +1,1 @@
+control-plane.yaml

--- a/examples/va/nvidia-mdev/README.md
+++ b/examples/va/nvidia-mdev/README.md
@@ -1,0 +1,163 @@
+# Validated Architecture - Nvidia-Mdev
+
+This document describes the CR's and deployment workflow to create an 
+environment with EDPM Compute Nodes capable of supplying Nvidia mediated 
+devices (Mdevs). Mdevs allow multiple guests to share the same physical GPU
+card on the hypervisor. The deployment also takes advantage of defining and
+mapping Custom Traits to different resource providers by passing definition via
+provider.yaml through a ConfigMap.
+
+## Purpose
+
+This topology is used to primarily verify environments that provide Nvidia
+Mdevs and confirm guests are able to take advantage of the resource correctly.
+It should be noted that this type of deployment cannot be simulated with nested
+virtualization and requires real baremetal hosts.
+
+## Environment
+
+### Nodes
+
+| Role                        | Machine Type | Count |
+| --------------------------- | ------------ | ----- |
+| Compact OpenShift           | vm           | 3     |
+| OpenStack Baremetal Compute | Baremetal    | 2     |
+
+### Networks
+
+| Name         | Type     | Interface | CIDR            |
+| ------------ | -------- | --------- | --------------- |
+| Provisioning | untagged | nic1      | 172.23.0.0/24   |
+| Machine      | untagged | nic2      | 192.168.51.0/20 |
+| RH OSP       | trunk    | nic3      |                 |
+
+
+#### VLAN networks in RH OSP
+
+| Name        | Type        | CIDR              |
+| ----------- | ----------- | ----------------- |
+| ctlplane    | untagged    | 192.168.122.0/24  |
+| internalapi | VLAN tagged | 172.17.0.0/24     |
+| storage     | VLAN tagged | 172.18.0.0/24     |
+| storagemgmt | VLAN tagged | 172.20.0.0/24     |
+| tenant      | VLAN tagged | 172.19.0.0/24     |
+
+#### Nova Mdev Configuration
+
+To deploy vGPU devices comprised of different types as well as the capacity to 
+live migrate, you would need the below configuration applied to Nova.
+
+```YAML
+---
+apiVersion: v1
+data:
+  25-cpu-pinning-nova.conf: |
+    [libvirt]
+    live_migration_completion_timeout = 0
+    live_migration_downtime = 500000
+    live_migration_downtime_steps = 3
+    live_migration_downtime_delay = 3
+    live_migration_permit_post_copy = false
+    [devices]
+    enabled_vgpu_types=nvidia-228,nvidia-229
+    [vgpu_nvidia-228]
+    device_addresses=0000:82:00.0
+    [vgpu_nvidia-229]
+    device_addresses=0000:04:00.0
+kind: ConfigMap
+metadata:
+  name: cpu-pinning-nova
+  namespace: openstack
+```
+
+#### Provider.yaml
+
+In order to easily take advantage of multiple Mdev types in an environment when
+creating flavors, we can associate traits to specific resource providers. With
+provier.yaml we can map those traits and apply them as part of a deployment.
+
+```YAML
+---
+apiVersion: v1
+data:
+  provider.yaml: |
+    meta:
+      schema_version: "1.0"
+    providers:
+      - identification:
+          name: edpm-compute-0.ctlplane.example.com_pci_0000_04_00_0
+        traits:
+          additional:
+            - CUSTOM_NVIDIA_229
+      - identification:
+          name: edpm-compute-0.ctlplane.example.com_pci_0000_82_00_0
+        traits:
+          additional:
+            - CUSTOM_NVIDIA_228
+      - identification:
+          name: edpm-compute-1.ctlplane.example.com_pci_0000_04_00_0
+        traits:
+          additional:
+            - CUSTOM_NVIDIA_229
+      - identification:
+          name: edpm-compute-1.ctlplane.example.com_pci_0000_82_00_0
+        traits:
+          additional:
+            - CUSTOM_NVIDIA_228
+kind: ConfigMap
+  name: compute-provider
+  namespace: openstack
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: compute-provider
+  namespace: openstack
+spec:
+  addCertMounts: false
+  caCerts: combined-ca-bundle
+  dataSources:
+  - configMapRef:
+      name: compute-provider
+  - configMapRef:
+      name: cpu-pinning-nova
+  - configMapRef:
+      name: sriov-nova
+  - secretRef:
+      name: nova-cell1-compute-config
+  - secretRef:
+      name: nova-migration-ssh-key
+  edpmServiceType: nova
+  playbook: osp.edpm.nova
+  tlsCerts:
+    default:
+      contents:
+      - dnsnames
+      - ips
+      issuer: osp-rootca-issuer-internal
+      networks:
+      - ctlplane
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: edpm-deployment-post-driver
+  namespace: openstack
+spec:
+  ansibleExtraVars:
+    edpm_reboot_strategy: force
+  nodeSets:
+  - openstack-edpm
+  preserveJobs: true
+  servicesOverride:
+  - reboot-os
+  - compute-provider
+```
+
+## Stages
+All stages must be executed in the order listed below. Everything is required unless otherwise indicated.
+
+1. [Install the OpenStack K8S operators and their dependencies](../../common/)
+2. [Configuring networking and deploy the OpenStack control plane](control-plane.md)
+3. [Configure and deploy the initial dataplane](edpm-pre.md)
+4. [Update Dataplane to deploy necessary vGPU MDev requirements](edpm-post.md)

--- a/examples/va/nvidia-mdev/control-plane.md
+++ b/examples/va/nvidia-mdev/control-plane.md
@@ -1,0 +1,54 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `local-storage` should already exist.
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the nvidia-mdev directory
+```
+cd architecture/examples/va/nvidia-mdev
+```
+Edit the [control-plance/nncp/values.yaml](control-plane/nncp/values.yaml) and
+[control-plane/service-values.yaml](control-plane/service-values.yaml) files to suit 
+your environment.
+```
+vi nncp/values.yaml
+vi service-values.yaml
+```
+
+## Apply node network configuration
+
+Generate the node network configuration
+```
+kustomize build control-plane/nncp > nncp.yaml
+```
+Apply the NNCP CRs
+```
+oc apply -f nncp.yaml
+```
+Wait for NNCPs to be available
+```
+oc wait nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=300s
+```
+
+## Apply networking and control-plane configuration
+
+Generate the control-plane and networking CRs.
+```
+kustomize build control-plane > control-plane.yaml
+```
+Apply the CRs
+```
+oc apply -f control-plane.yaml
+```
+
+Wait for control plane to be available
+```
+oc wait osctlplane controlplane --for condition=Ready --timeout=600s
+```

--- a/examples/va/nvidia-mdev/control-plane/.gitignore
+++ b/examples/va/nvidia-mdev/control-plane/.gitignore
@@ -1,0 +1,1 @@
+control-plane.yaml

--- a/examples/va/nvidia-mdev/control-plane/kustomization.yaml
+++ b/examples/va/nvidia-mdev/control-plane/kustomization.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/networking/metallb
+  - ../../../../lib/networking/netconfig
+  - ../../../../lib/networking/nad
+  - ../../../../lib/control-plane
+
+resources:
+  - nncp/values.yaml
+  - service-values.yaml
+
+replacements:
+  # Control plane customization
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.neutron.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.neutron.template.customServiceConfig
+        options:
+          create: true
+  # OVN control plane SRIOV customization
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.ovn.ovnController.nicMappings
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ovn.template.ovnController.nicMappings
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.default.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.swift.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.swift.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.schedulerServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.schedulerServiceTemplate.customServiceConfig
+        options:
+          create: true

--- a/examples/va/nvidia-mdev/control-plane/nncp/.gitignore
+++ b/examples/va/nvidia-mdev/control-plane/nncp/.gitignore
@@ -1,0 +1,1 @@
+nncp.yaml

--- a/examples/va/nvidia-mdev/control-plane/nncp/kustomization.yaml
+++ b/examples/va/nvidia-mdev/control-plane/nncp/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../lib/nncp
+
+resources:
+  - values.yaml

--- a/examples/va/nvidia-mdev/control-plane/nncp/values.yaml
+++ b/examples/va/nvidia-mdev/control-plane/nncp/values.yaml
@@ -1,0 +1,242 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # nodes
+  node_0:
+    name: ostest-master-0
+    internalapi_ip: 172.17.0.5
+    tenant_ip: 172.19.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+    swift_ip: 172.22.0.5
+  node_1:
+    name: ostest-master-1
+    internalapi_ip: 172.17.0.6
+    tenant_ip: 172.19.0.6
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.6
+    swift_ip: 172.22.0.6
+  node_2:
+    name: ostest-master-2
+    internalapi_ip: 172.17.0.7
+    tenant_ip: 172.19.0.7
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.7
+    swift_ip: 172.22.0.7
+
+  # networks
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet1
+    prefix-length: 24
+    iface: enp6s0
+    mtu: 9000
+    lb_addresses:
+      - 192.168.122.80-192.168.122.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "macvlan",
+        "master": "ospbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.122.0/24",
+          "range_start": "192.168.122.30",
+          "range_end": "192.168.122.70"
+        }
+      }
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "macvlan",
+        "master": "internalapi",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 9000
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "macvlan",
+        "master": "storage",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+  storagemgmt:  # used on RHEL, not used on OpenShift
+    dnsDomain: storagemgmt.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.20.0.250
+            start: 172.20.0.100
+        cidr: 172.20.0.0/24
+        name: subnet1
+        vlan: 23
+    mtu: 9000
+  tenant:
+    dnsDomain: tenant.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        name: subnet1
+        vlan: 22
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "macvlan",
+        "master": "tenant",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70"
+        }
+      }
+  external:
+    dnsDomain: external.example.com
+    subnets:
+      - allocationRanges:
+          - end: 10.0.0.250
+            start: 10.0.0.100
+        cidr: 10.0.0.0/24
+        gateway: 10.0.0.1
+        name: subnet1
+    mtu: 1500
+  swift:
+    dnsDomain: swift.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.22.0.250
+            start: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
+        name: subnet1
+        vlan: 25
+    mtu: 1500
+    prefix-length: 24
+    iface: swift
+    vlan: 25
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.22.0.80-172.22.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "swift",
+        "type": "macvlan",
+        "master": "swift",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.22.0.0/24",
+          "range_start": "172.22.0.100",
+          "range_end": "172.22.0.250"
+        }
+      }
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config: []
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr

--- a/examples/va/nvidia-mdev/control-plane/service-values.yaml
+++ b/examples/va/nvidia-mdev/control-plane/service-values.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  preserveJobs: false
+  neutron:
+    customServiceConfig: |
+      [DEFAULT]
+      service_plugins=qos,ovn-router,trunk,segments,port_forwarding,log,placement
+      [ml2]
+      mechanism_drivers=sriovnicswitch,ovn
+      extension_drivers=port_security,router,qos,segments,trunk,placement,port_numa_affinity_policy
+      [ml2_type_vlan]
+      network_vlan_ranges=datacentre:1:1000,physnet1:2000:2005
+  ovn:
+    ovnController:
+      nicMappings:
+        datacentre: enp6s0
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:swift
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+    default:
+      replicas: 1
+  swift:
+    enabled: true
+  nova:
+    schedulerServiceTemplate:
+      customServiceConfig: |
+        [filter_scheduler]
+        enabled_filters = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter

--- a/examples/va/nvidia-mdev/edpm-post-driver/.gitignore
+++ b/examples/va/nvidia-mdev/edpm-post-driver/.gitignore
@@ -1,0 +1,2 @@
+dataplane-deployment.yaml
+dataplane-nodeset.yaml

--- a/examples/va/nvidia-mdev/edpm-post-driver/deployment/.gitignore
+++ b/examples/va/nvidia-mdev/edpm-post-driver/deployment/.gitignore
@@ -1,0 +1,2 @@
+dataplane-deployment.yaml
+post-driver-deployment.yaml

--- a/examples/va/nvidia-mdev/edpm-post-driver/deployment/kustomization.yaml
+++ b/examples/va/nvidia-mdev/edpm-post-driver/deployment/kustomization.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../va/nvidia-mdev/edpm-post-driver/deployment
+  # - https://github.com/openstack-k8s-operators/architecture/va/nvidia-mdev/edpm-post-driver/deployment?ref=main
+  ## It's possible to replace ../../../../../va/nvidia-mdev/edpm-post-driver/deployment/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-post-driver-values
+      fieldPath: data.servicesOverride
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.servicesOverride
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-post-driver-values
+      fieldPath: data.ansibleExtraVars
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.ansibleExtraVars
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-post-driver-values
+      fieldPath: data.deployment.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true

--- a/examples/va/nvidia-mdev/edpm-post-driver/deployment/values.yaml
+++ b/examples/va/nvidia-mdev/edpm-post-driver/deployment/values.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: edpm-nodeset-post-driver-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  deployment:
+    name: edpm-deployment-post-driver
+  servicesOverride:
+    - reboot-os
+    - compute-provider
+  ansibleExtraVars:
+    edpm_reboot_strategy: force

--- a/examples/va/nvidia-mdev/edpm-post-driver/nodeset/.gitignore
+++ b/examples/va/nvidia-mdev/edpm-post-driver/nodeset/.gitignore
@@ -1,0 +1,1 @@
+compute-provider-service.yaml

--- a/examples/va/nvidia-mdev/edpm-post-driver/nodeset/kustomization.yaml
+++ b/examples/va/nvidia-mdev/edpm-post-driver/nodeset/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../va/nvidia-mdev/edpm-post-driver/nodeset
+
+resources:
+  - values.yaml

--- a/examples/va/nvidia-mdev/edpm-post-driver/nodeset/values.yaml
+++ b/examples/va/nvidia-mdev/edpm-post-driver/nodeset/values.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-provider-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nova:
+    compute:
+      provider: |
+        meta:
+          schema_version: "1.0"
+        providers:
+          - identification:
+              name: edpm-compute-0.ctlplane.example.com_pci_0000_04_00_0
+            traits:
+              additional:
+                - CUSTOM_NVIDIA_229
+          - identification:
+              name: edpm-compute-0.ctlplane.example.com_pci_0000_82_00_0
+            traits:
+              additional:
+                - CUSTOM_NVIDIA_228
+          - identification:
+              name: edpm-compute-1.ctlplane.example.com_pci_0000_04_00_0
+            traits:
+              additional:
+                - CUSTOM_NVIDIA_229
+          - identification:
+              name: edpm-compute-1.ctlplane.example.com_pci_0000_82_00_0
+            traits:
+              additional:
+                - CUSTOM_NVIDIA_228

--- a/examples/va/nvidia-mdev/edpm-post.md
+++ b/examples/va/nvidia-mdev/edpm-post.md
@@ -1,0 +1,60 @@
+# Download Nvidia drivers to EDPM Nodes and apply follow up deployment
+
+## Assumptions
+
+- Initial [dataplane](edpm-pre.md) deployment has finalized and is successful
+
+## Apply necessary Nvidia configurations to EDPM Nodes
+### The following commands should be executed on every EDPM Node expected to provide vGPU MDevs
+Log into EDPM Node and update or create a blacklist file in /etc/modeprobe
+```
+cat /etc/modprobe.d/blacklist-nouveau.conf
+blacklist nouveau
+options nouveau modeset=0
+```
+Download the relevant Nvidia driver for your hardware and install per Nvidia's
+instructions.
+
+Regenerate initramfs
+```
+dracut --force
+grub2-mkconfig -o /boot/grub2/grub.cfg --update-bls-cmdline
+```
+
+## Create a post deployment to finalize Nvidia configuration
+Log out of EDPMs and return to architecture repo on the controller.
+
+```
+cd architecture/examples/va/nvidia-mdev/edpm-post-driver
+```
+
+### Optional: Create a provider.yaml
+Create a configmap for the provider.yaml to map CUSTOM_TRAITS to the relevant
+resource providers and their MDevs, then create the corresponding service that
+will apply the configMap.
+
+Update the post [nodeset](edpm-post-driver/nodeset/values.yaml) values to how
+you wish to map resource provider to traits.
+
+```
+vi nodeset/values.yaml
+kustomize build nodeset > compute-provider-service.yaml
+oc apply -f compute-provider-service.yaml
+```
+
+## Reboot EDPM Nodes and optionaly apply provider.yaml
+In order finish Nvidia Driver installation the EDPM Nodes will need a final
+reboot. This will require a new deployment that will run ```reboot-os``` on the
+relevant EDPM Nodes.
+
+Update [deployment](edpm-post-driver/deployment/values.yaml) values to suit
+your environment and to include provider.yaml if using.
+```
+vi deployment/values.yaml
+```
+
+Create and apply deployment.
+```
+kustomize build deployment > post-driver-deployment.yaml
+oc apply -f post-driver-deployment.yaml
+```

--- a/examples/va/nvidia-mdev/edpm-pre.md
+++ b/examples/va/nvidia-mdev/edpm-pre.md
@@ -1,0 +1,49 @@
+# Configuring and deploying the dataplane
+
+## Assumptions
+
+- The [control plane](control-plane.md) has been created and successfully deployed
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the nvidia-mdev/edpm directory
+```
+cd architecture/examples/va/nvidia-mdev/edpm
+```
+Edit the [nodeset/values.yaml](edpm/nodeset/values.yaml) and [deployment/values.yaml](edpm/deployment/values.yaml) files to suit your environment.
+```
+vi nodeset/values.yaml
+vi deployment/values.yaml
+```
+Generate the dataplane nodeset CR.
+```
+kustomize build nodeset > dataplane-nodeset.yaml
+```
+Generate the dataplane deployment CR.
+```
+kustomize build deployment > dataplane-deployment.yaml
+```
+
+## Create CRs and do initial deployment
+Create the nodeset CR
+```
+oc apply -f dataplane-nodeset.yaml
+```
+Wait for dataplane nodeset setup to finish
+```
+oc wait osdpns openstack-edpm --for condition=SetupReady --timeout=600s
+```
+
+Start the deployment
+```
+oc apply -f dataplane-deployment.yaml
+```
+
+Wait for dataplane deployment to finish
+```
+oc wait osdpns openstack-edpm --for condition=Ready --timeout=60m
+```

--- a/examples/va/nvidia-mdev/edpm/.gitignore
+++ b/examples/va/nvidia-mdev/edpm/.gitignore
@@ -1,0 +1,2 @@
+dataplane-deployment.yaml
+dataplane-nodeset.yaml

--- a/examples/va/nvidia-mdev/edpm/deployment/.gitignore
+++ b/examples/va/nvidia-mdev/edpm/deployment/.gitignore
@@ -1,0 +1,2 @@
+dataplane-deployment.yaml
+deployment.yaml

--- a/examples/va/nvidia-mdev/edpm/deployment/kustomization.yaml
+++ b/examples/va/nvidia-mdev/edpm/deployment/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../va/nvidia-mdev/edpm/deployment
+  # - https://github.com/openstack-k8s-operators/architecture/va/nvidia-mdev/edpm/deployment?ref=main
+  ## It's possible to replace ../../../../../va/nvidia-mdev/edpm/deployment/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml

--- a/examples/va/nvidia-mdev/edpm/deployment/values.yaml
+++ b/examples/va/nvidia-mdev/edpm/deployment/values.yaml
@@ -1,0 +1,10 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data: {}

--- a/examples/va/nvidia-mdev/edpm/nodeset/.gitignore
+++ b/examples/va/nvidia-mdev/edpm/nodeset/.gitignore
@@ -1,0 +1,2 @@
+dataplane-nodeset.yaml
+nodeset.yaml

--- a/examples/va/nvidia-mdev/edpm/nodeset/kustomization.yaml
+++ b/examples/va/nvidia-mdev/edpm/nodeset/kustomization.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../va/nvidia-mdev/edpm/nodeset
+  # - https://github.com/openstack-k8s-operators/architecture/va/nvidia-mdev/edpm/nodeset?ref=main
+  ## It's possible to replace ../../../../../va/nvidia-mdev/edpm/nodeset/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.root_password
+    targets:
+      - select:
+          kind: Secret
+          name: baremetalset-password-secret
+        fieldPaths:
+          - data.NodeRootPassword
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.preProvisioned
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: openstack-edpm
+        fieldPaths:
+          - spec.preProvisioned
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.baremetalSetTemplate
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: openstack-edpm
+        fieldPaths:
+          - spec.baremetalSetTemplate
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.nova.compute.conf
+    targets:
+      - select:
+          kind: ConfigMap
+          name: cpu-pinning-nova
+        fieldPaths:
+          - data.25-cpu-pinning-nova\.conf
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.nova.pci.conf
+    targets:
+      - select:
+          kind: ConfigMap
+          name: sriov-nova
+        fieldPaths:
+          - data.03-sriov-nova\.conf
+        options:
+          create: true

--- a/examples/va/nvidia-mdev/edpm/nodeset/values.yaml
+++ b/examples/va/nvidia-mdev/edpm/nodeset/values.yaml
@@ -1,0 +1,160 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  root_password: cmVkaGF0Cg==
+  preProvisioned: false
+  baremetalSetTemplate:
+    ctlplaneInterface: eno2  # CHANGEME
+    cloudUserName: cloud-admin
+    provisioningInterface: enp1s0  # CHANGEME
+    bmhLabelSelector:
+      app: openstack  # CHANGEME
+    passwordSecret:
+      name: baremetalset-password-secret
+      namespace: openstack
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        # CHANGEME -- see https://access.redhat.com/solutions/253273
+        # edpm_bootstrap_command: |
+        #       subscription-manager register --username <subscription_manager_username> --password <subscription_manager_password>
+        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # CPU pinning settings
+        edpm_kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=16 intel_iommu=on iommu=pt isolcpus=4-23,28-47"
+        edpm_tuned_profile: "cpu-partitioning-powersave"
+        edpm_tuned_isolated_cores: "4-23,28-47"
+        # edpm_network_config
+        # These vars are edpm_network_config role vars
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-compute-0:
+            nic2: 6c:fe:54:3f:8a:02  # CHANGEME
+            nic3: 6c:fe:54:3f:8a:03  # CHANGEME
+          edpm-compute-1:
+            nic2: 6b:fe:54:3f:8a:02  # CHANGEME
+            nic3: 6b:fe:54:3f:8a:03  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            mtu: {{ min_viable_mtu }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            members:
+            - type: interface
+              name: nic2
+              mtu: {{ min_viable_mtu }}
+              # force the MAC address of the bridge to this interface
+              primary: true
+          {% for network in nodeset_networks %}
+            - type: vlan
+              mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+              vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+              addresses:
+              - ip_netmask:
+                  {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+              routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+          - type: sriov_pf
+            name: nic3
+            numvfs: 10
+            use_dhcp: false
+            promisc: true
+
+        # These vars are for the network config templates themselves and are
+        # considered EDPM network defaults.
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth0
+        # edpm_nodes_validation
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        dns_search_domains: []
+        gather_facts: false
+        # edpm firewall, change the allowed CIDR if needed
+        edpm_sshd_configure_firewall: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        # SRIOV settings
+        edpm_neutron_sriov_agent_SRIOV_NIC_physical_device_mappings: 'sriov-phy4:eno4'
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
+    nodes:
+      edpm-compute-0:
+        hostName: edpm-compute-0
+      edpm-compute-1:
+        hostName: edpm-compute-1
+    services:
+      - bootstrap
+      - download-cache
+      - reboot-os
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - install-certs
+      - ovn
+      - neutron-ovn
+      - neutron-metadata
+      - neutron-sriov
+      - libvirt
+      - nova-custom-sriov
+  nova:
+    compute:
+      conf: |
+        # CHANGEME
+        [DEFAULT]
+        reserved_host_memory_mb = 4096
+        reserved_huge_pages = node:0,size:4,count:524160
+        reserved_huge_pages = node:1,size:4,count:524160
+        [compute]
+        cpu_shared_set = 0-3,24-27
+        cpu_dedicated_set = 8-23,32-47
+        [devices]
+        mdev_enabled_types = nvidia-268
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5
+    pci:
+      conf: |
+        # CHANGEME
+        [pci]
+        device_spec = {"vendor_id":"8086", "product_id":"1572", "address": "0000:19:00.3", "physical_network":"sriov-phy4", "trusted":"true"}

--- a/va/nvidia-mdev/edpm-post-driver/deployment/kustomization.yaml
+++ b/va/nvidia-mdev/edpm-post-driver/deployment/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../lib/dataplane/deployment

--- a/va/nvidia-mdev/edpm-post-driver/nodeset/kustomization.yaml
+++ b/va/nvidia-mdev/edpm-post-driver/nodeset/kustomization.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+resources:
+  - nova_provider.yaml
+
+replacements:
+  # Nova provider yaml configuration
+  - source:
+      kind: ConfigMap
+      name: edpm-provider-values
+      fieldPath: data.nova.compute.provider
+    targets:
+      - select:
+          kind: ConfigMap
+          name: compute-provider
+        fieldPaths:
+          - data.provider\.yaml
+        options:
+          create: true

--- a/va/nvidia-mdev/edpm-post-driver/nodeset/nova_provider.yaml
+++ b/va/nvidia-mdev/edpm-post-driver/nodeset/nova_provider.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: compute-provider
+data:
+  provider.yaml: _replaced_
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: compute-provider
+spec:
+  label: dataplane-deployment-compute-provider
+  edpmServiceType: nova
+  dataSources:
+    - configMapRef:
+        name: compute-provider
+    - configMapRef:
+        name: cpu-pinning-nova
+    - configMapRef:
+        name: sriov-nova
+    - secretRef:
+        name: nova-cell1-compute-config
+    - secretRef:
+        name: nova-migration-ssh-key
+  playbook: osp.edpm.nova
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      networks:
+        - ctlplane
+      issuer: osp-rootca-issuer-internal
+  caCerts: combined-ca-bundle

--- a/va/nvidia-mdev/edpm/deployment/kustomization.yaml
+++ b/va/nvidia-mdev/edpm/deployment/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../lib/dataplane/deployment

--- a/va/nvidia-mdev/edpm/nodeset/baremetalset-password-secret.yaml
+++ b/va/nvidia-mdev/edpm/nodeset/baremetalset-password-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+data:
+  NodeRootPassword: _replaced_
+kind: Secret
+metadata:
+  name: baremetalset-password-secret
+  namespace: openstack
+type: Opaque

--- a/va/nvidia-mdev/edpm/nodeset/kustomization.yaml
+++ b/va/nvidia-mdev/edpm/nodeset/kustomization.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../lib/dataplane/nodeset
+
+resources:
+  - baremetalset-password-secret.yaml
+  - nova_sriov.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.root_password
+    targets:
+      - select:
+          kind: Secret
+          name: baremetalset-password-secret
+        fieldPaths:
+          - data.NodeRootPassword
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.preProvisioned
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: openstack-edpm
+        fieldPaths:
+          - spec.preProvisioned
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.baremetalSetTemplate
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: openstack-edpm
+        fieldPaths:
+          - spec.baremetalSetTemplate
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.nova.compute.conf
+    targets:
+      - select:
+          kind: ConfigMap
+          name: cpu-pinning-nova
+        fieldPaths:
+          - data.25-cpu-pinning-nova\.conf
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.nova.pci.conf
+    targets:
+      - select:
+          kind: ConfigMap
+          name: sriov-nova
+        fieldPaths:
+          - data.03-sriov-nova\.conf
+        options:
+          create: true

--- a/va/nvidia-mdev/edpm/nodeset/nova_sriov.yaml
+++ b/va/nvidia-mdev/edpm/nodeset/nova_sriov.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cpu-pinning-nova
+data:
+  25-cpu-pinning-nova.conf: _replaced_
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriov-nova
+data:
+  03-sriov-nova.conf: _replaced_
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: nova-custom-sriov
+spec:
+  label: dataplane-deployment-nova-custom-sriov
+  edpmServiceType: nova
+  dataSources:
+    - configMapRef:
+        name: cpu-pinning-nova
+    - configMapRef:
+        name: sriov-nova
+    - secretRef:
+        name: nova-cell1-compute-config
+    - secretRef:
+        name: nova-migration-ssh-key
+  playbook: osp.edpm.nova
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      networks:
+        - ctlplane
+      issuer: osp-rootca-issuer-internal
+  caCerts: combined-ca-bundle

--- a/va/nvidia-mdev/kustomization.yaml
+++ b/va/nvidia-mdev/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../lib/networking/metallb
+  - ../../lib/networking/netconfig
+  - ../../lib/networking/nad
+  - ../../lib/control-plane

--- a/va/nvidia-mdev/namespace.yaml
+++ b/va/nvidia-mdev/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: builtin
+kind: NamespaceTransformer
+metadata:
+  name: _ignored_
+  namespace: openstack
+setRoleBindingSubjects: none
+unsetOnly: true
+fieldSpecs:
+  - path: metadata/name
+    kind: Namespace
+    create: true

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -11,6 +11,7 @@
       - rhoso-architecture-validate-nfv-ovs-dpdk-sriov-adoption
       - rhoso-architecture-validate-nfv-ovs-dpdk-sriov-hci
       - rhoso-architecture-validate-nova-three-cells
+      - rhoso-architecture-validate-nvidia-mdev
       - rhoso-architecture-validate-osasinfra
       - rhoso-architecture-validate-osasinfra-ipv6
       - rhoso-architecture-validate-ovs-dpdk

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -121,6 +121,20 @@
       cifmw_architecture_scenario: nova-three-cells
 - job:
     files:
+    - examples/va/nvidia-mdev/control-plane
+    - examples/va/nvidia-mdev/control-plane/nncp
+    - examples/va/nvidia-mdev/edpm-post-driver/deployment
+    - examples/va/nvidia-mdev/edpm-post-driver/nodeset
+    - examples/va/nvidia-mdev/edpm/deployment
+    - examples/va/nvidia-mdev/edpm/nodeset
+    - lib
+    - va/nvidia-mdev
+    name: rhoso-architecture-validate-nvidia-mdev
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: nvidia-mdev
+- job:
+    files:
     - dt/osasinfra
     - examples/dt/osasinfra
     - examples/dt/osasinfra/control-plane


### PR DESCRIPTION
This VA allows for the deployment of an environment that supports providing multiple Mdev types to guests.  One of the key workflow differences in this deployment versus other VA/DT's is after the initial deploymentit needs to:
-  leverage CIFMW to install the necessary Nvidia drivers
- Create a provider.yaml to map traits to resource providers
- Reboot the computes

This workflow is not considered the universally official way of installing/deploying a vGPU available environment since the procedure can change depending on the underlying hardware, but this is the procedure we plan to use when testing with our own equipment.