### PR TITLE
[DCN DT] Set table-id explicitly for routes

### DIFF
--- a/examples/dt/dcn/control-plane/nncp/values.yaml
+++ b/examples/dt/dcn/control-plane/nncp/values.yaml
@@ -340,27 +340,35 @@ data:
             - destination: 192.168.133.0/24
               next-hop-address: 192.168.122.1
               next-hop-interface: ospbr
+              table-id: 254
             - destination: 192.168.144.0/24
               next-hop-address: 192.168.122.1
               next-hop-interface: ospbr
+              table-id: 254
             - destination: 172.17.10.0/24
               next-hop-address: 172.17.0.1
               next-hop-interface: internalapi
+              table-id: 254
             - destination: 172.18.10.0/24
               next-hop-address: 172.18.0.1
               next-hop-interface: storage
+              table-id: 254
             - destination: 172.19.10.0/24
               next-hop-address: 172.19.0.1
               next-hop-interface: tenant
+              table-id: 254
             - destination: 172.17.20.0/24
               next-hop-address: 172.17.0.1
               next-hop-interface: internalapi
+              table-id: 254
             - destination: 172.18.20.0/24
               next-hop-address: 172.18.0.1
               next-hop-interface: storage
+              table-id: 254
             - destination: 172.19.20.0/24
               next-hop-address: 172.19.0.1
               next-hop-interface: tenant
+              table-id: 254
     storage:
         base_iface: enp7s0
         dnsDomain: storage.example.com


### PR DESCRIPTION
Without it table id randomly get's set and
causes re creation of vlan interfaces. This
results into secondary nics removed from pods.

Related-Issue: [OSPRH-9899](https://issues.redhat.com//browse/OSPRH-9899)