### PR TITLE
Update NFV VAs to use network vanity names

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/nncp/values.yaml
@@ -72,7 +72,7 @@ data:
         vlan: 20
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.20
+    iface: internalapi
     vlan: 20
     base_iface: enp7s0
     lb_addresses:
@@ -105,7 +105,7 @@ data:
         vlan: 21
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.21
+    iface: storage
     vlan: 21
     base_iface: enp7s0
     lb_addresses:
@@ -134,7 +134,7 @@ data:
         vlan: 22
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.22
+    iface: tenant
     vlan: 22
     base_iface: enp7s0
     lb_addresses:

--- a/examples/va/nfv/ovs-dpdk/nncp/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/nncp/values.yaml
@@ -72,7 +72,7 @@ data:
         vlan: 20
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.20
+    iface: internalapi
     vlan: 20
     base_iface: enp7s0
     lb_addresses:
@@ -105,7 +105,7 @@ data:
         vlan: 21
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.21
+    iface: storage
     vlan: 21
     base_iface: enp7s0
     lb_addresses:
@@ -134,7 +134,7 @@ data:
         vlan: 22
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.22
+    iface: tenant
     vlan: 22
     base_iface: enp7s0
     lb_addresses:

--- a/examples/va/nfv/sriov/nncp/values.yaml
+++ b/examples/va/nfv/sriov/nncp/values.yaml
@@ -72,7 +72,7 @@ data:
         vlan: 20
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.20
+    iface: internalapi
     vlan: 20
     base_iface: enp7s0
     lb_addresses:
@@ -105,7 +105,7 @@ data:
         vlan: 21
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.21
+    iface: storage
     vlan: 21
     base_iface: enp7s0
     lb_addresses:
@@ -134,7 +134,7 @@ data:
         vlan: 22
     mtu: 1500
     prefix-length: 24
-    iface: enp7s0.22
+    iface: tenant
     vlan: 22
     base_iface: enp7s0
     lb_addresses:


### PR DESCRIPTION
Reference the vanity name defined by the NNCP objects in the
L2Advertisement objects which makes the configuration more robust with
less interfaces to change.
