### PR TITLE
[BGP] Remove L2Advertisements

### DIFF
--- a/examples/dt/bgp_dt01/control-plane/kustomization.yaml
+++ b/examples/dt/bgp_dt01/control-plane/kustomization.yaml
@@ -56,6 +56,14 @@ patches:
       kind: NetworkAttachmentDefinition
       labelSelector: "osp/net-attach-def-type=bgp"
     path: ocp_network_template.yaml
+  # All L2Advertisements are removed
+  - target:
+      kind: L2Advertisement
+    patch: |-
+      kind: L2Advertisement
+      metadata:
+        name: .*
+      $patch: delete
 
 replacements:
   # BGP peer IP addresses


### PR DESCRIPTION
L2Advertisements are not needed when BGP is used at controlplane level.