### PR TITLE
fix broken link in nfv ovs-dpdk doc

### DIFF
--- a/examples/va/nfv/ovs-dpdk/dataplane.md
+++ b/examples/va/nfv/ovs-dpdk/dataplane.md
@@ -14,7 +14,7 @@ Change to the nfv/ovs-dpdk/edpm directory
 ```
 cd architecture/examples/va/nfv/ovs-dpdk/edpm
 ```
-Edit the [nodeset/values.yaml](nodeset/values.yaml) and [deployment/values.yaml](deployment/values.yaml) files to suit 
+Edit the [nodeset/values.yaml](edpm/nodeset/values.yaml) and [deployment/values.yaml](edpm/deployment/values.yaml) files to suit
 your environment.
 ```
 vi nodeset/values.yaml


### PR DESCRIPTION
the values.yaml file links are broken in the dataplane.md
this PR fixes it to the correct link.