### PR TITLE
Increase data plane deployment timeout for uni06zeta

### DIFF
--- a/automation/vars/uni06zeta.yaml
+++ b/automation/vars/uni06zeta.yaml
@@ -36,7 +36,7 @@ vas:
             oc -n openstack wait openstackdataplanedeployment
             edpm-deployment
             --for condition=Ready
-            --timeout=40m
+            --timeout=80m
         values:
           - name: edpm-nodeset-values
             src_file: values.yaml


### PR DESCRIPTION
For some reasons, the deployment of this scenario started slowing down.
As we can't easily override the timeout of the data plane deployment, bump it.
