### PR TITLE
Revert "Revert "[BGP] Disable BFD""

### DIFF
--- a/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests

--- a/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
@@ -25,6 +25,7 @@ data:
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # conntrack is necessary for some tobiko tests


### PR DESCRIPTION
Reverts openstack-k8s-operators/architecture#526

BFD needs to be disabled again on BGP jobs due to a new bug: [OSPRH-15728](https://issues.redhat.com//browse/OSPRH-15728)