### PR TITLE
Add bgp-l3-xl dt

### DIFF
--- a/automation/mocks/bgp-l3-xl.yaml
+++ b/automation/mocks/bgp-l3-xl.yaml
@@ -1,0 +1,1440 @@
+---
+cifmw_networking_env_definition:
+  instances:
+    r0-compute-0:
+      hostname: r0-compute-0
+      name: r0-compute-0
+      networks:
+        ctlplaner0:
+          interface_name: eth1
+          ip_v4: 192.168.122.100
+          mac_addr: 52:54:00:6a:4a:25
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.100
+          mac_addr: 52:54:00:14:8c:e5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.100
+          mac_addr: 52:54:00:0d:c3:a1
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.100
+          mac_addr: '52:54:00:16:41:11'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r0-compute-1:
+      hostname: r0-compute-1
+      name: r0-compute-1
+      networks:
+        ctlplaner0:
+          interface_name: eth1
+          ip_v4: 192.168.122.101
+          mac_addr: 52:54:00:6a:4a:26
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.101
+          mac_addr: 52:54:00:14:8c:e6
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.101
+          mac_addr: 52:54:00:0d:c3:a2
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.101
+          mac_addr: '52:54:00:16:41:12'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r1-compute-0:
+      hostname: r1-compute-0
+      name: r1-compute-0
+      networks:
+        ctlplaner1:
+          interface_name: eth1
+          ip_v4: 192.168.123.101
+          mac_addr: 52:54:00:9b:e6:98
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.101
+          mac_addr: 52:54:00:38:f8:36
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.101
+          mac_addr: 52:54:00:4d:c4:0b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.101
+          mac_addr: 52:54:00:14:06:e3
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r1-compute-1:
+      hostname: r1-compute-1
+      name: r1-compute-1
+      networks:
+        ctlplaner1:
+          interface_name: eth1
+          ip_v4: 192.168.123.102
+          mac_addr: 52:54:00:9b:e6:98
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.102
+          mac_addr: 52:54:00:38:f8:36
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.102
+          mac_addr: 52:54:00:4d:c4:0b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.102
+          mac_addr: 52:54:00:14:06:e3
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r2-compute-0:
+      hostname: r2-compute-0
+      name: r2-compute-0
+      networks:
+        ctlplaner2:
+          interface_name: eth1
+          ip_v4: 192.168.124.103
+          mac_addr: 52:54:00:98:a6:ae
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.103
+          mac_addr: 52:54:00:6a:da:29
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.103
+          mac_addr: 52:54:00:03:0a:e8
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.103
+          mac_addr: 52:54:00:78:92:ee
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r2-compute-1:
+      hostname: r2-compute-1
+      name: r2-compute-1
+      networks:
+        ctlplaner2:
+          interface_name: eth1
+          ip_v4: 192.168.124.104
+          mac_addr: 52:54:00:98:a6:ae
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.104
+          mac_addr: 52:54:00:6a:da:29
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.104
+          mac_addr: 52:54:00:03:0a:e8
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.104
+          mac_addr: 52:54:00:78:92:ee
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    controller-0:
+      hostname: controller-0
+      name: controller-0
+      networks:
+        ctlplane:
+          interface_name: eth1
+          ip_v4: 192.168.122.9
+          mac_addr: 52:54:00:b2:7c:cb
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+    r0-networker-0:
+      hostname: r0-networker-0
+      name: r0-networker-0
+      networks:
+        ctlplaner0:
+          interface_name: eth1
+          ip_v4: 192.168.122.106
+          mac_addr: 52:54:00:15:d3:88
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.106
+          mac_addr: 52:54:00:10:fd:f9
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.106
+          mac_addr: '52:54:00:42:16:57'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r1-networker-0:
+      hostname: r1-networker-0
+      name: r1-networker-0
+      networks:
+        ctlplaner1:
+          interface_name: eth1
+          ip_v4: 192.168.122.107
+          mac_addr: 52:54:00:de:46:aa
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.107
+          mac_addr: 52:54:00:3c:46:9b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.107
+          mac_addr: 52:54:00:6c:66:38
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r2-networker-0:
+      hostname: r2-networker-0
+      name: r2-networker-0
+      networks:
+        ctlplaner2:
+          interface_name: eth1
+          ip_v4: 192.168.122.108
+          mac_addr: 52:54:00:3f:b8:15
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.108
+          mac_addr: 52:54:00:7c:e7:5f
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.108
+          mac_addr: 52:54:00:12:ef:f8
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-0:
+      hostname: master-0
+      name: ocp-0
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.10
+          mac_addr: 52:54:00:a6:a2:28
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.10
+          mac_addr: 52:54:00:4d:b7:40
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.10
+          mac_addr: 52:54:00:01:fb:71
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.10
+          mac_addr: 52:54:00:1d:70:f5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.10
+          mac_addr: 52:54:00:19:a0:48
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-1:
+      hostname: master-1
+      name: ocp-1
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.11
+          mac_addr: 52:54:00:5d:5c:75
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.11
+          mac_addr: 52:54:00:43:51:94
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.11
+          mac_addr: 52:54:00:4c:f6:5b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.11
+          mac_addr: 52:54:00:4e:3f:30
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.11
+          mac_addr: '52:54:00:52:32:54'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-2:
+      hostname: master-2
+      name: ocp-2
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.12
+          mac_addr: 52:54:00:51:83:2d
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.12
+          mac_addr: 52:54:00:5c:31:ac
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.12
+          mac_addr: 52:54:00:64:39:96
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.12
+          mac_addr: 52:54:00:2e:71:ce
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.12
+          mac_addr: 52:54:00:2f:c7:35
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-0:
+      hostname: worker-0
+      name: ocp_worker-0
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.13
+          mac_addr: 52:54:00:89:69:43
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.13
+          mac_addr: 52:54:00:35:4f:c2
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.13
+          mac_addr: 52:54:00:13:5a:96
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.13
+          mac_addr: '52:54:00:36:09:28'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.13
+          mac_addr: 52:54:00:5c:09:09
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-1:
+      hostname: worker-1
+      name: ocp_worker-1
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.14
+          mac_addr: 52:54:00:4b:f9:06
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.14
+          mac_addr: 52:54:00:4d:35:b4
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.14
+          mac_addr: 52:54:00:06:6b:f0
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.14
+          mac_addr: 52:54:00:2c:69:fe
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.14
+          mac_addr: 52:54:00:47:50:3b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-2:
+      hostname: worker-2
+      name: ocp_worker-2
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.15
+          mac_addr: 52:54:00:a3:32:7a
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.15
+          mac_addr: 52:54:00:2a:55:0f
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.15
+          mac_addr: 52:54:00:13:4e:27
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.15
+          mac_addr: 52:54:00:12:6e:dc
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.15
+          mac_addr: 52:54:00:18:2f:ac
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-3:
+      hostname: worker-3
+      name: ocp_worker-3
+      networks:
+        ctlplane:
+          interface_name: enp7s0
+          ip_v4: 192.168.122.16
+          mac_addr: 52:54:00:67:1b:c5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp7s0.20
+          ip_v4: 172.17.0.16
+          mac_addr: 52:54:00:65:17:db
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp7s0.23
+          ip_v4: 172.23.0.16
+          mac_addr: 52:54:00:2f:28:7e
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp7s0.21
+          ip_v4: 172.18.0.16
+          mac_addr: 52:54:00:46:68:6b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp7s0.22
+          ip_v4: 172.19.0.16
+          mac_addr: 52:54:00:31:3b:02
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-4:
+      hostname: worker-4
+      name: ocp_worker-4
+      networks:
+        ctlplane:
+          interface_name: enp7s0
+          ip_v4: 192.168.122.17
+          mac_addr: 52:54:00:67:1b:c5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp7s0.20
+          ip_v4: 172.17.0.17
+          mac_addr: 52:54:00:65:17:db
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp7s0.23
+          ip_v4: 172.23.0.17
+          mac_addr: 52:54:00:2f:28:7e
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp7s0.21
+          ip_v4: 172.18.0.17
+          mac_addr: 52:54:00:46:68:6b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp7s0.22
+          ip_v4: 172.19.0.17
+          mac_addr: 52:54:00:31:3b:02
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-5:
+      hostname: worker-5
+      name: ocp_worker-5
+      networks:
+        ctlplane:
+          interface_name: enp7s0
+          ip_v4: 192.168.122.18
+          mac_addr: 52:54:00:67:1b:c5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp7s0.20
+          ip_v4: 172.17.0.18
+          mac_addr: 52:54:00:65:17:db
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp7s0.23
+          ip_v4: 172.23.0.18
+          mac_addr: 52:54:00:2f:28:7e
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp7s0.21
+          ip_v4: 172.18.0.18
+          mac_addr: 52:54:00:46:68:6b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp7s0.22
+          ip_v4: 172.19.0.18
+          mac_addr: 52:54:00:31:3b:02
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-6:
+      hostname: worker-6
+      name: ocp_worker-6
+      networks:
+        ctlplane:
+          interface_name: enp7s0
+          ip_v4: 192.168.122.19
+          mac_addr: 52:54:00:67:1b:c5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp7s0.20
+          ip_v4: 172.17.0.19
+          mac_addr: 52:54:00:65:17:db
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp7s0.23
+          ip_v4: 172.23.0.19
+          mac_addr: 52:54:00:2f:28:7e
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp7s0.21
+          ip_v4: 172.18.0.19
+          mac_addr: 52:54:00:46:68:6b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp7s0.22
+          ip_v4: 172.19.0.19
+          mac_addr: 52:54:00:31:3b:02
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-7:
+      hostname: worker-7
+      name: ocp_worker-7
+      networks:
+        ctlplane:
+          interface_name: enp7s0
+          ip_v4: 192.168.122.20
+          mac_addr: 52:54:00:67:1b:c5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp7s0.20
+          ip_v4: 172.17.0.20
+          mac_addr: 52:54:00:65:17:db
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp7s0.23
+          ip_v4: 172.23.0.20
+          mac_addr: 52:54:00:2f:28:7e
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp7s0.21
+          ip_v4: 172.18.0.20
+          mac_addr: 52:54:00:46:68:6b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp7s0.22
+          ip_v4: 172.19.0.20
+          mac_addr: 52:54:00:31:3b:02
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-8:
+      hostname: worker-8
+      name: ocp_worker-8
+      networks:
+        ctlplane:
+          interface_name: enp7s0
+          ip_v4: 192.168.122.21
+          mac_addr: 52:54:00:67:1b:c5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp7s0.20
+          ip_v4: 172.17.0.21
+          mac_addr: 52:54:00:65:17:db
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp7s0.23
+          ip_v4: 172.23.0.21
+          mac_addr: 52:54:00:2f:28:7e
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp7s0.21
+          ip_v4: 172.18.0.21
+          mac_addr: 52:54:00:46:68:6b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp7s0.22
+          ip_v4: 172.19.0.21
+          mac_addr: 52:54:00:31:3b:02
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp_worker-9:
+      hostname: worker-9
+      name: ocp_worker-9
+      networks:
+        ctlplane:
+          interface_name: enp7s0
+          ip_v4: 192.168.122.22
+          mac_addr: 52:54:00:67:1b:c5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp7s0.20
+          ip_v4: 172.17.0.22
+          mac_addr: 52:54:00:65:17:db
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp7s0.23
+          ip_v4: 172.23.0.22
+          mac_addr: 52:54:00:2f:28:7e
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp7s0.21
+          ip_v4: 172.18.0.22
+          mac_addr: 52:54:00:46:68:6b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp7s0.22
+          ip_v4: 172.19.0.22
+          mac_addr: 52:54:00:31:3b:02
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+  networks:
+    ctlplane:
+      dns_v4:
+        - 192.168.122.1
+      dns_v6: []
+      gw_v4: 192.168.122.1
+      mtu: 1500
+      network_name: ctlplane
+      network_v4: 192.168.122.0/24
+      search_domain: ctlplane.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.122.90
+              end_host: 90
+              length: 11
+              start: 192.168.122.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.122.70
+              end_host: 70
+              length: 41
+              start: 192.168.122.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.122.120
+              end_host: 120
+              length: 21
+              start: 192.168.122.100
+              start_host: 100
+            - end: 192.168.122.200
+              end_host: 200
+              length: 51
+              start: 192.168.122.150
+              start_host: 150
+          ipv6_ranges: []
+    ctlplaner0:
+      dns_v4:
+        - 192.168.122.1
+      dns_v6: []
+      gw_v4: 192.168.122.1
+      mtu: 1500
+      network_name: ctlplaner0
+      network_v4: 192.168.122.0/24
+      search_domain: ctlplaner0.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.122.90
+              end_host: 90
+              length: 11
+              start: 192.168.122.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.122.70
+              end_host: 70
+              length: 41
+              start: 192.168.122.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.122.120
+              end_host: 120
+              length: 21
+              start: 192.168.122.100
+              start_host: 100
+            - end: 192.168.122.200
+              end_host: 200
+              length: 51
+              start: 192.168.122.150
+              start_host: 150
+          ipv6_ranges: []
+    ctlplaner1:
+      dns_v4:
+        - 192.168.123.1
+      dns_v6: []
+      gw_v4: 192.168.123.1
+      mtu: 1500
+      network_name: ctlplaner1
+      network_v4: 192.168.123.0/24
+      search_domain: ctlplaner1.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.123.90
+              end_host: 90
+              length: 11
+              start: 192.168.123.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.123.70
+              end_host: 70
+              length: 41
+              start: 192.168.123.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.123.120
+              end_host: 120
+              length: 21
+              start: 192.168.123.100
+              start_host: 100
+            - end: 192.168.123.200
+              end_host: 200
+              length: 51
+              start: 192.168.123.150
+              start_host: 150
+          ipv6_ranges: []
+    ctlplaner2:
+      dns_v4:
+        - 192.168.124.1
+      dns_v6: []
+      gw_v4: 192.168.124.1
+      mtu: 1500
+      network_name: ctlplaner2
+      network_v4: 192.168.124.0/24
+      search_domain: ctlplaner2.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.124.90
+              end_host: 90
+              length: 11
+              start: 192.168.124.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.124.70
+              end_host: 70
+              length: 41
+              start: 192.168.124.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.124.120
+              end_host: 120
+              length: 21
+              start: 192.168.124.100
+              start_host: 100
+            - end: 192.168.124.200
+              end_host: 200
+              length: 51
+              start: 192.168.124.150
+              start_host: 150
+          ipv6_ranges: []
+    external:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: external
+      network_v4: 192.168.32.0/20
+      search_domain: external.example.com
+      tools:
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.32.250
+              end_host: 250
+              length: 121
+              start: 192.168.32.130
+              start_host: 130
+          ipv6_ranges: []
+      vlan_id: 99
+    internalapi:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: internalapi
+      network_v4: 172.17.0.0/24
+      search_domain: internalapi.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 172.17.0.90
+              end_host: 90
+              length: 11
+              start: 172.17.0.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 172.17.0.70
+              end_host: 70
+              length: 41
+              start: 172.17.0.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 172.17.0.250
+              end_host: 250
+              length: 151
+              start: 172.17.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 20
+    octavia:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: octavia
+      network_v4: 172.23.0.0/24
+      search_domain: octavia.example.com
+      tools:
+        multus:
+          ipv4_ranges:
+            - end: 172.23.0.70
+              end_host: 70
+              length: 41
+              start: 172.23.0.30
+              start_host: 30
+          ipv6_ranges: []
+          ipv4_routes:
+            - destination: "172.24.0.0/16"
+              gateway: "172.23.0.150"
+        netconfig:
+          ipv4_ranges:
+            - end: 172.23.0.250
+              end_host: 250
+              length: 151
+              start: 172.23.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 23
+    storage:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: storage
+      network_v4: 172.18.0.0/24
+      search_domain: storage.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 172.18.0.90
+              end_host: 90
+              length: 11
+              start: 172.18.0.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 172.18.0.70
+              end_host: 70
+              length: 41
+              start: 172.18.0.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 172.18.0.250
+              end_host: 250
+              length: 151
+              start: 172.18.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 21
+    tenant:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: tenant
+      network_v4: 172.19.0.0/24
+      search_domain: tenant.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 172.19.0.90
+              end_host: 90
+              length: 11
+              start: 172.19.0.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 172.19.0.70
+              end_host: 70
+              length: 41
+              start: 172.19.0.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 172.19.0.250
+              end_host: 250
+              length: 151
+              start: 172.19.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 22
+  routers: {}

--- a/automation/vars/bgp-l3-xl.yaml
+++ b/automation/vars/bgp-l3-xl.yaml
@@ -1,0 +1,197 @@
+---
+vas:
+  bgp-l3-xl:
+    stages:
+      - pre_stage_run:
+          - name: Apply taint on worker-9
+            type: cr
+            definition:
+              spec:
+                taints:
+                  - effect: NoSchedule
+                    key: testOperator
+                    value: 'true'
+                  - effect: NoExecute
+                    key: testOperator
+                    value: 'true'
+            kind: Node
+            resource_name: worker-9
+            state: patched
+          - name: Disable rp_filters on OCP nodes
+            type: cr
+            definition:
+              spec:
+                profile:
+                  - data: |
+                      [main]
+                      summary=Optimize systems running OpenShift (provider specific parent profile)
+                      include=-provider-${f:exec:cat:/var/lib/ocp-tuned/provider},openshift
+
+                      [sysctl]
+                      net.ipv4.conf.enp7s0.rp_filter=0
+                      net.ipv4.conf.enp8s0.rp_filter=0
+                    name: openshift-no-reapply-sysctl
+                recommend:
+                  - match:
+                      # applied to all nodes except worker-9, because worker-9 has no enp8s0
+                      - label: kubernetes.io/hostname
+                        value: worker-0
+                      - label: kubernetes.io/hostname
+                        value: worker-1
+                      - label: kubernetes.io/hostname
+                        value: worker-2
+                      - label: kubernetes.io/hostname
+                        value: worker-3
+                      - label: kubernetes.io/hostname
+                        value: worker-4
+                      - label: kubernetes.io/hostname
+                        value: worker-5
+                      - label: kubernetes.io/hostname
+                        value: worker-6
+                      - label: kubernetes.io/hostname
+                        value: worker-7
+                      - label: kubernetes.io/hostname
+                        value: worker-8
+                      - label: node-role.kubernetes.io/master
+                    operand:
+                      tunedConfig:
+                        reapply_sysctl: false
+                    priority: 15
+                    profile: openshift-no-reapply-sysctl
+            api_version: tuned.openshift.io/v1
+            kind: Tuned
+            resource_name: openshift-no-reapply-sysctl
+            namespace: openshift-cluster-node-tuning-operator
+            state: present
+        path: examples/dt/bgp-l3-xl/control-plane/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=300s
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - path: examples/dt/bgp-l3-xl/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackcontrolplane
+            controlplane
+            --for condition=Ready
+            --timeout=30m
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+        post_stage_run:
+          - name: Create BGPConfiguration after controlplane is deployed
+            type: cr
+            definition:
+              spec: {}
+            api_version: network.openstack.org/v1beta1
+            kind: BGPConfiguration
+            resource_name: bgpconfiguration
+            namespace: openstack
+            state: present
+
+      -  # stage_2
+        path: examples/dt/bgp-l3-xl/edpm/computes/r0
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r0-compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r0-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r0-compute-nodeset.yaml
+
+      -  # stage_3
+        path: examples/dt/bgp-l3-xl/edpm/computes/r1
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r1-compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r1-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r1-compute-nodeset.yaml
+
+      -  # stage_4
+        path: examples/dt/bgp-l3-xl/edpm/computes/r2
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r2-compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r2-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r2-compute-nodeset.yaml
+
+      -  # stage_5
+        path: examples/dt/bgp-l3-xl/edpm/networkers/r0
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r0-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r0-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r0-networker-nodeset.yaml
+
+      -  # stage_6
+        path: examples/dt/bgp-l3-xl/edpm/networkers/r1
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r1-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r1-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r1-networker-nodeset.yaml
+
+      -  # stage_7
+        path: examples/dt/bgp-l3-xl/edpm/networkers/r2
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r2-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r2-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r2-networker-nodeset.yaml
+
+      -  # stage_8
+        path: examples/dt/bgp-l3-xl/edpm/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanedeployment
+            edpm-deployment
+            --for condition=Ready
+            --timeout=120m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: edpm-deployment.yaml
+        post_stage_run:
+          - name: Wait until computes are ready
+            type: playbook
+            source: "../../playbooks/bgp-l3-computes-ready.yml"
+            extra_vars:
+              num_computes: 6

--- a/dt/bgp/kustomization.yaml
+++ b/dt/bgp/kustomization.yaml
@@ -307,18 +307,6 @@ replacements:
 
   - source:
       kind: ConfigMap
-      name: service-values
-      fieldPath: data.ovn.ovnController.nicMappings
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.ovn.template.ovnController.nicMappings
-        options:
-          create: true
-
-  - source:
-      kind: ConfigMap
       name: network-values
       fieldPath: data.octavia.net-attach-def
     targets:

--- a/examples/dt/bgp-l3-xl/README.md
+++ b/examples/dt/bgp-l3-xl/README.md
@@ -1,0 +1,117 @@
+# RHOSO Deployed Topology - BGP-L3-XL DT - Kernel routing and OVN NB DB driver
+
+This document describes a scaled out BGP Deployed Topology (DT), used to test the
+BGP Dynamic Routing functionality on Red Hat OpenStack Services on OpenShift
+(RHOSO).
+
+The CRs included within this DT should be applied on an environment where EDPM
+and OCP nodes are connected through a spine/leaf network. The BGP protocol
+should be enabled on those spine and leaf routers.
+
+## Purpose
+
+This BGP DT (l3-xl) tests default BGP configuration:
+* Kernel routing (instead of OVN routing)
+* OVN NB DB driver (instead of OVN SB DB driver)
+
+The OCP cluster consists on the following nodes:
+* 3 OCP master nodes
+* 9 OCP worker nodes
+* 1 OCP worker node with special configuration (OCP tester node)
+
+This DT creates an OCP cluster that includes both master and worker nodes,
+instead of the usual master/worker combo nodes. The reason for this is to run
+disruptive tests only on the OCP workers, which host the Openstack Control
+Plane services, avoiding potential issues when OCP master nodes are disrupted
+that would not be relevant when testing RHOSO high availability scenarios.
+
+The extra OCP worker (OCP tester) is needed to run tests from it because:
+* disruptive tests can be run from this worker on the other workers without
+  affecting the test exection
+* this worker is connected to the spine/leaf routers with a special routing
+  configuration, so that it can reach the Openstack provider network
+The OCP tester is configured so that only test pods (created by the
+Openstack test-operator) run on it.
+
+This DT configures both compute and networker EDPM nodes. So far, networker
+nodes are needed when BGP is used on RHOSO, in order to expose routes to SNAT
+traffic (OVN Gateway IPs). In other words, when RHOSO is used with BGP, the OCP
+workers cannot be configured as OVN Gateways.
+
+The OCP and EDPM nodes deployed with this DT are distributed into three
+different racks. Each rack is connected to two leaves.
+Hence, the distribution of the nodes in the racks is the following one:
+* rack0: r0-compute-0, r0-compute-1, r0-networker-0, ocp-master-0, ocp-worker-0, leaf-0, leaf-1
+* rack1: r1-compute-0, r1-compute-1, r1-networker-0, ocp-master-1, ocp-worker-1, leaf-2, leaf-3
+* rack2: r2-compute-0, r2-compute-1, r2-networker-0, ocp-master-2, ocp-worker-2, leaf-4, leaf-5
+
+The OCP tester (ocp-worker-3) is not included into any rack. It is not
+connected to any leaves, but to a router connected to the spines, due to the
+reasons described before (it needs special connectivity to reach the provider
+network).
+
+## Node topology
+| Node role               | bm/vm | amount |
+| ----------------------- | ----- | ------ |
+| Openshift master nodes  | vm    | 3      |
+| Openshift worker nodes  | vm    | 10     |
+| Openstack Computes      | vm    | 6      |
+| Openstack Networker     | vm    | 3      |
+| Leaf routers            | vm    | 6      |
+| Spine routers           | vm    | 2      |
+| External routers        | vm    | 1      |
+| Ansible Controller      | vm    | 1      |
+
+### Networks
+
+| Name                     | Type     | CIDR             |
+| ------------------------ | -------- | ---------------- |
+| Controlplane rack0       | untagged | 192.168.122.0/24 |
+| Controlplane rack1       | untagged | 192.168.123.0/24 |
+| Controlplane rack2       | untagged | 192.168.124.0/24 |
+| Provider network         | untagged | 192.168.133.0/24 |
+| RH OSP                   | untagged | 192.168.111.0/24 |
+| edpm/ocp to left leaves  | untagged | 100.64.x.y/30    |
+| edpm/ocp to right leaves | untagged | 100.65.x.y/30    |
+
+## Services, enabled features and configurations
+
+| Service          | configuration    | Lock-in coverage?  |
+| ---------------- | ---------------- | ------------------ |
+| Glance           | Swift            | Must have          |
+| Swift            | (default)        | Must have          |
+| Octavia          | (default)        | Must have          |
+| Heat             | (default)        | Must have          |
+| frr              | dataplane        | Must have          |
+| ovn-bgp-agent    | dataplane        | Must have          |
+
+## Considerations/Constraints
+
+1. Virtual networks should be created to connect the nodes to the routers.
+2. All the VMs that are neither Openstack nor Openshift nodes, i.e. those that
+   act as routers, need to be properly configured in order to support the BGP
+   protocol.
+3. The spine/leaf topology separates the nodes into different L2
+   network segments, called racks. Each rack includes two leaves, some OCP
+   nodes and some EDPM nodes.
+4. The Openstack services running on the EDPM nodes are installed using the BGP
+   network, i.e. the Openstack services running on OCP nodes connect to the
+   Openstack services running on EDPM nodes using BGP. There is no direct L2
+   network connectivity between them. OCP version 4.18 or higher is required
+   because the Openstack Operators use the frr-k8s feature for this and frr-k8s
+   is not available in OCP 4.16.
+5. Once Openstack is installed on them, both dataplane and controlplane
+   connections are achieved using the BGP protocol.
+6. Tests are executed from the OCP worker to verify external connectivity.
+
+## Stages
+
+All stages must be executed in the order listed below. Everything is required unless otherwise indicated.
+
+1. [Configure taints on the OCP worker](configure-taints.md)
+2. [Disable RP filters on OCP nodes](disable-rp-filters.md)
+3. [Install the OpenStack K8S operators and their dependencies](../../common/)
+4. [Apply metallb customization required to run a speaker pod on the OCP tester node](metallb/)
+5. [Configuring networking and deploy the OpenStack control plane](control-plane.md)
+6. [Create BGPConfiguration after controplane is deployed](bgp-configuration.md)
+7. [Configure and deploy the dataplane - networker and compute nodes](data-plane.md)

--- a/examples/dt/bgp-l3-xl/bgp-configuration.md
+++ b/examples/dt/bgp-l3-xl/bgp-configuration.md
@@ -1,0 +1,16 @@
+# Create BGPConfiguration after controplane is deployed
+
+An empty BGPConfiguration Openshift resource needs to be created.
+The infra-operator will detect this resource is created and will automatically
+apply the required Openshift BGP configuration.
+OCP 4.18 release is necessary for this.
+
+The following CR needs to be applied:
+```
+apiVersion: network.openstack.org/v1beta1
+kind: BGPConfiguration
+metadata:
+  name: bgpconfiguration
+  namespace: openstack
+spec: {}
+```

--- a/examples/dt/bgp-l3-xl/configure-taints.md
+++ b/examples/dt/bgp-l3-xl/configure-taints.md
@@ -1,0 +1,21 @@
+# Apply taints on OCP tester node
+
+This OCP worker node should not run any Openstack service apart from those
+created by the test-operator.
+It should also run a metallb's speaker pod, in order to obtain the proper
+network configuration.
+Due to this, taints should be configured on this worker.
+
+Execute the following command:
+```
+oc patch node/worker-9 --type merge --patch '
+  spec:
+    taints:
+      - effect: NoSchedule
+        key: testOperator
+        value: "true"
+      - effect: NoExecute
+        key: testOperator
+        value: "true"
+'
+```

--- a/examples/dt/bgp-l3-xl/control-plane.md
+++ b/examples/dt/bgp-l3-xl/control-plane.md
@@ -1,0 +1,57 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `local-storage` should already exist.
+- An infrastructure of spine/leaf routers exists, is properly connected to the
+  OCP nodes and the routers are configured to support BGP.
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the bgp-l3-xl/control-plane directory
+```
+cd architecture/examples/dt/bgp-l3-xl/control-plane
+```
+Edit the [nncp/values.yaml](control-plane/nncp/values.yaml) and
+[service-values.yaml](control-plane/service-values.yaml) files to suit
+your environment.
+```
+vi nncp/values.yaml
+vi service-values.yaml
+```
+
+## Apply node network configuration
+
+Generate the node network configuration
+```
+kustomize build nncp > nncp.yaml
+```
+Apply the NNCP CRs
+```
+oc apply -f nncp.yaml
+```
+Wait for NNCPs to be available
+```
+oc wait nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=300s
+```
+
+## Apply networking and control-plane configuration
+
+Generate the control-plane and networking CRs.
+```
+kustomize build > control-plane.yaml
+```
+Apply the CRs
+```
+oc apply -f control-plane.yaml
+```
+
+Wait for control plane to be available
+```
+oc wait osctlplane controlplane --for condition=Ready --timeout=600s
+```
+

--- a/examples/dt/bgp-l3-xl/control-plane/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/kustomization.yaml
@@ -1,0 +1,342 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/bgp/
+
+resources:
+  - nncp/values.yaml
+  - service-values.yaml
+  - metallb_bgppeers.yaml
+  - ocp_networks_netattach.yaml
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+patches:
+  # Add BGPPeer to BGPAdvertisement
+  - target:
+      kind: BGPAdvertisement
+    patch: |-
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-3-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-3-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-4-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-4-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-5-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-5-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-6-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-6-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-7-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-7-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-8-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-8-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-9-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-9-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-10-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-10-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-11-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-11-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-12-0
+  - target:
+      kind: NetworkAttachmentDefinition
+      labelSelector: "osp/net-attach-def-type=bgp"
+    path: ocp_network_template.yaml
+
+  # All L2Advertisements are removed
+  - target:
+      kind: L2Advertisement
+    patch: |-
+      kind: L2Advertisement
+      metadata:
+        name: .*
+      $patch: delete
+
+replacements:
+  # BGP peer IP addresses
+  # node3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-3-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-3-1
+        fieldPaths:
+          - spec.peerAddress
+  # node4
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-4-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-4-1
+        fieldPaths:
+          - spec.peerAddress
+  # node5
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-5-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-5-1
+        fieldPaths:
+          - spec.peerAddress
+  # node6
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-6-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-6-1
+        fieldPaths:
+          - spec.peerAddress
+  # node7
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-7-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-7-1
+        fieldPaths:
+          - spec.peerAddress
+  # node8
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-8-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-8-1
+        fieldPaths:
+          - spec.peerAddress
+  # node9
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-9-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-9-1
+        fieldPaths:
+          - spec.peerAddress
+  # node10
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-10-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-10-1
+        fieldPaths:
+          - spec.peerAddress
+  # node11
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-11-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-11-1
+        fieldPaths:
+          - spec.peerAddress
+  # node12
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-12-0
+        fieldPaths:
+          - spec.peerAddress
+
+  # BGP NetworkAttachmentDefinition customization
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node12
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-worker-9
+        fieldPaths:
+          - spec.config
+  # disable OCP workers as gateway nodes
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.ovn.ovnController.external-ids
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ovn.template.ovnController.external-ids
+        options:
+          create: true
+  # configure neutron customServiceConfig
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.neutron.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.neutron.template.customServiceConfig
+        options:
+          create: true

--- a/examples/dt/bgp-l3-xl/control-plane/metallb_bgppeers.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/metallb_bgppeers.yaml
@@ -1,0 +1,304 @@
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-3-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-0"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-3-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-0"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-4-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-1"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-4-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-1"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-5-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-2"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-5-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-2"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-6-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-3"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-6-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-3"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-7-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-4"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-7-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-4"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-8-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-5"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-8-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-5"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-9-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-6"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-9-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-6"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-10-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-7"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-10-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-7"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-11-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-8"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-11-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-8"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-12-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-9"]  # worker-9 has only one bgp-peer

--- a/examples/dt/bgp-l3-xl/control-plane/nncp/.gitignore
+++ b/examples/dt/bgp-l3-xl/control-plane/nncp/.gitignore
@@ -1,0 +1,1 @@
+nncp.yaml

--- a/examples/dt/bgp-l3-xl/control-plane/nncp/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/nncp/kustomization.yaml
@@ -1,0 +1,1378 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../../lib/nncp-l3
+
+resources:
+  - values.yaml
+  - ocp_worker_nodes_nncp.yaml
+
+patches:
+  # Add BGP and octavia interfaces
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 1
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "master-.*"
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "node-[3-9]"
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "node-10"
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "node-11"
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: loopback interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          name: _replaced_
+          mtu: 65536
+          state: up
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia vlan host interface
+          name: octavia
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia bridge
+          mtu: 1500
+          name: octbr
+          type: linux-bridge
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+              - name: octavia
+  # Fix roles on masters
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "master-.*"
+    patch: |-
+      - op: add
+        path: /spec/nodeSelector/node-role.kubernetes.io~1master
+        value: ""
+      - op: remove
+        path: /spec/nodeSelector/node-role.kubernetes.io~1worker
+
+replacements:
+  # Node names (workers)
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-4
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-5
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-6
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-7
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-8
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-9
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-10
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-11
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-12
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+
+  # BGP master-0/node-0 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP master-1/node-1 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP master-2/node-2 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-0/node-3 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-1/node-4 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-2/node-5 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-3/node-6 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-4/node-7 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-5/node-8 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-6/node-9 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-7/node_10 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-8/node_11 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.ip
+  # BGP worker-9/node-12 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+
+
+  # BGP values
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.ifaces.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.ifaces.1
+    targets:  # target all nodes except worker-9 (regexs do not seem to work on select.name value)
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.iface
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.7.name
+      - select:  # in case of worker-9, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.prefix-length
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:  # in case of worker-9, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.prefix-length
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:  # in case of worker-9, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.prefix-length-ipv6
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv6.address.0.prefix-length
+      - select:  # in case of worker-9, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+  # Octavia
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.base_iface
+    targets:  # octavia interfaces are needed on the workers, except worker-3
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.vlan
+    targets:  # octavia interfaces are needed on the workers, except worker-3
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.id
+
+  # Overwrite worker-9 base routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.routes
+
+
+  # ROUTES
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.routes

--- a/examples/dt/bgp-l3-xl/control-plane/nncp/ocp_worker_nodes_nncp.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/nncp/ocp_worker_nodes_nncp.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-3
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-4
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-5
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-6
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-7
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-8
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-9
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-10
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-11
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-12
+  labels:
+    osp/nncm-config-type: standard

--- a/examples/dt/bgp-l3-xl/control-plane/nncp/values.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/nncp/values.yaml
@@ -1,0 +1,883 @@
+---
+# local-config: referenced, but not emitted by kustomize
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # nodes
+  node_0:
+    name: master-0
+    internalapi_ip: 172.17.0.5
+    tenant_ip: 172.19.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+    bgp_ip:
+      - 100.64.0.14
+      - 100.65.0.14
+    bgp_peers:
+      - 100.64.0.13
+      - 100.65.0.13
+    loopback_ip: 99.99.0.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:13
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.13
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.13
+          next-hop-interface: enp9s0
+  node_1:
+    name: master-1
+    internalapi_ip: 172.17.0.6
+    tenant_ip: 172.19.0.6
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.6
+    bgp_ip:
+      - 100.64.1.14
+      - 100.65.1.14
+    bgp_peers:
+      - 100.64.1.13
+      - 100.65.1.13
+    loopback_ip: 99.99.1.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:23
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.13
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.13
+          next-hop-interface: enp9s0
+  node_2:
+    name: master-2
+    internalapi_ip: 172.17.0.7
+    tenant_ip: 172.19.0.7
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.7
+    bgp_ip:
+      - 100.64.2.14
+      - 100.65.2.14
+    bgp_peers:
+      - 100.64.2.13
+      - 100.65.2.13
+    loopback_ip: 99.99.2.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:33
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.13
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.13
+          next-hop-interface: enp9s0
+  node_3:
+    name: worker-0
+    internalapi_ip: 172.17.0.8
+    tenant_ip: 172.19.0.8
+    ctlplane_ip: 192.168.122.13
+    storage_ip: 172.18.0.8
+    bgp_ip:
+      - 100.64.0.18
+      - 100.65.0.18
+    bgp_peers:
+      - 100.64.0.17
+      - 100.65.0.17
+    loopback_ip: 99.99.0.4
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:14
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.17
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.17
+          next-hop-interface: enp9s0
+  node_4:
+    name: worker-1
+    internalapi_ip: 172.17.0.9
+    tenant_ip: 172.19.0.9
+    ctlplane_ip: 192.168.122.14
+    storage_ip: 172.18.0.9
+    bgp_ip:
+      - 100.64.0.22
+      - 100.65.0.22
+    bgp_peers:
+      - 100.64.0.21
+      - 100.65.0.21
+    loopback_ip: 99.99.0.5
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:24
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.21
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.21
+          next-hop-interface: enp9s0
+  node_5:
+    name: worker-2
+    internalapi_ip: 172.17.0.10
+    tenant_ip: 172.19.0.10
+    ctlplane_ip: 192.168.122.15
+    storage_ip: 172.18.0.10
+    bgp_ip:
+      - 100.64.0.26
+      - 100.65.0.26
+    bgp_peers:
+      - 100.64.0.25
+      - 100.65.0.25
+    loopback_ip: 99.99.0.6
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.25
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.25
+          next-hop-interface: enp9s0
+  node_6:
+    name: worker-3
+    internalapi_ip: 172.17.0.11
+    tenant_ip: 172.19.0.11
+    ctlplane_ip: 192.168.122.16
+    storage_ip: 172.18.0.11
+    bgp_ip:
+      - 100.64.1.18
+      - 100.65.1.18
+    bgp_peers:
+      - 100.64.1.17
+      - 100.65.1.17
+    loopback_ip: 99.99.1.4
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.17
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.17
+          next-hop-interface: enp9s0
+
+  node_7:
+    name: worker-4
+    internalapi_ip: 172.17.0.12
+    tenant_ip: 172.19.0.12
+    ctlplane_ip: 192.168.122.17
+    storage_ip: 172.18.0.12
+    bgp_ip:
+      - 100.64.1.22
+      - 100.65.1.22
+    bgp_peers:
+      - 100.64.1.21
+      - 100.65.1.21
+    loopback_ip: 99.99.1.5
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.21
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.21
+          next-hop-interface: enp9s0
+  node_8:
+    name: worker-5
+    internalapi_ip: 172.17.0.13
+    tenant_ip: 172.19.0.13
+    ctlplane_ip: 192.168.122.18
+    storage_ip: 172.18.0.13
+    bgp_ip:
+      - 100.64.1.26
+      - 100.65.1.26
+    bgp_peers:
+      - 100.64.1.25
+      - 100.65.1.25
+    loopback_ip: 99.99.1.6
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.25
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.25
+          next-hop-interface: enp9s0
+  node_9:
+    name: worker-6
+    internalapi_ip: 172.17.0.14
+    tenant_ip: 172.19.0.14
+    ctlplane_ip: 192.168.122.19
+    storage_ip: 172.18.0.14
+    bgp_ip:
+      - 100.64.2.18
+      - 100.65.2.18
+    bgp_peers:
+      - 100.64.2.17
+      - 100.65.2.17
+    loopback_ip: 99.99.2.4
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.17
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.17
+          next-hop-interface: enp9s0
+  node_10:
+    name: worker-7
+    internalapi_ip: 172.17.0.15
+    tenant_ip: 172.19.0.15
+    ctlplane_ip: 192.168.122.20
+    storage_ip: 172.18.0.15
+    bgp_ip:
+      - 100.64.2.22
+      - 100.65.2.22
+    bgp_peers:
+      - 100.64.2.21
+      - 100.65.2.21
+    loopback_ip: 99.99.2.5
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.21
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.21
+          next-hop-interface: enp9s0
+  node_11:
+    name: worker-8
+    internalapi_ip: 172.17.0.16
+    tenant_ip: 172.19.0.16
+    ctlplane_ip: 192.168.122.21
+    storage_ip: 172.18.0.16
+    bgp_ip:
+      - 100.64.2.26
+      - 100.65.2.26
+    bgp_peers:
+      - 100.64.2.25
+      - 100.65.2.25
+    loopback_ip: 99.99.2.6
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.25
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.25
+          next-hop-interface: enp9s0
+  # test worker
+  node_12:
+    name: worker-9
+    internalapi_ip: 172.17.0.17
+    tenant_ip: 172.19.0.17
+    ctlplane_ip: 192.168.122.22
+    storage_ip: 172.18.0.17
+    bgp_ip:
+      - 100.64.10.2
+    bgp_peers:
+      - 100.64.10.1
+    loopback_ip: 99.99.10.2
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:43
+    base_if: enp7s0
+    routes:
+      config:
+        - destination: 192.168.133.0/24
+          next-hop-address: 100.64.10.1
+          next-hop-interface: enp8s0
+
+  # networks
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet0
+        routes:
+          - destination: 192.168.123.0/24
+            nexthop: 192.168.122.1
+          - destination: 192.168.124.0/24
+            nexthop: 192.168.122.1
+      - allocationRanges:
+          - end: 192.168.123.120
+            start: 192.168.123.100
+          - end: 192.168.123.170
+            start: 192.168.123.150
+        cidr: 192.168.123.0/24
+        gateway: 192.168.123.1
+        name: subnet1
+        routes:
+          - destination: 192.168.122.0/24
+            nexthop: 192.168.123.1
+          - destination: 192.168.124.0/24
+            nexthop: 192.168.123.1ØØ
+      - allocationRanges:
+          - end: 192.168.124.120
+            start: 192.168.124.100
+          - end: 192.168.124.170
+            start: 192.168.124.150
+        cidr: 192.168.124.0/24
+        gateway: 192.168.124.1
+        name: subnet2
+        routes:
+          - destination: 192.168.122.0/24
+            nexthop: 192.168.124.1
+          - destination: 192.168.123.0/24
+            nexthop: 192.168.124.1
+    prefix-length: 24
+    iface: enp7s0
+    mtu: 1500
+    lb_addresses:
+      - 192.168.125.80-192.168.125.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.125.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "bridge",
+        "bridge": "ctlplane",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.125.0/24",
+          "range_start": "192.168.125.30",
+          "range_end": "192.168.125.70"
+        }
+      }
+
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "bridge",
+        "bridge": "internalapi",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 1500
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "bridge",
+        "bridge": "storage",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+  tenant:
+    dnsDomain: tenant.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        name: subnet1
+        vlan: 22
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "bridge",
+        "bridge": "tenant",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70"
+        }
+      }
+  octavia:
+    dnsDomain: octavia.openstack.lab
+    mtu: 1500
+    vlan: 23
+    base_iface: enp7s0
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "octavia",
+        "type": "bridge",
+        "bridge": "octbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.23.0.0/24",
+          "range_start": "172.23.0.30",
+          "range_end": "172.23.0.70",
+          "routes": [
+            {
+              "dst": "172.24.0.0/16",
+              "gw": "172.23.0.150"
+            }
+          ]
+        }
+      }
+  external:
+    dnsDomain: external.example.com
+    subnets:
+      - allocationRanges:
+          - end: 10.0.0.250
+            start: 10.0.0.100
+        cidr: 10.0.0.0/24
+        gateway: 10.0.0.1
+        name: subnet1
+    mtu: 1500
+
+  bgp:
+    prefix-length: 30
+    ifaces:
+      - enp8s0
+      - enp9s0
+    asn: 64999
+    peer_asn: 64999
+    subnets:
+      bgpnet0:
+        - name: subnet0
+          allocationRanges:
+            - end: 100.64.0.36
+              start: 100.64.0.1
+          cidr: 100.64.0.0/24
+          gateway: 100.64.0.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.0.1
+        - name: subnet1
+          allocationRanges:
+            - end: 100.64.1.36
+              start: 100.64.1.1
+          cidr: 100.64.1.0/24
+          gateway: 100.64.1.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.1.1
+        - name: subnet2
+          allocationRanges:
+            - end: 100.64.2.36
+              start: 100.64.2.1
+          cidr: 100.64.2.0/24
+          gateway: 100.64.2.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.2.1
+      bgpnet1:
+        - name: subnet0
+          allocationRanges:
+            - end: 100.65.0.36
+              start: 100.65.0.1
+          cidr: 100.65.0.0/24
+          gateway: 100.65.0.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.0.1
+        - name: subnet1
+          allocationRanges:
+            - end: 100.65.1.36
+              start: 100.65.1.1
+          cidr: 100.65.1.0/24
+          gateway: 100.65.1.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.1.1
+        - name: subnet2
+          allocationRanges:
+            - end: 100.65.2.36
+              start: 100.65.2.1
+          cidr: 100.65.2.0/24
+          gateway: 100.65.2.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.2.1
+      bgpmainnet:
+        - name: subnet0
+          cidr: 99.99.0.0/24
+          allocationRanges:
+            - end: 99.99.0.14
+              start: 99.99.0.2
+        - name: subnet1
+          cidr: 99.99.1.0/24
+          allocationRanges:
+            - end: 99.99.1.14
+              start: 99.99.1.2
+        - name: subnet2
+          cidr: 99.99.2.0/24
+          allocationRanges:
+            - end: 99.99.2.14
+              start: 99.99.2.2
+        - name: subnet10
+          cidr: 99.99.10.0/24
+          allocationRanges:
+            - end: 99.99.10.14
+              start: 99.99.10.2
+      bgpmainnetv6:
+        - name: subnet0
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0010/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:001e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
+        - name: subnet1
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0020/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:002e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0022
+        - name: subnet2
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0030/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:003e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0032
+        - name: subnet3
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0040/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:004e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0042
+    bgpdefs:
+      node0:
+        bgpnet0:
+          bgp_peer: 100.64.0.13
+          bgp_ip: 100.64.0.14
+        bgpnet1:
+          bgp_peer: 100.65.0.13
+          bgp_ip: 100.65.0.14
+        loopback_ip: 99.99.0.3
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:13
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.13
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.13
+              next-hop-interface: enp9s0
+      node1:
+        bgpnet0:
+          bgp_peer: 100.64.1.13
+          bgp_ip: 100.64.1.14
+        bgpnet1:
+          bgp_peer: 100.65.1.13
+          bgp_ip: 100.65.1.14
+        loopback_ip: 99.99.1.3
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:23
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.13
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.13
+              next-hop-interface: enp9s0
+      node2:
+        bgpnet0:
+          bgp_peer: 100.64.2.13
+          bgp_ip: 100.64.2.14
+        bgpnet1:
+          bgp_peer: 100.65.2.13
+          bgp_ip: 100.65.2.14
+        loopback_ip: 99.99.2.3
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:33
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.13
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.13
+              next-hop-interface: enp9s0
+      node3:
+        bgpnet0:
+          bgp_peer: 100.64.0.17
+          bgp_ip: 100.64.0.18
+        bgpnet1:
+          bgp_peer: 100.65.0.17
+          bgp_ip: 100.65.0.18
+        loopback_ip: 99.99.0.4
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:14
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.17
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.17
+              next-hop-interface: enp9s0
+      node4:
+        bgpnet0:
+          bgp_peer: 100.64.0.21
+          bgp_ip: 100.64.0.22
+        bgpnet1:
+          bgp_peer: 100.65.0.21
+          bgp_ip: 100.65.0.22
+        loopback_ip: 99.99.0.5
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:15
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.21
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.21
+              next-hop-interface: enp9s0
+      node5:
+        bgpnet0:
+          bgp_peer: 100.64.0.25
+          bgp_ip: 100.64.0.26
+        bgpnet1:
+          bgp_peer: 100.65.0.25
+          bgp_ip: 100.65.0.26
+        loopback_ip: 99.99.0.6
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:16
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.25
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.25
+              next-hop-interface: enp9s0
+      node6:
+        bgpnet0:
+          bgp_peer: 100.64.1.17
+          bgp_ip: 100.64.1.18
+        bgpnet1:
+          bgp_peer: 100.65.1.17
+          bgp_ip: 100.65.1.18
+        loopback_ip: 99.99.1.4
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:24
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.17
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.17
+              next-hop-interface: enp9s0
+      node7:
+        bgpnet0:
+          bgp_peer: 100.64.1.21
+          bgp_ip: 100.64.1.22
+        bgpnet1:
+          bgp_peer: 100.65.1.21
+          bgp_ip: 100.65.1.22
+        loopback_ip: 99.99.1.5
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:25
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.21
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.21
+              next-hop-interface: enp9s0
+      node8:
+        bgpnet0:
+          bgp_peer: 100.64.1.25
+          bgp_ip: 100.64.1.26
+        bgpnet1:
+          bgp_peer: 100.65.1.25
+          bgp_ip: 100.65.1.26
+        loopback_ip: 99.99.1.6
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:26
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.25
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.25
+              next-hop-interface: enp9s0
+      node9:
+        bgpnet0:
+          bgp_peer: 100.64.2.17
+          bgp_ip: 100.64.2.18
+        bgpnet1:
+          bgp_peer: 100.65.2.17
+          bgp_ip: 100.65.2.18
+        loopback_ip: 99.99.2.4
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.17
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.17
+              next-hop-interface: enp9s0
+      node10:
+        bgpnet0:
+          bgp_peer: 100.64.2.21
+          bgp_ip: 100.64.2.22
+        bgpnet1:
+          bgp_peer: 100.65.2.21
+          bgp_ip: 100.65.2.22
+        loopback_ip: 99.99.2.5
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:35
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.21
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.21
+              next-hop-interface: enp9s0
+      node11:
+        bgpnet0:
+          bgp_peer: 100.64.2.25
+          bgp_ip: 100.64.2.26
+        bgpnet1:
+          bgp_peer: 100.65.2.25
+          bgp_ip: 100.65.2.26
+        loopback_ip: 99.99.2.6
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:36
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.25
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.25
+              next-hop-interface: enp9s0
+      node12:
+        bgpnet0:
+          bgp_peer: 100.64.10.1
+          bgp_ip: 100.64.10.2
+        loopback_ip: 99.99.10.2
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:43
+        routes:
+          config:
+            - destination: 192.168.133.0/24
+              next-hop-address: 100.64.10.1
+              next-hop-interface: enp8s0
+    net-attach-def:
+      node12: |
+        {
+          "cniVersion": "0.3.1",
+          "name": "bgpnet-worker-9",
+          "type": "host-device",
+          "device": "enp8s0",
+          "ipam": {
+            "type": "whereabouts",
+            "range": "100.64.10.0/30",
+            "range_start": "100.64.10.2",
+            "range_end": "100.64.10.2",
+            "routes": [{
+              "dst": "192.168.133.0/24",
+              "gw": "100.64.10.1"
+            }]
+          }
+        }
+
+  loopback:
+    prefix-length: 32
+    prefix-length-ipv6: 128
+    iface: lo
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config: []
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr

--- a/examples/dt/bgp-l3-xl/control-plane/ocp_network_template.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/ocp_network_template.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: nmstate.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: _ignored_
+spec:
+  config: |
+    _replaced_

--- a/examples/dt/bgp-l3-xl/control-plane/ocp_networks_netattach.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/ocp_networks_netattach.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgpnet-worker-9
+  labels:
+    osp/net: bgpnet-worker-9
+    osp/net-attach-def-type: bgp

--- a/examples/dt/bgp-l3-xl/control-plane/service-values.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/service-values.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  preserveJobs: false
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:swift
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+    default:
+      replicas: 1
+
+  swift:
+    enabled: true
+
+  octavia:
+    enabled: false
+    amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image
+    apacheContainerImage: registry.redhat.io/ubi9/httpd-24:latest
+    octaviaAPI:
+      networkAttachments:
+        - internalapi
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+    octaviaHousekeeping:
+      networkAttachments:
+        - octavia
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+    octaviaHealthManager:
+      networkAttachments:
+        - octavia
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+    octaviaWorker:
+      networkAttachments:
+        - octavia
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+
+  ovn:
+    ovnController:
+      external-ids:
+        enable-chassis-as-gateway: false
+  neutron:
+    customServiceConfig: |
+      [DEFAULT]
+      vlan_transparent = true
+      debug = true
+      [ovs]
+      igmp_snooping_enable = true

--- a/examples/dt/bgp-l3-xl/control-plane/tuned
+++ b/examples/dt/bgp-l3-xl/control-plane/tuned
@@ -1,0 +1,29 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: default
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Optimize systems running OpenShift (provider specific parent profile)
+      include=-provider-${f:exec:cat:/var/lib/ocp-tuned/provider},openshift
+
+      [sysctl]
+      net.ipv4.conf.enp8s0.rp_filter=0
+      net.ipv4.conf.enp9s0.rp_filter=0
+    name: openshift
+  recommend:
+  - match:
+    - label: node-role.kubernetes.io/master
+    - label: node-role.kubernetes.io/infra
+    operand:
+      tunedConfig: {}
+    priority: 30
+    profile: openshift-control-plane
+  - operand:
+      tunedConfig: {}
+    priority: 40
+    profile: openshift-node
+status: {}

--- a/examples/dt/bgp-l3-xl/data-plane.md
+++ b/examples/dt/bgp-l3-xl/data-plane.md
@@ -1,0 +1,92 @@
+# Configuring and deploying the dataplane - networker and compute nodes
+
+## Assumptions
+
+- The [control plane](control-plane.md) has been created and successfully deployed
+- An infrastructure of spine/leaf routers exists, is properly connected to the
+  pre-provisioned EDPM nodes and the routers are configured to support BGP.
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the bgp-l3-xl/ directory
+```
+cd architecture/examples/dt/bgp-l3-xl/
+```
+Edit the networker values.yaml files corresponding to each rack (r0, r1 and r2)
+to suit your environment:
+- [edpm/networkers/r0/values.yaml](edpm/networkers/r0/values.yaml)
+- [edpm/networkers/r1/values.yaml](edpm/networkers/r1/values.yaml)
+- [edpm/networkers/r2/values.yaml](edpm/networkers/r2/values.yaml)
+```
+vi values.yaml
+```
+Edit the compute values.yaml files corresponding to each rack (r0, r1 and r2)
+to suit your environment:
+- [edpm/computes/r0/values.yaml](edpm/computes/r0/values.yaml)
+- [edpm/computes/r1/values.yaml](edpm/computes/r1/values.yaml)
+- [edpm/computes/r2/values.yaml](edpm/computes/r2/values.yaml)
+```
+vi values.yaml
+```
+
+## Create Networker and Compute Nodeset CRs
+
+Generate the networkers dataplane nodeset CRs for each rack.
+```
+kustomize build edpm/networkers/r0 > edpm-r0-networker-nodeset.yaml
+kustomize build edpm/networkers/r1 > edpm-r1-networker-nodeset.yaml
+kustomize build edpm/networkers/r2 > edpm-r2-networker-nodeset.yaml
+```
+Generate the computes dataplane nodeset CRs for each rack.
+```
+kustomize build edpm/computes/r0 > edpm-r0-compute-nodeset.yaml
+kustomize build edpm/computes/r1 > edpm-r1-compute-nodeset.yaml
+kustomize build edpm/computes/r2 > edpm-r2-compute-nodeset.yaml
+```
+
+## Create EDPM  Deployment CR
+Generate the dataplane deployment CR.
+```
+kustomize build edpm/deployment > edpm-deployment.yaml
+```
+
+## Apply the Nodeset CRs
+
+Apply the Networker nodeset CRs
+```
+oc apply -f edpm/networkers/r0/edpm-r0-networker-nodeset.yaml
+oc apply -f edpm/networkers/r1/edpm-r1-networker-nodeset.yaml
+oc apply -f edpm/networkers/r2/edpm-r2-networker-nodeset.yaml
+```
+Wait for Networker dataplane nodesets setup to finish
+```
+oc wait osdpns r0-networker-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r1-networker-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r2-networker-nodes --for condition=SetupReady --timeout=600s
+```
+Apply the Compute nodeset CRs
+```
+oc apply -f edpm/computes/r0/edpm-r0-compute-nodeset.yaml
+oc apply -f edpm/computes/r1/edpm-r1-compute-nodeset.yaml
+oc apply -f edpm/computes/r2/edpm-r2-compute-nodeset.yaml
+```
+Wait for Compute dataplane nodesets setup to finish
+```
+oc wait osdpns r0-compute-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r1-compute-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r2-compute-nodes --for condition=SetupReady --timeout=600s
+```
+
+## Apply the deployment
+Start the deployment
+```
+oc apply -f edpm/deployment/edpm-deployment.yaml
+```
+Wait for dataplane deployment to finish
+```
+oc wait osdpd edpm-deployment --for condition=Ready --timeout=2400s
+```

--- a/examples/dt/bgp-l3-xl/disable-rp-filters.md
+++ b/examples/dt/bgp-l3-xl/disable-rp-filters.md
@@ -1,0 +1,39 @@
+# Disable RP filters on OCP workers
+
+Reverse path filters need to be disabled on OCP workers running Openstack services.
+This is needed to make OCP workers forward traffic properly based on the BGP
+advertisements received.
+
+The following CR needs to be applied:
+```
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-no-reapply-sysctl
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Optimize systems running OpenShift (provider specific parent profile)
+      include=-provider-${f:exec:cat:/var/lib/ocp-tuned/provider},openshift
+
+      [sysctl]
+      net.ipv4.conf.enp7s0.rp_filter=0
+      net.ipv4.conf.enp8s0.rp_filter=0
+    name: openshift-no-reapply-sysctl
+  recommend:
+  - match:
+    - label: kubernetes.io/hostname
+      value: worker-0
+    - label: kubernetes.io/hostname
+      value: worker-1
+    - label: kubernetes.io/hostname
+      value: worker-2
+    - label: node-role.kubernetes.io/master
+    operand:
+      tunedConfig:
+        reapply_sysctl: false
+    priority: 15
+    profile: openshift-no-reapply-sysctl
+```

--- a/examples/dt/bgp-l3-xl/edpm/computes/r0/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r0/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r0-compute-nodes

--- a/examples/dt/bgp-l3-xl/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r0/values.yaml
@@ -1,0 +1,212 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r0-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+          edpm-r0-compute-1:
+            nic2: 6b:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r0-compute-0:
+        hostName: edpm-r0-compute-0
+        ansible:
+          ansibleHost: 192.168.122.100
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.0.1
+              - 100.65.0.1
+            edpm_frr_bgp_peers:
+              - 100.64.0.1
+              - 100.65.0.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.0.2
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.0.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.0.2
+          - name: BgpmainnetV6
+            subnetName: subnet0
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
+      edpm-r0-compute-1:
+        hostName: edpm-r0-compute-1
+        ansible:
+          ansibleHost: 192.168.122.101
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.0.5
+              - 100.65.0.5
+            edpm_frr_bgp_peers:
+              - 100.64.0.5
+              - 100.65.0.5
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet0
+            fixedIP: 100.64.0.6
+          - name: Bgpnet1
+            subnetName: subnet0
+            fixedIP: 100.65.0.6
+          - name: Bgpmainnet
+            subnetName: subnet0
+            fixedIP: 99.99.0.3
+          - name: BgpmainnetV6
+            subnetName: subnet0
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0013
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - frr
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp-l3-xl/edpm/computes/r1/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r1/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r1-compute-nodes

--- a/examples/dt/bgp-l3-xl/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r1/values.yaml
@@ -1,0 +1,212 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r1-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+          edpm-compute-1:
+            nic2: 6b:fe:54:3f:8a:02
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r1-compute-0:
+        hostName: edpm-r1-compute-0
+        ansible:
+          ansibleHost: 192.168.123.100
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.1.1
+              - 100.65.1.1
+            edpm_frr_bgp_peers:
+              - 100.64.1.1
+              - 100.65.1.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.123.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.1.2
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.1.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.1.2
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
+      edpm-r1-compute-1:
+        ansible:
+          ansibleVars:
+            edpm_frr_bgp_peers:
+              - 100.64.1.5
+              - 100.65.1.5
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.1.5
+              - 100.65.1.5
+          host: 192.168.123.101
+        hostName: edpm-r1-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.123.101
+            name: ctlplane
+            subnetName: subnet2
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+          - fixedIP: 100.64.1.6
+            name: BgpNet0
+            subnetName: subnet1
+          - fixedIP: 100.65.1.6
+            name: BgpNet1
+            subnetName: subnet1
+          - fixedIP: 99.99.1.8
+            name: BgpMainNet
+            subnetName: subnet1
+          - fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0028
+            name: BgpMainNetV6
+            subnetName: subnet1
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - frr
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp-l3-xl/edpm/computes/r2/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r2/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r2-compute-nodes

--- a/examples/dt/bgp-l3-xl/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r2/values.yaml
@@ -1,0 +1,212 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r2-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+          edpm-r2-compute-1:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r2-compute-0:
+        hostName: edpm-r2-compute-0
+        ansible:
+          ansibleHost: 192.168.124.100
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.2.1
+              - 100.65.2.1
+            edpm_frr_bgp_peers:
+              - 100.64.2.1
+              - 100.65.2.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.124.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet2
+            fixedIP: 100.64.2.2
+          - name: Bgpnet1
+            subnetName: subnet2
+            fixedIP: 100.65.2.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.2.2
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033
+      edpm-r2-compute-1:
+        ansible:
+          ansibleVars:
+            edpm_frr_bgp_peers:
+              - 100.64.2.5
+              - 100.65.2.5
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.2.5
+              - 100.65.2.5
+          host: 192.168.124.101
+        hostName: edpm-r2-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.124.101
+            name: ctlplane
+            subnetName: subnet3
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+          - fixedIP: 100.64.2.6
+            name: BgpNet0
+            subnetName: subnet2
+          - fixedIP: 100.65.2.6
+            name: BgpNet1
+            subnetName: subnet2
+          - fixedIP: 99.99.2.8
+            name: BgpMainNet
+            subnetName: subnet2
+          - fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0038
+            name: BgpMainNetV6
+            subnetName: subnet2
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - frr
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp-l3-xl/edpm/deployment/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/deployment/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bgp/edpm/deployment
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/deployment/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.nodeSets
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.nodeSets

--- a/examples/dt/bgp-l3-xl/edpm/deployment/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/deployment/values.yaml
@@ -1,0 +1,16 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeSets:
+    - r0-networker-nodes
+    - r1-networker-nodes
+    - r2-networker-nodes
+    - r0-compute-nodes
+    - r1-compute-nodes
+    - r2-compute-nodes

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r0/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r0/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r0-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r0/values.yaml
@@ -1,0 +1,175 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r0-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r0-networker-0:
+        hostName: edpm-r0-networker-0
+        ansible:
+          ansibleHost: 192.168.122.200
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.0.9
+              - 100.65.0.9
+            edpm_frr_bgp_peers:
+              - 100.64.0.9
+              - 100.65.0.9
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.200
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet0
+            fixedIP: 100.64.0.10
+          - name: Bgpnet1
+            subnetName: subnet0
+            fixedIP: 100.65.0.10
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.0.4
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0014
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - frr
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r1/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r1/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r1-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r1/values.yaml
@@ -1,0 +1,175 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r1-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r1-networker-0:
+        hostName: edpm-r1-networker-0
+        ansible:
+          ansibleHost: 192.168.123.200
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.1.9
+              - 100.65.1.9
+            edpm_frr_bgp_peers:
+              - 100.64.1.9
+              - 100.65.1.9
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.123.200
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.1.10
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.1.10
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.1.4
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0024
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - frr
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r2/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r2/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r2-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r2/values.yaml
@@ -1,0 +1,175 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r2-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r2-networker-0:
+        hostName: edpm-r2-networker-0
+        ansible:
+          ansibleHost: 192.168.124.200
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.2.9
+              - 100.65.2.9
+            edpm_frr_bgp_peers:
+              - 100.64.2.9
+              - 100.65.2.9
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.124.200
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet2
+            fixedIP: 100.64.2.10
+          - name: Bgpnet1
+            subnetName: subnet2
+            fixedIP: 100.65.2.10
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.2.4
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0034
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - frr
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp-l3-xl/metallb/README.md
+++ b/examples/dt/bgp-l3-xl/metallb/README.md
@@ -1,0 +1,16 @@
+# MetalLB
+
+Observe CRs which will be generated.
+```
+kustomize build examples/dt/bgp/bgp_dt01/metallb/
+```
+
+Apply the metallb kustomization from this directory.
+```
+oc apply -k examples/dt/bgp/bgp_dt01/metallb/
+```
+
+Then, check that a speaker is running on the OCP tester node.
+```
+oc -n metallb-system wait pod -l component=speaker --field-selector=spec.host=worker-3 --for condition=Ready --timeout=300s
+```

--- a/examples/dt/bgp-l3-xl/metallb/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/metallb/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+components:
+  - ../../../../lib/metallb
+
+patches:
+  - target:
+      kind: MetalLB
+      name: metallb
+      namespace: metallb-system
+    patch: |-
+      - op: add
+        path: /spec/speakerTolerations
+        value:
+          - key: "testOperator"
+            value: "true"
+            effect: "NoSchedule"
+          - key: "testOperator"
+            value: "true"
+            effect: "NoExecute"

--- a/lib/nncp-l3/ocp_node_template.yaml
+++ b/lib/nncp-l3/ocp_node_template.yaml
@@ -34,15 +34,14 @@ spec:
         state: up
         type: linux-bridge
         mtu: 1500
-        ipv4:
-          enabled: false
       - description: ctlplane interface
         name: _replaced_
         state: up
         type: ethernet
         mtu: 1500
         ipv4:
-          enabled: false
+          enabled: true
+          dhcp: true
         ipv6:
           enabled: false
   nodeSelector:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,6 +2,7 @@
     github-check:
       jobs: &id001
       - noop
+      - rhoso-architecture-validate-bgp-l3-xl
       - rhoso-architecture-validate-bgp_dt01
       - rhoso-architecture-validate-bmo01
       - rhoso-architecture-validate-dcn

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -1,5 +1,22 @@
 - job:
     files:
+    - automation/mocks/bgp-l3-xl.yaml
+    - examples/dt/bgp-l3-xl/control-plane
+    - examples/dt/bgp-l3-xl/control-plane/nncp
+    - examples/dt/bgp-l3-xl/edpm/computes/r0
+    - examples/dt/bgp-l3-xl/edpm/computes/r1
+    - examples/dt/bgp-l3-xl/edpm/computes/r2
+    - examples/dt/bgp-l3-xl/edpm/deployment
+    - examples/dt/bgp-l3-xl/edpm/networkers/r0
+    - examples/dt/bgp-l3-xl/edpm/networkers/r1
+    - examples/dt/bgp-l3-xl/edpm/networkers/r2
+    - lib
+    name: rhoso-architecture-validate-bgp-l3-xl
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: bgp-l3-xl
+- job:
+    files:
     - automation/mocks/bgp_dt01.yaml
     - examples/dt/bgp_dt01/control-plane
     - examples/dt/bgp_dt01/control-plane/nncp


### PR DESCRIPTION
This commit adds a "bgp-l3-xl" dt where workers/computes/networkers are deployed across three racks over a virtualized spine/leaf fabric using bgp.

The overall footprint consists of 3 masters, 9 workers (3x rack), 6 computes (2x rack), 3 networkers (1x rack) plus 1 router, 2 spines and 6 leaf switches (2x rack).

~~~
$ virsh list
 Id     Name                   State
----------------------------------------
 1292   cifmw-controller-0     running
 1293   cifmw-r0-compute-0     running
 1294   cifmw-r0-compute-1     running
 1295   cifmw-r1-compute-0     running
 1296   cifmw-r1-compute-1     running
 1297   cifmw-r2-compute-0     running
 1298   cifmw-r2-compute-1     running
 1299   cifmw-r0-networker-0   running
 1300   cifmw-r1-networker-0   running
 1301   cifmw-r2-networker-0   running
 1302   cifmw-ocp-master-0     running
 1303   cifmw-ocp-master-1     running
 1304   cifmw-ocp-master-2     running
 1305   cifmw-ocp-worker-0     running
 1306   cifmw-ocp-worker-1     running
 1307   cifmw-ocp-worker-2     running
 1308   cifmw-ocp-worker-3     running
 1309   cifmw-ocp-worker-4     running
 1310   cifmw-ocp-worker-5     running
 1311   cifmw-ocp-worker-6     running
 1312   cifmw-ocp-worker-7     running
 1313   cifmw-ocp-worker-8     running
 1314   cifmw-ocp-worker-9     running
 1315   cifmw-router-0         running
 1316   cifmw-spine-0          running
 1317   cifmw-spine-1          running
 1318   cifmw-leaf-0           running
 1319   cifmw-leaf-1           running
 1320   cifmw-leaf-2           running
 1321   cifmw-leaf-3           running
 1322   cifmw-leaf-4           running
 1323   cifmw-leaf-5           running
~~~

depends-on: https://github.com/openstack-k8s-operators/ci-framework/pull/2864