### PR TITLE
[DNM] Add power monitoring to uni alpha

### DIFF
--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -120,6 +120,15 @@ data:
     enabled: true
     metricStorage:
       enabled: true
+      dashboardsEnabled: true
+      monitoringStack:
+        alertingEnabled: true
+        scrapeInterval: 30s
+        storage:
+          strategy: persistent
+          retention: 24h
+          persistent:
+            pvcStorageRequest: 20G
     autoscaling:
       enabled: true
     ceilometer:
@@ -175,3 +184,16 @@ data:
       [ml2]
       type_drivers = geneve,vxlan,vlan,flat,local
       tenant_network_types = geneve,flat
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-operators
+spec:
+  channel: development
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/examples/dt/uni01alpha/edpm/values.yaml
+++ b/examples/dt/uni01alpha/edpm/values.yaml
@@ -133,3 +133,4 @@ data:
       - libvirt
       - nova
       - telemetry
+      - telemetry-power-monitoring


### PR DESCRIPTION
This patch enables power monitoring in uni01alpha, for kepler deployment testing purposes only