### PR TITLE
Remove reference to deleted downstream workflow

### DIFF
--- a/.github/workflows/trigger-downstream-gh-action-job.yaml
+++ b/.github/workflows/trigger-downstream-gh-action-job.yaml
@@ -1,9 +1,0 @@
----
-name: Github Action to trigger downstream job
-on:  # yamllint disable-line rule:truthy
-  issue_comment:
-    types: [created, edited]
-
-jobs:
-  trigger_workflow:
-    uses: openstack-k8s-operators/ci-framework/.github/workflows/github-action-trigger-downstream-job-reusable-workflow.yaml@main


### PR DESCRIPTION
The workflow referenced no longer exists in CIFMW [1] and throws an error whenever someone comments on a PR.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2703