### PR TITLE
BGP controlplane Pure L3 Spine&Leaf

### DIFF
--- a/automation/mocks/bgp_dt01.yaml
+++ b/automation/mocks/bgp_dt01.yaml
@@ -1,11 +1,11 @@
 ---
 cifmw_networking_env_definition:
   instances:
-    compute-0:
-      hostname: compute-0
-      name: compute-0
+    r0-compute-0:
+      hostname: r0-compute-0
+      name: r0-compute-0
       networks:
-        ctlplane:
+        ctlplaner0:
           interface_name: eth1
           ip_v4: 192.168.122.100
           mac_addr: 52:54:00:6a:4a:25
@@ -47,13 +47,13 @@ cifmw_networking_env_definition:
           prefix_length_v4: 24
           skip_nm: false
           vlan_id: 22
-    compute-1:
-      hostname: compute-1
-      name: compute-1
+    r1-compute-0:
+      hostname: r1-compute-0
+      name: r1-compute-0
       networks:
-        ctlplane:
+        ctlplaner1:
           interface_name: eth1
-          ip_v4: 192.168.122.101
+          ip_v4: 192.168.123.101
           mac_addr: 52:54:00:9b:e6:98
           mtu: 1500
           netmask_v4: 255.255.255.0
@@ -93,13 +93,13 @@ cifmw_networking_env_definition:
           prefix_length_v4: 24
           skip_nm: false
           vlan_id: 22
-    compute-2:
-      hostname: compute-2
-      name: compute-2
+    r2-compute-0:
+      hostname: r2-compute-0
+      name: r2-compute-0
       networks:
-        ctlplane:
+        ctlplaner2:
           interface_name: eth1
-          ip_v4: 192.168.122.102
+          ip_v4: 192.168.124.102
           mac_addr: 52:54:00:98:a6:ae
           mtu: 1500
           netmask_v4: 255.255.255.0
@@ -152,11 +152,11 @@ cifmw_networking_env_definition:
           network_name: ctlplane
           prefix_length_v4: 24
           skip_nm: false
-    networker-0:
-      hostname: networker-0
-      name: networker-0
+    r0-networker-0:
+      hostname: r0-networker-0
+      name: r0-networker-0
       networks:
-        ctlplane:
+        ctlplaner0:
           interface_name: eth1
           ip_v4: 192.168.122.106
           mac_addr: 52:54:00:15:d3:88
@@ -187,11 +187,11 @@ cifmw_networking_env_definition:
           prefix_length_v4: 24
           skip_nm: false
           vlan_id: 22
-    networker-1:
-      hostname: networker-1
-      name: networker-1
+    r1-networker-0:
+      hostname: r1-networker-0
+      name: r1-networker-0
       networks:
-        ctlplane:
+        ctlplaner1:
           interface_name: eth1
           ip_v4: 192.168.122.107
           mac_addr: 52:54:00:de:46:aa
@@ -222,11 +222,11 @@ cifmw_networking_env_definition:
           prefix_length_v4: 24
           skip_nm: false
           vlan_id: 22
-    networker-2:
-      hostname: networker-2
-      name: networker-2
+    r2-networker-0:
+      hostname: r2-networker-0
+      name: r2-networker-0
       networks:
-        ctlplane:
+        ctlplaner2:
           interface_name: eth1
           ip_v4: 192.168.122.108
           mac_addr: 52:54:00:3f:b8:15
@@ -694,6 +694,123 @@ cifmw_networking_env_definition:
               end_host: 200
               length: 51
               start: 192.168.122.150
+              start_host: 150
+          ipv6_ranges: []
+    ctlplaner0:
+      dns_v4:
+        - 192.168.122.1
+      dns_v6: []
+      gw_v4: 192.168.122.1
+      mtu: 1500
+      network_name: ctlplaner0
+      network_v4: 192.168.122.0/24
+      search_domain: ctlplaner0.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.122.90
+              end_host: 90
+              length: 11
+              start: 192.168.122.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.122.70
+              end_host: 70
+              length: 41
+              start: 192.168.122.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.122.120
+              end_host: 120
+              length: 21
+              start: 192.168.122.100
+              start_host: 100
+            - end: 192.168.122.200
+              end_host: 200
+              length: 51
+              start: 192.168.122.150
+              start_host: 150
+          ipv6_ranges: []
+    ctlplaner1:
+      dns_v4:
+        - 192.168.123.1
+      dns_v6: []
+      gw_v4: 192.168.123.1
+      mtu: 1500
+      network_name: ctlplaner1
+      network_v4: 192.168.123.0/24
+      search_domain: ctlplaner1.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.123.90
+              end_host: 90
+              length: 11
+              start: 192.168.123.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.123.70
+              end_host: 70
+              length: 41
+              start: 192.168.123.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.123.120
+              end_host: 120
+              length: 21
+              start: 192.168.123.100
+              start_host: 100
+            - end: 192.168.123.200
+              end_host: 200
+              length: 51
+              start: 192.168.123.150
+              start_host: 150
+          ipv6_ranges: []
+    ctlplaner2:
+      dns_v4:
+        - 192.168.124.1
+      dns_v6: []
+      gw_v4: 192.168.124.1
+      mtu: 1500
+      network_name: ctlplaner2
+      network_v4: 192.168.124.0/24
+      search_domain: ctlplaner2.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.124.90
+              end_host: 90
+              length: 11
+              start: 192.168.124.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.124.70
+              end_host: 70
+              length: 41
+              start: 192.168.124.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.124.120
+              end_host: 120
+              length: 21
+              start: 192.168.124.100
+              start_host: 100
+            - end: 192.168.124.200
+              end_host: 200
+              length: 51
+              start: 192.168.124.150
               start_host: 150
           ipv6_ranges: []
     external:

--- a/automation/vars/bgp_dt01.yaml
+++ b/automation/vars/bgp_dt01.yaml
@@ -2,7 +2,8 @@
 vas:
   bgp_dt01:
     stages:
-      - pre_stage_run:
+      -  # stage_0
+        pre_stage_run:
           - name: Apply taint on worker-3
             type: cr
             definition:
@@ -17,19 +18,54 @@ vas:
             kind: Node
             resource_name: worker-3
             state: patched
+          - name: Disable rp_filters on OCP nodes
+            type: cr
+            definition:
+              spec:
+                profile:
+                  - data: |
+                      [main]
+                      summary=Optimize systems running OpenShift (provider specific parent profile)
+                      include=-provider-${f:exec:cat:/var/lib/ocp-tuned/provider},openshift
+
+                      [sysctl]
+                      net.ipv4.conf.enp7s0.rp_filter=0
+                      net.ipv4.conf.enp8s0.rp_filter=0
+                    name: openshift-no-reapply-sysctl
+                recommend:
+                  - match:
+                      # applied to all nodes except worker-3, because worker-3 has no enp8s0
+                      - label: kubernetes.io/hostname
+                        value: worker-0
+                      - label: kubernetes.io/hostname
+                        value: worker-1
+                      - label: kubernetes.io/hostname
+                        value: worker-2
+                      - label: node-role.kubernetes.io/master
+                    operand:
+                      tunedConfig:
+                        reapply_sysctl: false
+                    priority: 15
+                    profile: openshift-no-reapply-sysctl
+            api_version: tuned.openshift.io/v1
+            kind: Tuned
+            resource_name: openshift-no-reapply-sysctl
+            namespace: openshift-cluster-node-tuning-operator
+            state: present
         path: examples/dt/bgp/bgp_dt01/control-plane/nncp
         wait_conditions:
           - >-
             oc -n openstack wait nncp
             -l osp/nncm-config-type=standard
             --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
-            --timeout=60s
+            --timeout=300s
         values:
           - name: network-values
             src_file: values.yaml
         build_output: nncp.yaml
 
-      - path: examples/dt/bgp/bgp_dt01/control-plane
+      -  # stage_1
+        path: examples/dt/bgp/bgp_dt01/control-plane
         wait_conditions:
           - >-
             oc -n openstack wait openstackcontrolplane
@@ -42,39 +78,110 @@ vas:
           - name: service-values
             src_file: service-values.yaml
         build_output: control-plane.yaml
+        post_stage_run:
+          - name: Create BGPConfiguration after controplane is deployed
+            type: cr
+            definition:
+              spec: {}
+            api_version: network.openstack.org/v1beta1
+            kind: BGPConfiguration
+            resource_name: bgpconfiguration
+            namespace: openstack
+            state: present
 
-      - path: examples/dt/bgp/bgp_dt01/edpm/networkers
+      -  # stage_2
+        path: examples/dt/bgp/bgp_dt01/edpm/computes/r0
         wait_conditions:
           - >-
             oc -n openstack wait openstackdataplanenodeset
-            networker-nodes
+            r0-compute-nodes
             --for condition=SetupReady
             --timeout=600s
         values:
-          - name: edpm-networker-nodeset-values
+          - name: edpm-r0-compute-nodeset-values
             src_file: values.yaml
-        build_output: edpm-networker-nodeset.yaml
+        build_output: edpm-r0-compute-nodeset.yaml
 
-      - path: examples/dt/bgp/bgp_dt01/edpm/computes
+      -  # stage_3
+        path: examples/dt/bgp/bgp_dt01/edpm/computes/r1
         wait_conditions:
           - >-
             oc -n openstack wait openstackdataplanenodeset
-            compute-nodes
+            r1-compute-nodes
             --for condition=SetupReady
             --timeout=600s
         values:
-          - name: edpm-compute-nodeset-values
+          - name: edpm-r1-compute-nodeset-values
             src_file: values.yaml
-        build_output: edpm-compute-nodeset.yaml
+        build_output: edpm-r1-compute-nodeset.yaml
 
-      - path: examples/dt/bgp/bgp_dt01/edpm/deployment
+      -  # stage_4
+        path: examples/dt/bgp/bgp_dt01/edpm/computes/r2
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r2-compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r2-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r2-compute-nodeset.yaml
+
+      -  # stage_5
+        path: examples/dt/bgp/bgp_dt01/edpm/networkers/r0
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r0-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r0-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r0-networker-nodeset.yaml
+
+      -  # stage_6
+        path: examples/dt/bgp/bgp_dt01/edpm/networkers/r1
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r1-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r1-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r1-networker-nodeset.yaml
+
+      -  # stage_7
+        path: examples/dt/bgp/bgp_dt01/edpm/networkers/r2
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r2-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r2-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r2-networker-nodeset.yaml
+
+      -  # stage_8
+        path: examples/dt/bgp/bgp_dt01/edpm/deployment
         wait_conditions:
           - >-
             oc -n openstack wait openstackdataplanedeployment
             edpm-deployment
             --for condition=Ready
-            --timeout=90m
+            --timeout=120m
         values:
           - name: edpm-deployment-values
             src_file: values.yaml
         build_output: edpm-deployment.yaml
+        post_stage_run:
+          - name: Wait until computes are ready
+            type: playbook
+            source: "../../playbooks/bgp-l3-computes-ready.yml"
+            extra_vars:
+              num_computes: 3

--- a/dt/bgp/edpm/nodeset/kustomization.yaml
+++ b/dt/bgp/edpm/nodeset/kustomization.yaml
@@ -19,3 +19,20 @@ transformers:
 
 components:
   - ../../../../lib/dataplane/nodeset
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /spec/env
+        value:
+          - name: ANSIBLE_FORCE_COLOR
+            value: "True"
+          - name: ANSIBLE_TIMEOUT
+            value: "60"
+          - name: ANSIBLE_SSH_TIMEOUT
+            value: "60"
+          - name: ANSIBLE_SSH_RETRIES
+            value: "60"

--- a/examples/dt/bgp/bgp_dt01/README.md
+++ b/examples/dt/bgp/bgp_dt01/README.md
@@ -41,9 +41,9 @@ workers cannot be configured as OVN Gateways.
 The OCP and EDPM nodes deployed with this DT are distributed into three
 different racks. Each rack is connected to two leaves.
 Hence, the distribution of the nodes in the racks is the following one:
-* rack0: compute-0, networker-0, ocp-master-0, ocp-worker-0, leaf-0, leaf-1
-* rack1: compute-1, networker-1, ocp-master-1, ocp-worker-1, leaf-2, leaf-3
-* rack2: compute-2, networker-2, ocp-master-2, ocp-worker-2, leaf-4, leaf-5
+* rack0: r0-compute-0, r0-networker-0, ocp-master-0, ocp-worker-0, leaf-0, leaf-1
+* rack1: r1-compute-0, r1-networker-0, ocp-master-1, ocp-worker-1, leaf-2, leaf-3
+* rack2: r2-compute-0, r2-networker-0, ocp-master-2, ocp-worker-2, leaf-4, leaf-5
 
 The OCP tester (ocp-worker-3) is not included into any rack. It is not
 connected to any leaves, but to a router connected to the spines, due to the
@@ -66,7 +66,9 @@ network).
 
 | Name                     | Type     | CIDR             |
 | ------------------------ | -------- | ---------------- |
-| Provisioning             | untagged | 192.168.122.0/24 |
+| Controlplane rack0       | untagged | 192.168.122.0/24 |
+| Controlplane rack1       | untagged | 192.168.123.0/24 |
+| Controlplane rack2       | untagged | 192.168.124.0/24 |
 | Provider network         | untagged | 192.168.133.0/24 |
 | RH OSP                   | untagged | 192.168.111.0/24 |
 | edpm/ocp to left leaves  | untagged | 100.64.x.y/30    |
@@ -89,13 +91,17 @@ network).
 2. All the VMs that are neither Openstack nor Openshift nodes, i.e. those that
    act as routers, need to be properly configured in order to support the BGP
    protocol.
-3. The spine/leaf topology separates the overcloud nodes into different L2
+3. The spine/leaf topology separates the nodes into different L2
    network segments, called racks. Each rack includes two leaves, some OCP
    nodes and some EDPM nodes.
-4. A separate provisioning network is necessary to install Openstack on those
-   nodes.
-5. Once Openstack is installed on them, dataplane connectivity is achieved
-   using the BGP protocol.
+4. The Openstack services running on the EDPM nodes are installed using the BGP
+   network, i.e. the Openstack services running on OCP nodes connect to the
+   Openstack services running on EDPM nodes using BGP. There is no direct L2
+   network connectivity between them. OCP version 4.18 or higher is required
+   because the Openstack Operators use the frr-k8s feature for this and frr-k8s
+   is not available in OCP 4.16.
+5. Once Openstack is installed on them, both dataplane and controlplane
+   connections are achieved using the BGP protocol.
 6. Tests are executed from the OCP worker to verify external connectivity.
 
 ## Stages
@@ -103,7 +109,9 @@ network).
 All stages must be executed in the order listed below. Everything is required unless otherwise indicated.
 
 1. [Configure taints on the OCP worker](configure-taints.md)
-2. [Install the OpenStack K8S operators and their dependencies](../../../common/)
-3. [Apply metallb customization required to run a speaker pod on the OCP tester node](metallb/)
-4. [Configuring networking and deploy the OpenStack control plane](control-plane.md)
-5. [Configure and deploy the dataplane - networker and compute nodes](data-plane.md)
+2. [Disable RP filters on OCP nodes](disable-rp-filters.md)
+3. [Install the OpenStack K8S operators and their dependencies](../../../common/)
+4. [Apply metallb customization required to run a speaker pod on the OCP tester node](metallb/)
+5. [Configuring networking and deploy the OpenStack control plane](control-plane.md)
+6. [Create BGPConfiguration after controplane is deployed](bgp-configuration.md)
+7. [Configure and deploy the dataplane - networker and compute nodes](data-plane.md)

--- a/examples/dt/bgp/bgp_dt01/bgp-configuration.md
+++ b/examples/dt/bgp/bgp_dt01/bgp-configuration.md
@@ -1,0 +1,16 @@
+# Create BGPConfiguration after controplane is deployed
+
+An empty BGPConfiguration Openshift resource needs to be created.
+The infra-operator will detect this resource is created and will automatically
+apply the required Openshift BGP configuration.
+OCP 4.18 release is necessary for this.
+
+The following CR needs to be applied:
+```
+apiVersion: network.openstack.org/v1beta1
+kind: BGPConfiguration
+metadata:
+  name: bgpconfiguration
+  namespace: openstack
+spec: {}
+```

--- a/examples/dt/bgp/bgp_dt01/control-plane/nncp/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/nncp/kustomization.yaml
@@ -18,7 +18,7 @@ transformers:
       create: true
 
 components:
-  - ../../../../../../lib/nncp
+  - ../../../../../../lib/nncp-l3
 
 resources:
   - values.yaml
@@ -196,213 +196,6 @@ replacements:
         fieldPaths:
           - metadata.name
           - spec.nodeSelector.[kubernetes.io/hostname]
-
-  # Static Node IPs: node-3/worker-0
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_3.internalapi_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-0
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_3.tenant_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-0
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_3.ctlplane_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-0
-        fieldPaths:
-          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_3.storage_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-0
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
-
-  # Static Node IPs: node-4 / worker-1
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_4.internalapi_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-1
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_4.tenant_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-1
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_4.ctlplane_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-1
-        fieldPaths:
-          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_4.storage_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-1
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
-
-  # Static Node IPs: node-5 / worker-2
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_5.internalapi_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-2
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_5.tenant_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-2
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_5.ctlplane_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-2
-        fieldPaths:
-          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_5.storage_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-2
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
-
-  # Static Node IPs: node-6 / worker-3
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_6.internalapi_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-3
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_6.tenant_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-3
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_6.ctlplane_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-3
-        fieldPaths:
-          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_6.storage_ip
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-3
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
-
-
-  # prefix-lengths
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.ctlplane.prefix-length
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-        fieldPaths:
-          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.prefix-length
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.internalapi.prefix-length
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.prefix-length
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.tenant.prefix-length
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.prefix-length
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.storage.prefix-length
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.prefix-length
 
   # BGP master-0/node-0 IPs
   - source:
@@ -919,22 +712,6 @@ replacements:
           kind: NodeNetworkConfigurationPolicy
         fieldPaths:
           - spec.desiredState.interfaces.[name=octavia].vlan.id
-  # Overwrite worker-3 base interface
-  - source:
-      kind: ConfigMap
-      name: network-values
-      fieldPath: data.node_6.base_if
-    targets:
-      - select:
-          kind: NodeNetworkConfigurationPolicy
-          name: worker-3
-        fieldPaths:
-          - spec.desiredState.interfaces.[name=internalapi].vlan.base-iface
-          - spec.desiredState.interfaces.[name=tenant].vlan.base-iface
-          - spec.desiredState.interfaces.[name=storage].vlan.base-iface
-          - spec.desiredState.interfaces.[description=^ctlplane.*].name
-          - spec.desiredState.interfaces.[description=^linux-bridge.*].bridge.port.0.name
-          - spec.desiredState.interfaces.[name=octavia].vlan.base-iface
   # Overwrite worker-3 base routes
   - source:
       kind: ConfigMap
@@ -944,5 +721,72 @@ replacements:
       - select:
           kind: NodeNetworkConfigurationPolicy
           name: worker-3
+        fieldPaths:
+          - spec.desiredState.routes
+
+  # NEW L3 ROUTES
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
         fieldPaths:
           - spec.desiredState.routes

--- a/examples/dt/bgp/bgp_dt01/control-plane/nncp/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/nncp/values.yaml
@@ -20,8 +20,16 @@ data:
     bgp_peers:
       - 100.64.0.9
       - 100.65.0.9
-    loopback_ip: 172.30.0.3
+    loopback_ip: 99.99.0.3
     loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:13
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.1
+          next-hop-interface: enp7s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.1
+          next-hop-interface: enp8s0
   node_1:
     name: master-1
     internalapi_ip: 172.17.0.6
@@ -34,8 +42,16 @@ data:
     bgp_peers:
       - 100.64.1.9
       - 100.65.1.9
-    loopback_ip: 172.30.1.3
+    loopback_ip: 99.99.1.3
     loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:23
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.1
+          next-hop-interface: enp7s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.1
+          next-hop-interface: enp8s0
   node_2:
     name: master-2
     internalapi_ip: 172.17.0.7
@@ -48,8 +64,16 @@ data:
     bgp_peers:
       - 100.64.2.9
       - 100.65.2.9
-    loopback_ip: 172.30.2.3
+    loopback_ip: 99.99.2.3
     loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:33
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.1
+          next-hop-interface: enp7s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.1
+          next-hop-interface: enp8s0
   node_3:
     name: worker-0
     internalapi_ip: 172.17.0.8
@@ -62,8 +86,16 @@ data:
     bgp_peers:
       - 100.64.0.12
       - 100.65.0.12
-    loopback_ip: 172.30.0.4
+    loopback_ip: 99.99.0.4
     loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:14
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.1
+          next-hop-interface: enp7s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.1
+          next-hop-interface: enp8s0
   node_4:
     name: worker-1
     internalapi_ip: 172.17.0.9
@@ -76,8 +108,16 @@ data:
     bgp_peers:
       - 100.64.1.13
       - 100.65.1.13
-    loopback_ip: 172.30.1.4
+    loopback_ip: 99.99.1.4
     loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:24
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.1
+          next-hop-interface: enp7s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.1
+          next-hop-interface: enp8s0
   node_5:
     name: worker-2
     internalapi_ip: 172.17.0.10
@@ -90,8 +130,16 @@ data:
     bgp_peers:
       - 100.64.2.13
       - 100.65.2.13
-    loopback_ip: 172.30.2.4
+    loopback_ip: 99.99.2.4
     loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.1
+          next-hop-interface: enp7s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.1
+          next-hop-interface: enp8s0
   node_6:
     name: worker-3
     internalapi_ip: 172.17.0.11
@@ -102,14 +150,14 @@ data:
       - 100.64.10.2
     bgp_peers:
       - 100.64.10.1
-    loopback_ip: 172.30.10.2
+    loopback_ip: 99.99.10.2
     loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:43
-    base_if: enp7s0
+    base_if: enp6s0
     routes:
       config:
         - destination: 192.168.133.0/24
           next-hop-address: 100.64.10.1
-          next-hop-interface: enp8s0
+          next-hop-interface: enp7s0
 
   # networks
   ctlplane:
@@ -123,28 +171,131 @@ data:
         cidr: 192.168.122.0/24
         gateway: 192.168.122.1
         name: subnet1
+        routes:
+          - destination: 192.168.123.0/24
+            nexthop: 192.168.122.1
+          - destination: 192.168.124.0/24
+            nexthop: 192.168.122.1
+      - allocationRanges:
+          - end: 192.168.123.120
+            start: 192.168.123.100
+          - end: 192.168.123.170
+            start: 192.168.123.150
+        cidr: 192.168.123.0/24
+        gateway: 192.168.123.1
+        name: subnet2
+        routes:
+          - destination: 192.168.122.0/24
+            nexthop: 192.168.123.1
+          - destination: 192.168.124.0/24
+            nexthop: 192.168.123.1ØØ
+      - allocationRanges:
+          - end: 192.168.124.120
+            start: 192.168.124.100
+          - end: 192.168.124.170
+            start: 192.168.124.150
+        cidr: 192.168.124.0/24
+        gateway: 192.168.124.1
+        name: subnet3
+        routes:
+          - destination: 192.168.122.0/24
+            nexthop: 192.168.124.1
+          - destination: 192.168.123.0/24
+            nexthop: 192.168.124.1
     prefix-length: 24
-    iface: enp7s0
+    iface: enp6s0
     mtu: 1500
     lb_addresses:
-      - 192.168.122.80-192.168.122.90
+      - 192.168.125.80-192.168.125.90
     endpoint_annotations:
       metallb.universe.tf/address-pool: ctlplane
       metallb.universe.tf/allow-shared-ip: ctlplane
-      metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+      metallb.universe.tf/loadBalancerIPs: 192.168.125.80
     net-attach-def: |
       {
         "cniVersion": "0.3.1",
         "name": "ctlplane",
-        "type": "macvlan",
-        "master": "ospbr",
+        "type": "bridge",
+        "bridge": "ctlplane",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
         "ipam": {
           "type": "whereabouts",
-          "range": "192.168.122.0/24",
-          "range_start": "192.168.122.30",
-          "range_end": "192.168.122.70"
+          "range": "192.168.125.0/24",
+          "range_start": "192.168.125.30",
+          "range_end": "192.168.125.70"
         }
       }
+
+    ctlplaner1:
+      dnsDomain: ctlplaner1.example.com
+      endpoint_annotations:
+        metallb.universe.tf/address-pool: ctlplaner1
+        metallb.universe.tf/allow-shared-ip: ctlplaner1
+        metallb.universe.tf/loadBalancerIPs: 192.168.123.80
+      iface: eth1
+      lb_addresses:
+        - 192.168.123.80-192.168.123.90
+      mtu: 1500
+      net-attach-def: |
+        {
+          "cniVersion": "0.3.1",
+          "name": "ctlplaner1",
+          "type": "macvlan",
+          "master": "eth1",
+          "ipam": {
+            "type": "whereabouts",
+            "range": "192.168.123.0/24",
+            "range_start": "192.168.123.30",
+            "range_end": "192.168.123.70"
+          }
+        }
+      prefix-length: 24
+      subnets:
+        - allocationRanges:
+            - end: 192.168.123.120
+              start: 192.168.123.100
+            - end: 192.168.123.170
+              start: 192.168.123.150
+          cidr: 192.168.123.0/24
+          gateway: 192.168.123.1
+          name: subnet1
+    ctlplaner2:
+      dnsDomain: ctlplaner2.example.com
+      endpoint_annotations:
+        metallb.universe.tf/address-pool: ctlplaner2
+        metallb.universe.tf/allow-shared-ip: ctlplaner2
+        metallb.universe.tf/loadBalancerIPs: 192.168.124.80
+      iface: eth1
+      lb_addresses:
+        - 192.168.124.80-192.168.124.90
+      mtu: 1500
+      net-attach-def: |
+        {
+          "cniVersion": "0.3.1",
+          "name": "ctlplaner2",
+          "type": "macvlan",
+          "master": "eth1",
+          "ipam": {
+            "type": "whereabouts",
+            "range": "192.168.124.0/24",
+            "range_start": "192.168.124.30",
+            "range_end": "192.168.124.70"
+          }
+        }
+      prefix-length: 24
+      subnets:
+        - allocationRanges:
+            - end: 192.168.124.120
+              start: 192.168.124.100
+            - end: 192.168.124.170
+              start: 192.168.124.150
+          cidr: 192.168.124.0/24
+          gateway: 192.168.124.1
+          name: subnet1
+
   internalapi:
     dnsDomain: internalapi.example.com
     subnets:
@@ -158,7 +309,7 @@ data:
     prefix-length: 24
     iface: internalapi
     vlan: 20
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
       - 172.17.0.80-172.17.0.90
     endpoint_annotations:
@@ -169,8 +320,12 @@ data:
       {
         "cniVersion": "0.3.1",
         "name": "internalapi",
-        "type": "macvlan",
-        "master": "internalapi",
+        "type": "bridge",
+        "bridge": "internalapi",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
         "ipam": {
           "type": "whereabouts",
           "range": "172.17.0.0/24",
@@ -191,15 +346,19 @@ data:
     prefix-length: 24
     iface: storage
     vlan: 21
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
       - 172.18.0.80-172.18.0.90
     net-attach-def: |
       {
         "cniVersion": "0.3.1",
         "name": "storage",
-        "type": "macvlan",
-        "master": "storage",
+        "type": "bridge",
+        "bridge": "storage",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
         "ipam": {
           "type": "whereabouts",
           "range": "172.18.0.0/24",
@@ -220,15 +379,19 @@ data:
     prefix-length: 24
     iface: tenant
     vlan: 22
-    base_iface: enp7s0
+    base_iface: enp6s0
     lb_addresses:
       - 172.19.0.80-172.19.0.90
     net-attach-def: |
       {
         "cniVersion": "0.3.1",
         "name": "tenant",
-        "type": "macvlan",
-        "master": "tenant",
+        "type": "bridge",
+        "bridge": "tenant",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
         "ipam": {
           "type": "whereabouts",
           "range": "172.19.0.0/24",
@@ -240,7 +403,7 @@ data:
     dnsDomain: octavia.openstack.lab
     mtu: 1500
     vlan: 23
-    base_iface: enp7s0
+    base_iface: enp6s0
     net-attach-def: |
       {
         "cniVersion": "0.3.1",
@@ -275,8 +438,8 @@ data:
     prefix-length: 30
     prefix-length-worker-3: 24
     ifaces:
+      - enp7s0
       - enp8s0
-      - enp9s0
     asn: 64999
     peer_asn: 64999
     subnets:
@@ -338,25 +501,25 @@ data:
               nexthop: 100.65.2.1
       bgpmainnet:
         - name: subnet0
-          cidr: 172.30.0.0/28
+          cidr: 99.99.0.0/28
           allocationRanges:
-            - end: 172.30.0.14
-              start: 172.30.0.2
+            - end: 99.99.0.14
+              start: 99.99.0.2
         - name: subnet1
-          cidr: 172.30.1.0/28
+          cidr: 99.99.1.0/28
           allocationRanges:
-            - end: 172.30.1.14
-              start: 172.30.1.2
+            - end: 99.99.1.14
+              start: 99.99.1.2
         - name: subnet2
-          cidr: 172.30.2.0/28
+          cidr: 99.99.2.0/28
           allocationRanges:
-            - end: 172.30.2.14
-              start: 172.30.2.2
+            - end: 99.99.2.14
+              start: 99.99.2.2
         - name: subnet10
-          cidr: 172.30.10.0/28
+          cidr: 99.99.10.0/28
           allocationRanges:
-            - end: 172.30.10.14
-              start: 172.30.10.2
+            - end: 99.99.10.14
+              start: 99.99.10.2
       bgpmainnetv6:
         - name: subnet0
           cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0010/124
@@ -386,6 +549,14 @@ data:
         bgpnet1:
           bgp_peer: 100.65.0.9
           bgp_ip: 100.65.0.10
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.1
+              next-hop-interface: enp7s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.1
+              next-hop-interface: enp8s0
       node1:
         bgpnet0:
           bgp_peer: 100.64.1.9
@@ -393,6 +564,14 @@ data:
         bgpnet1:
           bgp_peer: 100.65.1.9
           bgp_ip: 100.65.1.10
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.1
+              next-hop-interface: enp7s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.1
+              next-hop-interface: enp8s0
       node2:
         bgpnet0:
           bgp_peer: 100.64.2.9
@@ -400,6 +579,14 @@ data:
         bgpnet1:
           bgp_peer: 100.65.2.9
           bgp_ip: 100.65.2.10
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.1
+              next-hop-interface: enp7s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.1
+              next-hop-interface: enp8s0
       node3:
         bgpnet0:
           bgp_peer: 100.64.0.13
@@ -407,6 +594,14 @@ data:
         bgpnet1:
           bgp_peer: 100.65.0.13
           bgp_ip: 100.65.0.14
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.1
+              next-hop-interface: enp7s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.1
+              next-hop-interface: enp8s0
       node4:
         bgpnet0:
           bgp_peer: 100.64.1.13
@@ -414,6 +609,14 @@ data:
         bgpnet1:
           bgp_peer: 100.65.1.13
           bgp_ip: 100.65.1.14
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.1
+              next-hop-interface: enp7s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.1
+              next-hop-interface: enp8s0
       node5:
         bgpnet0:
           bgp_peer: 100.64.2.13
@@ -421,6 +624,14 @@ data:
         bgpnet1:
           bgp_peer: 100.65.2.13
           bgp_ip: 100.65.2.14
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.1
+              next-hop-interface: enp7s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.1
+              next-hop-interface: enp8s0
       node6:
         bgpnet0:
           bgp_peer: 100.64.10.1
@@ -429,14 +640,14 @@ data:
           config:
             - destination: 192.168.133.0/24
               next-hop-address: 100.64.10.1
-              next-hop-interface: enp8s0
+              next-hop-interface: enp7s0
     net-attach-def:
       node6: |
         {
           "cniVersion": "0.3.1",
           "name": "bgpnet-worker-3",
           "type": "macvlan",
-          "master": "enp8s0",
+          "master": "enp7s0",
           "ipam": {
             "type": "whereabouts",
             "range": "100.64.10.0/24",

--- a/examples/dt/bgp/bgp_dt01/control-plane/service-values.yaml
+++ b/examples/dt/bgp/bgp_dt01/control-plane/service-values.yaml
@@ -59,7 +59,7 @@ data:
     ovnController:
       nicMappings:
         datacentre: ocpbr
-        octavia: octbr
+        # octavia: octbr TODO(eolivare): enable octavia
       external-ids:
         enable-chassis-as-gateway: false
   neutron:

--- a/examples/dt/bgp/bgp_dt01/data-plane.md
+++ b/examples/dt/bgp/bgp_dt01/data-plane.md
@@ -16,26 +16,36 @@ Change to the bgp_dt01/ directory
 ```
 cd architecture/examples/dt/bgp/bgp_dt01/
 ```
-Edit the [edpm/networkers/values.yaml](edpm/networkers/values.yaml) file to suit
-your environment.
+Edit the networker values.yaml files corresponding to each rack (r0, r1 and r2)
+to suit your environment:
+- [edpm/networkers/r0/values.yaml](edpm/networkers/r0/values.yaml)
+- [edpm/networkers/r1/values.yaml](edpm/networkers/r1/values.yaml)
+- [edpm/networkers/r2/values.yaml](edpm/networkers/r2/values.yaml)
 ```
 vi values.yaml
 ```
-Edit the [edpm/computes/values.yaml](edpm/computes/values.yaml) file to suit
-your environment.
+Edit the compute values.yaml files corresponding to each rack (r0, r1 and r2)
+to suit your environment:
+- [edpm/computes/r0/values.yaml](edpm/computes/r0/values.yaml)
+- [edpm/computes/r1/values.yaml](edpm/computes/r1/values.yaml)
+- [edpm/computes/r2/values.yaml](edpm/computes/r2/values.yaml)
 ```
 vi values.yaml
 ```
 
 ## Create Networker and Compute Nodeset CRs
 
-Generate the networkers dataplane nodeset CR.
+Generate the networkers dataplane nodeset CRs for each rack.
 ```
-kustomize build edpm/networkers > edpm-networker-nodeset.yaml
+kustomize build edpm/networkers/r0 > edpm-r0-networker-nodeset.yaml
+kustomize build edpm/networkers/r1 > edpm-r1-networker-nodeset.yaml
+kustomize build edpm/networkers/r2 > edpm-r2-networker-nodeset.yaml
 ```
-Generate the computes dataplane nodeset CR.
+Generate the computes dataplane nodeset CRs for each rack.
 ```
-kustomize build edpm/computes > edpm-compute-nodeset.yaml
+kustomize build edpm/computes/r0 > edpm-r0-compute-nodeset.yaml
+kustomize build edpm/computes/r1 > edpm-r1-compute-nodeset.yaml
+kustomize build edpm/computes/r2 > edpm-r2-compute-nodeset.yaml
 ```
 
 ## Create EDPM  Deployment CR
@@ -46,27 +56,35 @@ kustomize build edpm/deployment > edpm-deployment.yaml
 
 ## Apply the Nodeset CRs
 
-Apply the Networker nodeset CR
+Apply the Networker nodeset CRs
 ```
-oc apply -f edpm-networker-nodeset.yaml
+oc apply -f edpm/networkers/r0/edpm-r0-networker-nodeset.yaml
+oc apply -f edpm/networkers/r1/edpm-r1-networker-nodeset.yaml
+oc apply -f edpm/networkers/r2/edpm-r2-networker-nodeset.yaml
 ```
-Wait for Networker dataplane nodeset setup to finish
+Wait for Networker dataplane nodesets setup to finish
 ```
-oc wait osdpns networker-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r0-networker-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r1-networker-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r2-networker-nodes --for condition=SetupReady --timeout=600s
 ```
-Apply the Compute nodeset CR
+Apply the Compute nodeset CRs
 ```
-oc apply -f edpm-compute-nodeset.yaml
+oc apply -f edpm/computes/r0/edpm-r0-compute-nodeset.yaml
+oc apply -f edpm/computes/r1/edpm-r1-compute-nodeset.yaml
+oc apply -f edpm/computes/r2/edpm-r2-compute-nodeset.yaml
 ```
-Wait for Compute dataplane nodeset setup to finish
+Wait for Compute dataplane nodesets setup to finish
 ```
-oc wait osdpns compute-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r0-compute-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r1-compute-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r2-compute-nodes --for condition=SetupReady --timeout=600s
 ```
 
 ## Apply the deployment
 Start the deployment
 ```
-oc apply -f edpm-deployment.yaml
+oc apply -f edpm/deployment/edpm-deployment.yaml
 ```
 Wait for dataplane deployment to finish
 ```

--- a/examples/dt/bgp/bgp_dt01/disable-rp-filters.md
+++ b/examples/dt/bgp/bgp_dt01/disable-rp-filters.md
@@ -1,0 +1,39 @@
+# Disable RP filters on OCP workers
+
+Reverse path filters need to be disabled on OCP workers running Openstack services.
+This is needed to make OCP workers forward traffic properly based on the BGP
+advertisements received.
+
+The following CR needs to be applied:
+```
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-no-reapply-sysctl
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Optimize systems running OpenShift (provider specific parent profile)
+      include=-provider-${f:exec:cat:/var/lib/ocp-tuned/provider},openshift
+
+      [sysctl]
+      net.ipv4.conf.enp7s0.rp_filter=0
+      net.ipv4.conf.enp8s0.rp_filter=0
+    name: openshift-no-reapply-sysctl
+  recommend:
+  - match:
+    - label: kubernetes.io/hostname
+      value: worker-0
+    - label: kubernetes.io/hostname
+      value: worker-1
+    - label: kubernetes.io/hostname
+      value: worker-2
+    - label: node-role.kubernetes.io/master
+    operand:
+      tunedConfig:
+        reapply_sysctl: false
+    priority: 15
+    profile: openshift-no-reapply-sysctl
+```

--- a/examples/dt/bgp/bgp_dt01/edpm/computes/r0/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/r0/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 components:
-  - ../../../../../../dt/bgp/edpm/nodeset
+  - ../../../../../../../dt/bgp/edpm/nodeset
   ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
   ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
 
@@ -17,13 +17,4 @@ patches:
     patch: |-
       - op: replace
         path: /metadata/name
-        value: networker-nodes
-
-  - target:
-      kind: Secret
-      name: nova-migration-ssh-key
-    patch: |-
-      - op: add
-        path: /metadata/annotations
-        value:
-          config.kubernetes.io/local-config: true
+        value: r0-compute-nodes

--- a/examples/dt/bgp/bgp_dt01/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/r0/values.yaml
@@ -52,32 +52,18 @@ data:
           - type: ovs_bridge
             name: {{ neutron_physical_bridge_name }}
             use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
             dns_servers: {{ ctlplane_dns_nameservers }}
             domain: {{ dns_search_domains }}
             addresses:
               - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
-            routes: []
-            members:
-              - type: interface
-                name: nic2
-                mtu: {{ min_viable_mtu }}
-                # force the MAC address of the bridge to this interface
-                primary: true
-          {% for network in nodeset_networks %}
-          {%   if not network.lower().startswith('bgp') %}
-              - type: vlan
-                mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
-                vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
-                addresses:
-                  - ip_netmask: >-
-                      {{
-                        lookup('vars', networks_lower[network] ~ '_ip')
-                      }}/{{
-                        lookup('vars', networks_lower[network] ~ '_cidr')
-                      }}
-                routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
-          {% endif %}
-          {% endfor %}
           - type: interface
             name: nic3
             use_dhcp: false
@@ -93,6 +79,9 @@ data:
             addresses:
             - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
         edpm_sshd_allowed_ranges:
@@ -159,85 +148,17 @@ data:
           - name: Tenant
             subnetName: subnet1
           - name: Bgpnet0
-            subnetName: subnet0
+            subnetName: subnet1
             fixedIP: 100.64.0.2
           - name: Bgpnet1
-            subnetName: subnet0
+            subnetName: subnet1
             fixedIP: 100.65.0.2
           - name: Bgpmainnet
             subnetName: subnet1
-            fixedIP: 172.30.0.2
+            fixedIP: 99.99.0.2
           - name: BgpmainnetV6
-            subnetName: subnet1
+            subnetName: subnet0
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
-      edpm-compute-1:
-        hostName: edpm-compute-1
-        ansible:
-          ansibleHost: 192.168.122.101
-          ansibleVars:
-            edpm_ovn_bgp_agent_local_ovn_peer_ips:
-              - 100.64.1.1
-              - 100.65.1.1
-            edpm_frr_bgp_peers:
-              - 100.64.1.1
-              - 100.65.1.1
-        networks:
-          - defaultRoute: true
-            fixedIP: 192.168.122.101
-            name: CtlPlane
-            subnetName: subnet1
-          - name: InternalApi
-            subnetName: subnet1
-          - name: Storage
-            subnetName: subnet1
-          - name: Tenant
-            subnetName: subnet1
-          - name: Bgpnet0
-            subnetName: subnet1
-            fixedIP: 100.64.1.2
-          - name: Bgpnet1
-            subnetName: subnet1
-            fixedIP: 100.65.1.2
-          - name: Bgpmainnet
-            subnetName: subnet1
-            fixedIP: 172.30.1.3
-          - name: BgpmainnetV6
-            subnetName: subnet1
-            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
-      edpm-compute-2:
-        hostName: edpm-compute-2
-        ansible:
-          ansibleHost: 192.168.122.102
-          ansibleVars:
-            edpm_ovn_bgp_agent_local_ovn_peer_ips:
-              - 100.64.2.1
-              - 100.65.2.1
-            edpm_frr_bgp_peers:
-              - 100.64.2.1
-              - 100.65.2.1
-        networks:
-          - defaultRoute: true
-            fixedIP: 192.168.122.102
-            name: CtlPlane
-            subnetName: subnet1
-          - name: InternalApi
-            subnetName: subnet1
-          - name: Storage
-            subnetName: subnet1
-          - name: Tenant
-            subnetName: subnet1
-          - name: Bgpnet0
-            subnetName: subnet2
-            fixedIP: 100.64.2.2
-          - name: Bgpnet1
-            subnetName: subnet2
-            fixedIP: 100.65.2.2
-          - name: Bgpmainnet
-            subnetName: subnet1
-            fixedIP: 172.30.2.3
-          - name: BgpmainnetV6
-            subnetName: subnet1
-            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033
     services:
       - download-cache
       - bootstrap

--- a/examples/dt/bgp/bgp_dt01/edpm/computes/r1/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/r1/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 components:
-  - ../../../../../../dt/bgp/edpm/nodeset
+  - ../../../../../../../dt/bgp/edpm/nodeset
   ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
   ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
 
@@ -17,4 +17,4 @@ patches:
     patch: |-
       - op: replace
         path: /metadata/name
-        value: compute-nodes
+        value: r1-compute-nodes

--- a/examples/dt/bgp/bgp_dt01/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/r1/values.yaml
@@ -1,0 +1,182 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks:
+          - nic3
+          - nic4
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+          edpm-compute-1:
+            nic2: 6b:fe:54:3f:8a:02  # CHANGEME
+          edpm-compute-2:
+            nic2: 6c:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-compute-1:
+        hostName: edpm-compute-1
+        ansible:
+          ansibleHost: 192.168.122.101
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.1.1
+              - 100.65.1.1
+            edpm_frr_bgp_peers:
+              - 100.64.1.1
+              - 100.65.1.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.1.2
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.1.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.1.2
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - frr
+      - install-os
+      - configure-os
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp/bgp_dt01/edpm/computes/r2/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/r2/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r2-compute-nodes

--- a/examples/dt/bgp/bgp_dt01/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/computes/r2/values.yaml
@@ -1,0 +1,182 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks:
+          - nic3
+          - nic4
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+          edpm-compute-1:
+            nic2: 6b:fe:54:3f:8a:02  # CHANGEME
+          edpm-compute-2:
+            nic2: 6c:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-compute-2:
+        hostName: edpm-compute-2
+        ansible:
+          ansibleHost: 192.168.122.102
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.2.1
+              - 100.65.2.1
+            edpm_frr_bgp_peers:
+              - 100.64.2.1
+              - 100.65.2.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.102
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet2
+            fixedIP: 100.64.2.2
+          - name: Bgpnet1
+            subnetName: subnet2
+            fixedIP: 100.65.2.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.2.2
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - frr
+      - install-os
+      - configure-os
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp/bgp_dt01/edpm/deployment/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/deployment/values.yaml
@@ -8,5 +8,9 @@ metadata:
     config.kubernetes.io/local-config: "true"
 data:
   nodeSets:
-    - networker-nodes
-    - compute-nodes
+    - r0-networker-nodes
+    - r1-networker-nodes
+    - r2-networker-nodes
+    - r0-compute-nodes
+    - r1-compute-nodes
+    - r2-compute-nodes

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/r0/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/r0/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r0-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/r0/values.yaml
@@ -1,0 +1,181 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks:
+          - nic3
+          - nic4
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+          edpm-networker-1:
+            nic2: 6e:fe:54:3f:8a:02  # CHANGEME
+          edpm-networker-2:
+            nic2: 6f:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-networker-0:
+        hostName: edpm-networker-0
+        ansible:
+          ansibleHost: 192.168.122.105
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.0.5
+              - 100.65.0.5
+            edpm_frr_bgp_peers:
+              - 100.64.0.5
+              - 100.65.0.5
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.105
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet0
+            fixedIP: 100.64.0.6
+          - name: Bgpnet1
+            subnetName: subnet0
+            fixedIP: 100.65.0.6
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.0.3
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0013
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - frr
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/r1/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/r1/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r1-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/r1/values.yaml
@@ -1,0 +1,181 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks:
+          - nic3
+          - nic4
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+          edpm-networker-1:
+            nic2: 6e:fe:54:3f:8a:02  # CHANGEME
+          edpm-networker-2:
+            nic2: 6f:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-networker-1:
+        hostName: edpm-networker-1
+        ansible:
+          ansibleHost: 192.168.122.106
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.1.5
+              - 100.65.1.5
+            edpm_frr_bgp_peers:
+              - 100.64.1.5
+              - 100.65.1.5
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.106
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.1.6
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.1.6
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.1.3
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - frr
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/r2/kustomization.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/r2/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r2-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/bgp/bgp_dt01/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp/bgp_dt01/edpm/networkers/r2/values.yaml
@@ -52,32 +52,18 @@ data:
           - type: ovs_bridge
             name: {{ neutron_physical_bridge_name }}
             use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
             dns_servers: {{ ctlplane_dns_nameservers }}
             domain: {{ dns_search_domains }}
             addresses:
               - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
-            routes: []
-            members:
-              - type: interface
-                name: nic2
-                mtu: {{ min_viable_mtu }}
-                # force the MAC address of the bridge to this interface
-                primary: true
-          {% for network in nodeset_networks %}
-          {%   if not network.lower().startswith('bgp') %}
-              - type: vlan
-                mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
-                vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
-                addresses:
-                  - ip_netmask: >-
-                      {{
-                        lookup('vars', networks_lower[network] ~ '_ip')
-                      }}/{{
-                        lookup('vars', networks_lower[network] ~ '_cidr')
-                      }}
-                routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
-          {% endif %}
-          {% endfor %}
           - type: interface
             name: nic3
             use_dhcp: false
@@ -93,6 +79,8 @@ data:
             addresses:
             - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
         edpm_enable_chassis_gw: true
@@ -137,74 +125,6 @@ data:
       - name: BgpMainNetV6
         subnetName: subnet2
     nodes:
-      edpm-networker-0:
-        hostName: edpm-networker-0
-        ansible:
-          ansibleHost: 192.168.122.105
-          ansibleVars:
-            edpm_ovn_bgp_agent_local_ovn_peer_ips:
-              - 100.64.0.5
-              - 100.65.0.5
-            edpm_frr_bgp_peers:
-              - 100.64.0.5
-              - 100.65.0.5
-        networks:
-          - defaultRoute: true
-            fixedIP: 192.168.122.105
-            name: CtlPlane
-            subnetName: subnet1
-          - name: InternalApi
-            subnetName: subnet1
-          - name: Storage
-            subnetName: subnet1
-          - name: Tenant
-            subnetName: subnet1
-          - name: Bgpnet0
-            subnetName: subnet0
-            fixedIP: 100.64.0.6
-          - name: Bgpnet1
-            subnetName: subnet0
-            fixedIP: 100.65.0.6
-          - name: Bgpmainnet
-            subnetName: subnet1
-            fixedIP: 172.30.0.3
-          - name: BgpmainnetV6
-            subnetName: subnet1
-            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0013
-      edpm-networker-1:
-        hostName: edpm-networker-1
-        ansible:
-          ansibleHost: 192.168.122.106
-          ansibleVars:
-            edpm_ovn_bgp_agent_local_ovn_peer_ips:
-              - 100.64.1.5
-              - 100.65.1.5
-            edpm_frr_bgp_peers:
-              - 100.64.1.5
-              - 100.65.1.5
-        networks:
-          - defaultRoute: true
-            fixedIP: 192.168.122.106
-            name: CtlPlane
-            subnetName: subnet1
-          - name: InternalApi
-            subnetName: subnet1
-          - name: Storage
-            subnetName: subnet1
-          - name: Tenant
-            subnetName: subnet1
-          - name: Bgpnet0
-            subnetName: subnet1
-            fixedIP: 100.64.1.6
-          - name: Bgpnet1
-            subnetName: subnet1
-            fixedIP: 100.65.1.6
-          - name: Bgpmainnet
-            subnetName: subnet1
-            fixedIP: 172.30.1.3
-          - name: BgpmainnetV6
-            subnetName: subnet1
-            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
       edpm-networker-2:
         hostName: edpm-networker-2
         ansible:
@@ -235,7 +155,7 @@ data:
             fixedIP: 100.65.2.6
           - name: Bgpmainnet
             subnetName: subnet1
-            fixedIP: 172.30.2.3
+            fixedIP: 99.99.2.3
           - name: BgpmainnetV6
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033

--- a/lib/nncp-l3/kustomization.yaml
+++ b/lib/nncp-l3/kustomization.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ocp_nodes_nncp.yaml
+
+patches:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      labelSelector: "osp/nncm-config-type=standard"
+    path: ocp_node_template.yaml
+
+replacements:
+  # ctlplane type is ethernet (not vlan)
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=ethernet].name
+
+  # Node names
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-0
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-1
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-2
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  # DNS
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.dns-resolver.config
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.dns-resolver.config
+
+  # Routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.routes

--- a/lib/nncp-l3/ocp_node_template.yaml
+++ b/lib/nncp-l3/ocp_node_template.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: _ignored_
+spec:
+  desiredState:
+    dns-resolver:
+      config:
+        search: []
+        server: []
+    routes:
+      config: []
+    route-rules:
+      config: []
+    interfaces:
+      - description: internalapi bridge
+        name: internalapi
+        state: up
+        type: linux-bridge
+        mtu: 1500
+      - description: storage bridge
+        name: storage
+        state: up
+        type: linux-bridge
+        mtu: 1500
+      - description: tenant bridge
+        name: tenant
+        state: up
+        type: linux-bridge
+        mtu: 1500
+      - description: ctlplane bridge
+        name: ospbr
+        state: up
+        type: linux-bridge
+        mtu: 1500
+        ipv4:
+          enabled: false
+      - description: ctlplane interface
+        name: _replaced_
+        state: up
+        type: ethernet
+        mtu: 1500
+        ipv4:
+          enabled: false
+        ipv6:
+          enabled: false
+  nodeSelector:
+    kubernetes.io/hostname: _replaced_
+    node-role.kubernetes.io/worker: ""

--- a/lib/nncp-l3/ocp_nodes_nncp.yaml
+++ b/lib/nncp-l3/ocp_nodes_nncp.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-0
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-1
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-2
+  labels:
+    osp/nncm-config-type: standard

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -17,9 +17,13 @@
     - automation/mocks/bgp_dt01.yaml
     - examples/dt/bgp/bgp_dt01/control-plane
     - examples/dt/bgp/bgp_dt01/control-plane/nncp
-    - examples/dt/bgp/bgp_dt01/edpm/computes
+    - examples/dt/bgp/bgp_dt01/edpm/computes/r0
+    - examples/dt/bgp/bgp_dt01/edpm/computes/r1
+    - examples/dt/bgp/bgp_dt01/edpm/computes/r2
     - examples/dt/bgp/bgp_dt01/edpm/deployment
-    - examples/dt/bgp/bgp_dt01/edpm/networkers
+    - examples/dt/bgp/bgp_dt01/edpm/networkers/r0
+    - examples/dt/bgp/bgp_dt01/edpm/networkers/r1
+    - examples/dt/bgp/bgp_dt01/edpm/networkers/r2
     - lib
     name: rhoso-architecture-validate-bgp_dt01
     parent: rhoso-architecture-base-job


### PR DESCRIPTION
With this PR, BGP DT01 configures isolated L2 segments for networkers and computes.
The controlplane communications between RHOSO services running on OCP
nodes and services running on EDPM nodes is routed through the BGP
network. Spines and leaves connect the computes, networkers and OCP
nodes in different racks and route the traffic between them, as well as
the dataplane traffic to/from the Openstack VM instances.

[OSPRH-13820](https://issues.redhat.com//browse/OSPRH-13820)

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2691