### PR TITLE
Update COO sub channel to stable

### DIFF
--- a/examples/dt/uni01alpha/control-plane.md
+++ b/examples/dt/uni01alpha/control-plane.md
@@ -22,7 +22,7 @@ metadata:
   labels:
     operators.coreos.com/observability-operator.openshift-operators: ""
 spec:
-  channel: development
+  channel: stable
   installPlanApproval: Automatic
   name: cluster-observability-operator
   source: redhat-operators

--- a/lib/olm-deps/coo_subscription.yaml
+++ b/lib/olm-deps/coo_subscription.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     operators.coreos.com/observability-operator.openshift-operators: ""
 spec:
-  channel: development
+  channel: stable
   installPlanApproval: Automatic
   name: cluster-observability-operator
   source: redhat-operators


### PR DESCRIPTION
COO released v 1.0.0 and the development channel disappeared. We need to switch to the stable channel.