### PR TITLE
external netwrok list missing for networker ovs dpdk

### DIFF
--- a/examples/va/nfv/ovs-dpdk-networker/networker/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-networker/networker/nodeset/values.yaml
@@ -195,6 +195,8 @@ data:
         subnetName: subnet1
       - name: tenant
         subnetName: subnet1
+      - name: external
+        subnetName: subnet1
     nodes:
       networker-0:
         hostName: networker-0


### PR DESCRIPTION
This change is to add external network list item in the networker ovs dpdk nodeset CR.