### PR TITLE
Switch cinder uniquePodNames to true for DCN deployments

### DIFF
--- a/dt/dcn/control-plane/kustomization.yaml
+++ b/dt/dcn/control-plane/kustomization.yaml
@@ -91,17 +91,6 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
-      fieldPath: data.cinder.uniquePodNames
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.cinder.uniquePodNames
-        options:
-          create: true
-  - source:
-      kind: ConfigMap
-      name: service-values
       fieldPath: data.cinderVolumes
     targets:
       - select:

--- a/examples/dt/dcn/control-plane/scaledown/service-values.yaml
+++ b/examples/dt/dcn/control-plane/scaledown/service-values.yaml
@@ -11,7 +11,6 @@ data:
     customServiceConfig: |
       [DEFAULT]
       default_availability_zone = az0
-    uniquePodNames: false
   cinderAPI:
     replicas: 3
   cinderBackup:

--- a/examples/dt/dcn/service-values.yaml
+++ b/examples/dt/dcn/service-values.yaml
@@ -12,7 +12,6 @@ data:
     customServiceConfig: |
       [DEFAULT]
       storage_availability_zone = az0
-    uniquePodNames: false
   cinderAPI:
     replicas: 3
   cinderBackup:
@@ -353,10 +352,8 @@ data:
           extraVolType: Ceph
           volumes:
             - name: ceph
-              projected:
-                sources:
-                  - secret:
-                      name: ceph-conf-files
+              secret:
+                secretName: ceph-conf-files
           mounts:
             - name: ceph
               mountPath: /etc/ceph


### PR DESCRIPTION
This patch reverts the work done in [1], where `uniquePodNames`
was added as a `kustomization` parameter for Cinder and switched
to false due to [2].
In addition, this patch fixes the way `extraMounts` `Ceph` secrets
are accessed, and removes the not required `projected` key.

[1] https://github.com/openstack-k8s-operators/architecture/pull/436
[2] https://issues.redhat.com/browse/OSPRH-11240

Jira: https://issues.redhat.com/browse/OSPRH-11240