### PR TITLE
Increase timeout in uni01alpha

### DIFF
--- a/automation/vars/uni01alpha.yaml
+++ b/automation/vars/uni01alpha.yaml
@@ -91,7 +91,7 @@ vas:
             oc -n openstack wait openstackdataplanedeployment
             edpm-deployment
             --for condition=Ready
-            --timeout=40m
+            --timeout=60m
         values:
           - name: edpm-deployment-values
             src_file: values.yaml


### PR DESCRIPTION
My local deployments on smaller machines seem to fail with FIPS enabled scenario only due to a few minutes margin – hence I propose increasing the timeout on deployment.