### PR TITLE
Remove telemetry metricStorage for NFV

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
@@ -56,8 +56,6 @@ data:
     template:
       ceilometer:
         enabled: true
-      metricStorage:
-        enabled: true
   extraMounts:
     - name: v1
       region: r1

--- a/va/nfv/ovs-dpdk-sriov/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-sriov/kustomization.yaml
@@ -109,17 +109,6 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
-      fieldPath: data.telemetry.template.metricStorage
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.telemetry.template.metricStorage
-        options:
-          create: true
-  - source:
-      kind: ConfigMap
-      name: service-values
       fieldPath: data.extraMounts
     targets:
       - select:


### PR DESCRIPTION
This reverts changes introduced in [1].
[1] https://github.com/openstack-k8s-operators/architecture/pull/431