### PR TITLE
[BGP] Deploy frr after configure-os

### DIFF
--- a/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
@@ -158,9 +158,9 @@ data:
       - bootstrap
       - configure-network
       - validate-network
-      - frr
       - install-os
       - configure-os
+      - frr
       - run-os
       - reboot-os
       - install-certs

--- a/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
@@ -158,9 +158,9 @@ data:
       - bootstrap
       - configure-network
       - validate-network
-      - frr
       - install-os
       - configure-os
+      - frr
       - run-os
       - reboot-os
       - install-certs

--- a/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
@@ -158,9 +158,9 @@ data:
       - bootstrap
       - configure-network
       - validate-network
-      - frr
       - install-os
       - configure-os
+      - frr
       - run-os
       - reboot-os
       - install-certs

--- a/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
@@ -158,9 +158,9 @@ data:
       - bootstrap
       - configure-network
       - validate-network
-      - frr
       - install-os
       - configure-os
+      - frr
       - ssh-known-hosts
       - run-os
       - reboot-os

--- a/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
@@ -158,9 +158,9 @@ data:
       - bootstrap
       - configure-network
       - validate-network
-      - frr
       - install-os
       - configure-os
+      - frr
       - ssh-known-hosts
       - run-os
       - reboot-os

--- a/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
@@ -158,9 +158,9 @@ data:
       - bootstrap
       - configure-network
       - validate-network
-      - frr
       - install-os
       - configure-os
+      - frr
       - ssh-known-hosts
       - run-os
       - reboot-os


### PR DESCRIPTION
After https://github.com/openstack-k8s-operators/edpm-ansible/pull/897, due to the nft rules applied during the installation of frr on the EDPM nodes, ssh traffic is blocked.
That is resolved by the configure-os service, which adds nft rules to allow ssh traffic again.
Hence, the configure-os service has to be deployed before the frr service to avoid blocking ssh.