### PR TITLE
[BGP_DT01] edpm_frr_bgp_uplinks removed from EDPM CRs

### DIFF
--- a/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
@@ -25,9 +25,6 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
-        edpm_frr_bgp_uplinks:
-          - nic3
-          - nic4
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
@@ -25,9 +25,6 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
-        edpm_frr_bgp_uplinks:
-          - nic3
-          - nic4
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
@@ -25,9 +25,6 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
-        edpm_frr_bgp_uplinks:
-          - nic3
-          - nic4
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
@@ -25,9 +25,6 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
-        edpm_frr_bgp_uplinks:
-          - nic3
-          - nic4
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
@@ -25,9 +25,6 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
-        edpm_frr_bgp_uplinks:
-          - nic3
-          - nic4
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
@@ -25,9 +25,6 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
-        edpm_frr_bgp_uplinks:
-          - nic3
-          - nic4
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests


### PR DESCRIPTION
Once [OSPRH-14173](https://issues.redhat.com//browse/OSPRH-14173) has been resolved with [1], edpm_frr_bgp_uplinks does not need to be configured when edpm_frr_bgp_peers is configured.

Due to that, edpm_frr_bgp_uplinks is removed from BGP_DT01 EDPM values.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/883