### PR TITLE
[BGP] Fix EDPM hostnames

### DIFF
--- a/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
@@ -32,12 +32,8 @@ data:
           dnf -y install conntrack-tools
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
-          edpm-compute-0:
+          edpm-r0-compute-0:
             nic2: 6a:fe:54:3f:8a:02  # CHANGEME
-          edpm-compute-1:
-            nic2: 6b:fe:54:3f:8a:02  # CHANGEME
-          edpm-compute-2:
-            nic2: 6c:fe:54:3f:8a:02  # CHANGEME
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}
@@ -122,8 +118,8 @@ data:
       - name: BgpMainNetV6
         subnetName: subnet2
     nodes:
-      edpm-compute-0:
-        hostName: edpm-compute-0
+      edpm-r0-compute-0:
+        hostName: edpm-r0-compute-0
         ansible:
           ansibleHost: 192.168.122.100
           ansibleVars:

--- a/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
@@ -32,12 +32,8 @@ data:
           dnf -y install conntrack-tools
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
-          edpm-compute-0:
+          edpm-r1-compute-0:
             nic2: 6a:fe:54:3f:8a:02  # CHANGEME
-          edpm-compute-1:
-            nic2: 6b:fe:54:3f:8a:02  # CHANGEME
-          edpm-compute-2:
-            nic2: 6c:fe:54:3f:8a:02  # CHANGEME
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}
@@ -122,10 +118,10 @@ data:
       - name: BgpMainNetV6
         subnetName: subnet2
     nodes:
-      edpm-compute-1:
-        hostName: edpm-compute-1
+      edpm-r1-compute-0:
+        hostName: edpm-r1-compute-0
         ansible:
-          ansibleHost: 192.168.122.101
+          ansibleHost: 192.168.123.100
           ansibleVars:
             edpm_ovn_bgp_agent_local_ovn_peer_ips:
               - 100.64.1.1
@@ -135,7 +131,7 @@ data:
               - 100.65.1.1
         networks:
           - defaultRoute: true
-            fixedIP: 192.168.122.101
+            fixedIP: 192.168.123.100
             name: CtlPlane
             subnetName: subnet1
           - name: InternalApi

--- a/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
@@ -32,12 +32,8 @@ data:
           dnf -y install conntrack-tools
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
-          edpm-compute-0:
+          edpm-r2-compute-0:
             nic2: 6a:fe:54:3f:8a:02  # CHANGEME
-          edpm-compute-1:
-            nic2: 6b:fe:54:3f:8a:02  # CHANGEME
-          edpm-compute-2:
-            nic2: 6c:fe:54:3f:8a:02  # CHANGEME
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}
@@ -122,10 +118,10 @@ data:
       - name: BgpMainNetV6
         subnetName: subnet2
     nodes:
-      edpm-compute-2:
-        hostName: edpm-compute-2
+      edpm-r2-compute-0:
+        hostName: edpm-r2-compute-0
         ansible:
-          ansibleHost: 192.168.122.102
+          ansibleHost: 192.168.124.100
           ansibleVars:
             edpm_ovn_bgp_agent_local_ovn_peer_ips:
               - 100.64.2.1
@@ -135,7 +131,7 @@ data:
               - 100.65.2.1
         networks:
           - defaultRoute: true
-            fixedIP: 192.168.122.102
+            fixedIP: 192.168.124.100
             name: CtlPlane
             subnetName: subnet1
           - name: InternalApi

--- a/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
@@ -32,12 +32,8 @@ data:
           dnf -y install conntrack-tools
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
-          edpm-networker-0:
+          edpm-r0-networker-0:
             nic2: 6d:fe:54:3f:8a:02  # CHANGEME
-          edpm-networker-1:
-            nic2: 6e:fe:54:3f:8a:02  # CHANGEME
-          edpm-networker-2:
-            nic2: 6f:fe:54:3f:8a:02  # CHANGEME
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}
@@ -122,10 +118,10 @@ data:
       - name: BgpMainNetV6
         subnetName: subnet2
     nodes:
-      edpm-networker-0:
-        hostName: edpm-networker-0
+      edpm-r0-networker-0:
+        hostName: edpm-r0-networker-0
         ansible:
-          ansibleHost: 192.168.122.105
+          ansibleHost: 192.168.122.200
           ansibleVars:
             edpm_ovn_bgp_agent_local_ovn_peer_ips:
               - 100.64.0.5
@@ -135,7 +131,7 @@ data:
               - 100.65.0.5
         networks:
           - defaultRoute: true
-            fixedIP: 192.168.122.105
+            fixedIP: 192.168.122.200
             name: CtlPlane
             subnetName: subnet1
           - name: InternalApi

--- a/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
@@ -32,12 +32,8 @@ data:
           dnf -y install conntrack-tools
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
-          edpm-networker-0:
+          edpm-r1-networker-0:
             nic2: 6d:fe:54:3f:8a:02  # CHANGEME
-          edpm-networker-1:
-            nic2: 6e:fe:54:3f:8a:02  # CHANGEME
-          edpm-networker-2:
-            nic2: 6f:fe:54:3f:8a:02  # CHANGEME
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}
@@ -122,10 +118,10 @@ data:
       - name: BgpMainNetV6
         subnetName: subnet2
     nodes:
-      edpm-networker-1:
-        hostName: edpm-networker-1
+      edpm-r1-networker-0:
+        hostName: edpm-r1-networker-0
         ansible:
-          ansibleHost: 192.168.122.106
+          ansibleHost: 192.168.123.200
           ansibleVars:
             edpm_ovn_bgp_agent_local_ovn_peer_ips:
               - 100.64.1.5
@@ -135,7 +131,7 @@ data:
               - 100.65.1.5
         networks:
           - defaultRoute: true
-            fixedIP: 192.168.122.106
+            fixedIP: 192.168.123.200
             name: CtlPlane
             subnetName: subnet1
           - name: InternalApi

--- a/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
@@ -32,12 +32,8 @@ data:
           dnf -y install conntrack-tools
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
-          edpm-networker-0:
+          edpm-r2-networker-0:
             nic2: 6d:fe:54:3f:8a:02  # CHANGEME
-          edpm-networker-1:
-            nic2: 6e:fe:54:3f:8a:02  # CHANGEME
-          edpm-networker-2:
-            nic2: 6f:fe:54:3f:8a:02  # CHANGEME
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}
@@ -122,10 +118,10 @@ data:
       - name: BgpMainNetV6
         subnetName: subnet2
     nodes:
-      edpm-networker-2:
-        hostName: edpm-networker-2
+      edpm-r2-networker-0:
+        hostName: edpm-r2-networker-0
         ansible:
-          ansibleHost: 192.168.122.107
+          ansibleHost: 192.168.124.200
           ansibleVars:
             edpm_ovn_bgp_agent_local_ovn_peer_ips:
               - 100.64.2.5
@@ -135,7 +131,7 @@ data:
               - 100.65.2.5
         networks:
           - defaultRoute: true
-            fixedIP: 192.168.122.107
+            fixedIP: 192.168.124.200
             name: CtlPlane
             subnetName: subnet1
           - name: InternalApi


### PR DESCRIPTION
The ansibleVars values were not properly obtained by ci-fmw due to the wrong EDPM hostnames used.
The right hostnames after [OSPRH-13820](https://issues.redhat.com//browse/OSPRH-13820) changes are:
- edpm-r0-compute-0 (compute connected to rack0)
- edpm-r1-compute-0 (compute connected to rack1)
- edpm-r0-networker-0 (networker connected to rack0)
...

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2762