### PR TITLE
[BGP] Replace worker-3 NAD from host-device to macvlan

### DIFF
--- a/examples/dt/bgp/bgp_dt01/control-plane/nncp/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/nncp/kustomization.yaml
@@ -808,6 +808,11 @@ replacements:
         fieldPaths:
           - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
           - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.prefix-length-worker-3
+    targets:
       - select:  # in case of worker-3, there is one less interfaces
           kind: NodeNetworkConfigurationPolicy
           name: worker-3

--- a/examples/dt/bgp/bgp_dt01/control-plane/nncp/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/nncp/values.yaml
@@ -273,6 +273,7 @@ data:
 
   bgp:
     prefix-length: 30
+    prefix-length-worker-3: 24
     ifaces:
       - enp8s0
       - enp9s0
@@ -434,13 +435,13 @@ data:
         {
           "cniVersion": "0.3.1",
           "name": "bgpnet-worker-3",
-          "type": "host-device",
-          "device": "enp8s0",
+          "type": "macvlan",
+          "master": "enp8s0",
           "ipam": {
             "type": "whereabouts",
-            "range": "100.64.10.0/30",
-            "range_start": "100.64.10.2",
-            "range_end": "100.64.10.2",
+            "range": "100.64.10.0/24",
+            "range_start": "100.64.10.10",
+            "range_end": "100.64.10.19",
             "routes": [{
               "dst": "192.168.133.0/24",
               "gw": "100.64.10.1"


### PR DESCRIPTION
We implemented a solution to connect test pods running in worker-3 to the provider network using a host-device NAD. This has been working fine while only one test pod ran simultaneously.
With the new feature added to tobiko to run a tobiko-ping pod in parallel with the usual tobiko pod, attaching several pods to that NAD is necessary.
This PR modified the BGP configuration so that the mentioned host-device NAD is replaced with a macvlan NAD that allows multiple connections.