### PR TITLE
Add OpenStack OLM subscription configurations

### DIFF
--- a/examples/common/olm-subscriptions/README.md
+++ b/examples/common/olm-subscriptions/README.md
@@ -1,0 +1,13 @@
+# OLM subscription that are used for deploying specific versions.
+
+To deploy a specific version rather than the latest from OLM images
+containing multiple version definitions, it is necessary to explicitly
+set the `startingCSV` parameter.
+
+This kustomization setup accomplishes this for:
+- v1.0.3
+- v1.0.6: this version no longer includes the AnsibleEE operator
+- v1.0.7 and later: these versions only include the OpenStack operator
+
+Refer to the `ci_gen_kustomize_values` role README for configuration
+details.

--- a/examples/common/olm-subscriptions/kustomization.yaml
+++ b/examples/common/olm-subscriptions/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+components:
+  - ../../../lib/olm-deps
+  - ../../../lib/olm-openstack-subscriptions/overlays/default
+resources:
+  - values.yaml

--- a/examples/common/olm-subscriptions/values.yaml
+++ b/examples/common/olm-subscriptions/values.yaml
@@ -1,0 +1,17 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: olm-values
+    annotations:
+        config.kubernetes.io/local-config: 'true'
+data:
+    openstack-operator-channel: "alpha"
+    openstack-operator-image: "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
+    openstack-operator-display-name: "CI Test"
+    openstack-operator-installplanapproval: "Automatic"
+    openstack-operator-publisher: "Testing Team"
+    openstack-operator-catalog-source: "openstack-operator-index"
+    openstack-operator-subscription-namespace: "openstack-operators"
+    openstack-operator-version: "latest"

--- a/lib/olm-openstack-subscriptions/base/catalogsource.yaml
+++ b/lib/olm-openstack-subscriptions/base/catalogsource.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: openstack-operator-index
+  namespace: openshift-marketplace
+  labels:
+    category: openstack-catalog
+spec:
+  image: quay.io/openstack-k8s-operators/openstack-operator-index:latest
+  sourceType: grpc
+  displayName: CI Test
+  publisher: Test Team

--- a/lib/olm-openstack-subscriptions/base/kustomization.yaml
+++ b/lib/olm-openstack-subscriptions/base/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - catalogsource.yaml
+  - namespaces.yaml
+  - operatorgroup.yaml

--- a/lib/olm-openstack-subscriptions/base/namespaces.yaml
+++ b/lib/olm-openstack-subscriptions/base/namespaces.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openstack-operators
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openstack
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"

--- a/lib/olm-openstack-subscriptions/base/operatorgroup.yaml
+++ b/lib/olm-openstack-subscriptions/base/operatorgroup.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openstack
+  namespace: openstack-operators

--- a/lib/olm-openstack-subscriptions/overlays/default/kustomization.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/default/kustomization.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ../../base
+  - openstack-subscription.yaml
+
+replacements:
+  # CatalogSource
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-image
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - spec.image
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-publisher
+    targets:
+      - select:
+          kind: CatalagSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - spec.publisher
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-display-name
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - spec.displayName
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-catalog-source
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - metadata.name
+  # Subscriptions
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-channel
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.channel
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-installplanapproval
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.installPlanApproval
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-subscription-namespace
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - metadata.namespace
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-catalog-source
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.source
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-version
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.startingCSV

--- a/lib/olm-openstack-subscriptions/overlays/default/openstack-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/default/openstack-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openstack
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: openstack-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: openstack-operator.latest

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/barbican-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/barbican-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: barbican
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: barbican-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: barbican-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/cinder-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/cinder-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cinder
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: cinder-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: cinder-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/designate-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/designate-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: designate
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: designate-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: designate-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/glance-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/glance-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: glance
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: glance-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: glance-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/heat-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/heat-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: heat
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: heat-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: heat-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/horizon-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/horizon-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: horizon
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: horizon-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: horizon-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/infra-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/infra-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: infra
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: infra-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: infra-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/ironic-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/ironic-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ironic
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: ironic-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: ironic-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/keystone-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/keystone-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: keystone
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: keystone-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: keystone-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/kustomization.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/kustomization.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ../../base
+  - openstack-ansibleee-subscription.yaml
+  - barbican-subscription.yaml
+  - cinder-subscription.yaml
+  - designate-subscription.yaml
+  - glance-subscription.yaml
+  - heat-subscription.yaml
+  - horizon-subscription.yaml
+  - infra-subscription.yaml
+  - ironic-subscription.yaml
+  - keystone-subscription.yaml
+  - manila-subscription.yaml
+  - mariadb-subscription.yaml
+  - neutron-subscription.yaml
+  - nova-subscription.yaml
+  - octavia-subscription.yaml
+  - openstack-baremetal-subscription.yaml
+  - ovn-subscription.yaml
+  - placement-subscription.yaml
+  - rabbitmq-cluster-subscription.yaml
+  - swift-subscription.yaml
+  - telemetry-subscription.yaml
+  - openstack-subscription.yaml
+
+replacements:
+  # CatalogSource
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-image
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - spec.image
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-publisher
+    targets:
+      - select:
+          kind: CatalagSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - spec.publisher
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-display-name
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - spec.displayName
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-catalog-source
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - metadata.name
+  # Subscriptions
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-channel
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.channel
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-installplanapproval
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.installPlanApproval
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-subscription-namespace
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - metadata.namespace
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-catalog-source
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.source

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/manila-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/manila-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: manila
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: manila-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: manila-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/mariadb-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/mariadb-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: mariadb
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: mariadb-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: mariadb-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/neutron-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/neutron-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: neutron
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: neutron-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: neutron-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/nova-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/nova-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nova
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: nova-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: nova-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/octavia-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/octavia-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: octavia
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: octavia-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: octavia-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/openstack-ansibleee-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/openstack-ansibleee-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openstack-ansibleee
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: openstack-ansibleee-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: openstack-ansibleee-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/openstack-baremetal-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/openstack-baremetal-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openstack-baremetal
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: openstack-baremetal-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: openstack-baremetal-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/openstack-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/openstack-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openstack
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: openstack-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: openstack-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/ovn-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/ovn-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ovn
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: ovn-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: ovn-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/placement-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/placement-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: placement
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: placement-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: placement-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/rabbitmq-cluster-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/rabbitmq-cluster-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rabbitmq-cluster
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: rabbitmq-cluster-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: rabbitmq-cluster-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/swift-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/swift-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: swift
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: swift-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: swift-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/telemetry-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/telemetry-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: telemetry
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: telemetry-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: telemetry-operator.v1.0.3

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/barbican-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/barbican-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: barbican
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: barbican-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: barbican-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/cinder-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/cinder-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cinder
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: cinder-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: cinder-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/designate-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/designate-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: designate
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: designate-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: designate-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/glance-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/glance-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: glance
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: glance-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: glance-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/heat-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/heat-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: heat
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: heat-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: heat-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/horizon-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/horizon-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: horizon
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: horizon-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: horizon-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/infra-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/infra-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: infra
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: infra-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: infra-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/ironic-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/ironic-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ironic
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: ironic-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: ironic-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/keystone-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/keystone-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: keystone
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: keystone-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: keystone-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/kustomization.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/kustomization.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ../../base
+  - barbican-subscription.yaml
+  - cinder-subscription.yaml
+  - designate-subscription.yaml
+  - glance-subscription.yaml
+  - heat-subscription.yaml
+  - horizon-subscription.yaml
+  - infra-subscription.yaml
+  - ironic-subscription.yaml
+  - keystone-subscription.yaml
+  - manila-subscription.yaml
+  - mariadb-subscription.yaml
+  - neutron-subscription.yaml
+  - nova-subscription.yaml
+  - octavia-subscription.yaml
+  - openstack-baremetal-subscription.yaml
+  - ovn-subscription.yaml
+  - placement-subscription.yaml
+  - rabbitmq-cluster-subscription.yaml
+  - swift-subscription.yaml
+  - telemetry-subscription.yaml
+  - openstack-subscription.yaml
+
+replacements:
+  # CatalogSource
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-image
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - spec.image
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-publisher
+    targets:
+      - select:
+          kind: CatalagSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - spec.publisher
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-display-name
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - spec.displayName
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-catalog-source
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - metadata.name
+  # Subscriptions
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-channel
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.channel
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-installplanapproval
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.installPlanApproval
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-subscription-namespace
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - metadata.namespace
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-operator-catalog-source
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.source

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/manila-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/manila-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: manila
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: manila-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: manila-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/mariadb-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/mariadb-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: mariadb
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: mariadb-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: mariadb-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/neutron-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/neutron-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: neutron
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: neutron-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: neutron-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/nova-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/nova-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nova
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: nova-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: nova-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/octavia-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/octavia-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: octavia
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: octavia-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: octavia-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/openstack-baremetal-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/openstack-baremetal-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openstack-baremetal
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: openstack-baremetal-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: openstack-baremetal-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/openstack-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/openstack-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openstack
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: openstack-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: openstack-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/ovn-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/ovn-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ovn
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: ovn-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: ovn-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/placement-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/placement-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: placement
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: placement-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: placement-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/rabbitmq-cluster-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/rabbitmq-cluster-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rabbitmq-cluster
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: rabbitmq-cluster-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: rabbitmq-cluster-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/swift-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/swift-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: swift
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: swift-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: swift-operator.v1.0.6

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/telemetry-subscription.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/telemetry-subscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: telemetry
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: telemetry-operator
+  source: openstack-operator-index
+  sourceNamespace: openshift-marketplace
+  startingCSV: telemetry-operator.v1.0.6


### PR DESCRIPTION
Ability to install a specific version of the operator(s) when multiple
versions are available in the OLM catalog.

Added new kustomization files and YAML configurations for OpenStack
operator subscriptions using OLM. This includes catalog sources,
namespaces, and operator groups for openstack-operators, as well as
subscription definitions for the OpenStack components when the version
is below v1.0.7.

Kustomization facilitates version-specific configurations starting
with v1.0.3 and v1.0.6, incorporating modifications like the
elimination of the AnsibleEE operator in subsequent versions. From
version 1.0.7 onwards, only the OpenStack operator is retained.

For each overlay we define the same set of ConfigMap that reach a set
of relevant parameter in the subscriptions and catalog source
definitions.

An unexpected mechanism here is that we override the
`common/olm-subscriptions/kustomization.yaml` file from ci-framework
for version `v1.0.3` and `v1.0.6`.  This enables the dynamic selection
of the right overlay.  For version `v1.0.7` and beyond we used the
default overlay and we don't need to overwrite the `kustomization`
file.

The problems that we cannot solve with just parameters are:
- `v1.0.3` and `v1.0.6` have a different set of subscriptions to
include
- `startingCSV` parameter is "dynamic" as it's composed of the
`spec.name`.`version`, not just `version`. Thus we cannot encode in a
kustomize parameter without create our own transformer. As
transformwer are not deployed here, it would be too much work to
boostrap it.

All this disapear starting with `v1.0.7` where we have only one
subscription to set.

Resolves-Part-Of: [OSPRH-15056](https://issues.redhat.com//browse/OSPRH-15056)