### PR TITLE
Set Cinder customServiceConfig globally in DCN DT

### DIFF
--- a/dt/dcn/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/dcn/edpm-post-ceph/nodeset/kustomization.yaml
@@ -148,12 +148,12 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
-      fieldPath: data.cinderAPI.customServiceConfig
+      fieldPath: data.cinder.customServiceConfig
     targets:
       - select:
           kind: OpenStackControlPlane
         fieldPaths:
-          - spec.cinder.template.cinderAPI.customServiceConfig
+          - spec.cinder.template.customServiceConfig
         options:
           create: true
   - source:

--- a/examples/dt/dcn/service-values.yaml
+++ b/examples/dt/dcn/service-values.yaml
@@ -9,12 +9,12 @@ metadata:
 data:
   preserveJobs: false
   cinder:
+    customServiceConfig: |
+      [DEFAULT]
+      storage_availability_zone = az0
     uniquePodNames: false
   cinderAPI:
     replicas: 3
-    customServiceConfig: |
-      [DEFAULT]
-      default_availability_zone = az0
   cinderBackup:
     replicas: 3
     customServiceConfig: |
@@ -23,7 +23,6 @@ data:
       backup_ceph_conf = /etc/ceph/az0.conf
       backup_ceph_pool = backups
       backup_ceph_user = openstack
-      storage_availability_zone = az0
   cinderVolumes:
     az0:
       customServiceConfig: |


### PR DESCRIPTION
The customServiceConfig for cinder in the DCN DT is used to set the storage_availability_zone. We wish to do this for all Cinder services in the default site (`az0`), not just for cinderAPI or cinderBackup as the AZ was missing from the cinder-scheduler. Thus, we will move it to the global section under the cinder template and out of the cinderAPI and cinderBackup since they will inherit it. We still need to set the backend_availability_zone in all cinderVolumes except az0 since it will also inherit the new default value. However, the additional line is kept in az0's customServiceConfig to make the pattern easier to see for az0, az1, az2, etc.

Jira: https://issues.redhat.com/browse/OSPRH-11915