### PR TITLE
[OSASINFRA-IPV6 DT]Set MTU to 9000

### DIFF
--- a/examples/dt/osasinfra-ipv6/service-values.yaml
+++ b/examples/dt/osasinfra-ipv6/service-values.yaml
@@ -8,6 +8,12 @@ metadata:
     config.kubernetes.io/local-config: "true"
 data:
   preserveJobs: false
+  neutron:
+    # To avoid hitting https://access.redhat.com/solutions/7088208 during
+    # shiftstack installation:
+    customServiceConfig: |
+      [DEFAULT]
+      global_physnet_mtu = 9000
   cinderAPI:
     replicas: 3
   cinderBackup:


### PR DESCRIPTION
With 1500 MTU, we hit https://access.redhat.com/solutions/7088208

Same is not hit in ipv4 because the overhead is higher in ipv6. This patch is updating the MTU to 9000 so the shiftstack installation on top of this DT can succeed.