### PR TITLE
[uni04delta-ipv6] Install conntrack tools on EDPM nodes

### DIFF
--- a/examples/dt/uni04delta-ipv6/values.yaml
+++ b/examples/dt/uni04delta-ipv6/values.yaml
@@ -77,6 +77,10 @@ data:
         edpm_sshd_allowed_ranges:
           - '2620:cf:cf:aaaa::0/64'
 
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+
         gather_facts: false
 
         image_tag: current-podified


### PR DESCRIPTION
It is required for some Tobiko scenario tests