### PR TITLE
[OSPRH-15434] Multi-namespace VA

### DIFF
--- a/automation/net-env/multi-namespace.yaml
+++ b/automation/net-env/multi-namespace.yaml
@@ -1,0 +1,1021 @@
+---
+instances:
+    compute-0:
+        name: compute-0
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.100
+                is_trunk_parent: true
+                mac_addr: 52:54:03:b1:78:6c
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane
+                prefix_length_v4: 24
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.100
+                is_trunk_parent: false
+                mac_addr: 52:54:00:1e:58:da
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 20
+            ocpbm:
+                interface_name: eth2
+                ip_v4: 192.168.111.100
+                mac_addr: 52:54:03:16:9c:42
+                netmask_v4: 255.255.255.0
+                network_name: ocpbm
+                prefix_length_v4: 24
+                skip_nm: false
+            storage:
+                interface_name: eth1.21
+                ip_v4: 172.18.0.100
+                is_trunk_parent: false
+                mac_addr: 52:54:00:7e:be:ad
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 21
+            tenant:
+                interface_name: eth1.22
+                ip_v4: 172.19.0.100
+                is_trunk_parent: false
+                mac_addr: 52:54:00:33:ee:37
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 22
+    compute-1:
+        name: compute-1
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.101
+                is_trunk_parent: true
+                mac_addr: 52:54:04:e1:d6:b1
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane
+                prefix_length_v4: 24
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.101
+                is_trunk_parent: false
+                mac_addr: 52:54:00:4f:50:5d
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 20
+            ocpbm:
+                interface_name: eth2
+                ip_v4: 192.168.111.101
+                mac_addr: 52:54:04:8a:2a:c3
+                netmask_v4: 255.255.255.0
+                network_name: ocpbm
+                prefix_length_v4: 24
+                skip_nm: false
+            storage:
+                interface_name: eth1.21
+                ip_v4: 172.18.0.101
+                is_trunk_parent: false
+                mac_addr: 52:54:00:0d:95:37
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 21
+            tenant:
+                interface_name: eth1.22
+                ip_v4: 172.19.0.101
+                is_trunk_parent: false
+                mac_addr: 52:54:00:64:f1:a9
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 22
+    compute-2:
+        name: compute-2
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.102
+                is_trunk_parent: true
+                mac_addr: 52:54:05:d8:c8:d8
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane
+                prefix_length_v4: 24
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.102
+                is_trunk_parent: false
+                mac_addr: 52:54:00:6f:f2:1f
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 20
+            ocpbm:
+                interface_name: eth2
+                ip_v4: 192.168.111.102
+                mac_addr: 52:54:05:f8:0a:66
+                netmask_v4: 255.255.255.0
+                network_name: ocpbm
+                prefix_length_v4: 24
+                skip_nm: false
+            storage:
+                interface_name: eth1.21
+                ip_v4: 172.18.0.102
+                is_trunk_parent: false
+                mac_addr: 52:54:00:7c:4d:ba
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 21
+            tenant:
+                interface_name: eth1.22
+                ip_v4: 172.19.0.102
+                is_trunk_parent: false
+                mac_addr: 52:54:00:54:3f:6d
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 22
+    compute2-0:
+        name: compute2-0
+        networks:
+            ocpbm:
+                interface_name: eth2
+                ip_v4: 192.168.111.30
+                mac_addr: 52:54:06:4e:52:3f
+                netmask_v4: 255.255.255.0
+                network_name: ocpbm
+                prefix_length_v4: 24
+                skip_nm: false
+            ctlplane2:
+                interface_name: eth1
+                ip_v4: 192.168.133.100
+                is_trunk_parent: true
+                mac_addr: 52:54:00:56:6a:54
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane2
+                prefix_length_v4: 24
+                skip_nm: false
+            internalapi2:
+                interface_name: eth1.30
+                ip_v4: 172.17.10.100
+                is_trunk_parent: false
+                mac_addr: 52:54:00:25:67:fa
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 30
+            storage2:
+                interface_name: eth1.31
+                ip_v4: 172.18.10.100
+                is_trunk_parent: false
+                mac_addr: 52:54:00:79:94:b4
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 31
+            tenant2:
+                interface_name: eth1.32
+                ip_v4: 172.19.10.100
+                is_trunk_parent: false
+                mac_addr: 52:54:00:4b:57:31
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 32
+    compute2-1:
+        name: compute2-1
+        networks:
+            ocpbm:
+                interface_name: eth2
+                ip_v4: 192.168.111.31
+                mac_addr: 52:54:07:19:6d:11
+                netmask_v4: 255.255.255.0
+                network_name: ocpbm
+                prefix_length_v4: 24
+                skip_nm: false
+            ctlplane2:
+                interface_name: eth1
+                ip_v4: 192.168.133.101
+                is_trunk_parent: true
+                mac_addr: 52:54:00:09:bd:ca
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane2
+                prefix_length_v4: 24
+                skip_nm: false
+            internalapi2:
+                interface_name: eth1.30
+                ip_v4: 172.17.10.101
+                is_trunk_parent: false
+                mac_addr: 52:54:00:0b:13:64
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 30
+            storage2:
+                interface_name: eth1.31
+                ip_v4: 172.18.10.101
+                is_trunk_parent: false
+                mac_addr: 52:54:00:78:15:95
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 31
+            tenant2:
+                interface_name: eth1.32
+                ip_v4: 172.19.10.101
+                is_trunk_parent: false
+                mac_addr: 52:54:00:5b:07:0d
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 32
+    compute2-2:
+        name: compute2-2
+        networks:
+            ocpbm:
+                interface_name: eth2
+                ip_v4: 192.168.111.32
+                mac_addr: 52:54:08:a5:5f:23
+                netmask_v4: 255.255.255.0
+                network_name: ocpbm
+                prefix_length_v4: 24
+                skip_nm: false
+            ctlplane2:
+                interface_name: eth1
+                ip_v4: 192.168.133.102
+                is_trunk_parent: true
+                mac_addr: 52:54:00:5b:5f:2d
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane2
+                prefix_length_v4: 24
+                skip_nm: false
+            internalapi2:
+                interface_name: eth1.30
+                ip_v4: 172.17.10.102
+                is_trunk_parent: false
+                mac_addr: 52:54:00:19:a3:b3
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 30
+            storage2:
+                interface_name: eth1.31
+                ip_v4: 172.18.10.102
+                is_trunk_parent: false
+                mac_addr: 52:54:00:52:c8:20
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 31
+            tenant2:
+                interface_name: eth1.32
+                ip_v4: 172.19.10.102
+                is_trunk_parent: false
+                mac_addr: 52:54:00:15:8d:c1
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 32
+    controller-0:
+        hostname: controller-0
+        name: controller-0
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.9
+                mac_addr: 52:54:09:5e:8b:66
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane
+                prefix_length_v4: 24
+                skip_nm: false
+            ctlplane2:
+                interface_name: eth2
+                ip_v4: 192.168.133.9
+                mac_addr: 52:54:00:3e:1f:74
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane2
+                prefix_length_v4: 24
+                skip_nm: false
+            ocpbm:
+                interface_name: eth3
+                ip_v4: 192.168.111.9
+                mac_addr: 52:54:09:d4:63:bb
+                netmask_v4: 255.255.255.0
+                network_name: ocpbm
+                prefix_length_v4: 24
+                skip_nm: false
+    ocp-master-0:
+        hostname: master-0
+        name: ocp-master-0
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.10
+                is_trunk_parent: true
+                mac_addr: 52:54:00:15:07:f4
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane
+                prefix_length_v4: 24
+                skip_nm: false
+            ctlplane2:
+                interface_name: enp7s0
+                ip_v4: 192.168.133.10
+                is_trunk_parent: true
+                mac_addr: 52:54:00:5d:24:0a
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane2
+                prefix_length_v4: 24
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.10
+                is_trunk_parent: false
+                mac_addr: 52:54:00:68:4b:ce
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 20
+            internalapi2:
+                interface_name: enp7s0.30
+                ip_v4: 172.17.10.10
+                is_trunk_parent: false
+                mac_addr: 52:54:00:15:f3:26
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 30
+            ocpbm:
+                interface_name: enp2s0
+                ip_v4: 192.168.111.10
+                mac_addr: 52:54:00:df:8c:54
+                netmask_v4: 255.255.255.0
+                network_name: ocpbm
+                prefix_length_v4: 24
+                skip_nm: false
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.10
+                is_trunk_parent: false
+                mac_addr: 52:54:00:05:23:2c
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 21
+            storage2:
+                interface_name: enp7s0.31
+                ip_v4: 172.18.10.10
+                is_trunk_parent: false
+                mac_addr: 52:54:00:75:5d:4f
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 31
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.10
+                is_trunk_parent: false
+                mac_addr: 52:54:00:06:80:f0
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 22
+            tenant2:
+                interface_name: enp7s0.32
+                ip_v4: 172.19.10.10
+                is_trunk_parent: false
+                mac_addr: 52:54:00:16:92:88
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 32
+    ocp-master-1:
+        hostname: master-1
+        name: ocp-master-1
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.11
+                is_trunk_parent: true
+                mac_addr: 52:54:01:43:50:83
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane
+                prefix_length_v4: 24
+                skip_nm: false
+            ctlplane2:
+                interface_name: enp7s0
+                ip_v4: 192.168.133.11
+                is_trunk_parent: true
+                mac_addr: 52:54:00:0f:d8:f3
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane2
+                prefix_length_v4: 24
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.11
+                is_trunk_parent: false
+                mac_addr: 52:54:00:71:78:e6
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 20
+            internalapi2:
+                interface_name: enp7s0.30
+                ip_v4: 172.17.10.11
+                is_trunk_parent: false
+                mac_addr: 52:54:00:07:78:69
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 30
+            ocpbm:
+                interface_name: enp2s0
+                ip_v4: 192.168.111.11
+                mac_addr: 52:54:01:51:68:1e
+                netmask_v4: 255.255.255.0
+                network_name: ocpbm
+                prefix_length_v4: 24
+                skip_nm: false
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.11
+                is_trunk_parent: false
+                mac_addr: 52:54:00:76:3d:ba
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 21
+            storage2:
+                interface_name: enp7s0.31
+                ip_v4: 172.18.10.11
+                is_trunk_parent: false
+                mac_addr: 52:54:00:73:55:1a
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 31
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.11
+                is_trunk_parent: false
+                mac_addr: 52:54:00:7a:5d:1d
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 22
+            tenant2:
+                interface_name: enp7s0.32
+                ip_v4: 172.19.10.11
+                is_trunk_parent: false
+                mac_addr: 52:54:00:28:02:1f
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 32
+    ocp-master-2:
+        hostname: master-2
+        name: ocp-master-2
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.12
+                is_trunk_parent: true
+                mac_addr: 52:54:02:fd:b8:5a
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane
+                prefix_length_v4: 24
+                skip_nm: false
+            ctlplane2:
+                interface_name: enp7s0
+                ip_v4: 192.168.133.12
+                is_trunk_parent: true
+                mac_addr: 52:54:00:28:5e:bb
+                mtu: 1500
+                netmask_v4: 255.255.255.0
+                network_name: ctlplane2
+                prefix_length_v4: 24
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.12
+                is_trunk_parent: false
+                mac_addr: 52:54:00:66:a0:7c
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 20
+            internalapi2:
+                interface_name: enp7s0.30
+                ip_v4: 172.17.10.12
+                is_trunk_parent: false
+                mac_addr: 52:54:00:5a:21:7a
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: internalapi2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 30
+            ocpbm:
+                interface_name: enp2s0
+                ip_v4: 192.168.111.12
+                mac_addr: 52:54:02:50:e9:87
+                netmask_v4: 255.255.255.0
+                network_name: ocpbm
+                prefix_length_v4: 24
+                skip_nm: false
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.12
+                is_trunk_parent: false
+                mac_addr: 52:54:00:09:45:3b
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 21
+            storage2:
+                interface_name: enp7s0.31
+                ip_v4: 172.18.10.12
+                is_trunk_parent: false
+                mac_addr: 52:54:00:38:ce:7e
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: storage2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 31
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.12
+                is_trunk_parent: false
+                mac_addr: 52:54:00:22:70:9f
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane
+                vlan_id: 22
+            tenant2:
+                interface_name: enp7s0.32
+                ip_v4: 172.19.10.12
+                is_trunk_parent: false
+                mac_addr: 52:54:00:51:96:4f
+                mtu: 1496
+                netmask_v4: 255.255.255.0
+                network_name: tenant2
+                prefix_length_v4: 24
+                skip_nm: false
+                trunk_parent: ctlplane2
+                vlan_id: 32
+networks:
+    ctlplane:
+        dns_v4:
+            - 192.168.122.1
+        dns_v6: []
+        gw_v4: 192.168.122.1
+        mtu: 1500
+        network_name: ctlplane
+        network_v4: 192.168.122.0/24
+        search_domain: ctlplane.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                    - end: 192.168.122.90
+                      end_host: 90
+                      length: 11
+                      start: 192.168.122.80
+                      start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                    - end: 192.168.122.70
+                      end_host: 70
+                      length: 41
+                      start: 192.168.122.30
+                      start_host: 30
+                ipv4_routes: []
+                ipv6_ranges: []
+                ipv6_routes: []
+            netconfig:
+                ipv4_ranges:
+                    - end: 192.168.122.120
+                      end_host: 120
+                      length: 21
+                      start: 192.168.122.100
+                      start_host: 100
+                    - end: 192.168.122.170
+                      end_host: 170
+                      length: 21
+                      start: 192.168.122.150
+                      start_host: 150
+                ipv6_ranges: []
+    ctlplane2:
+        dns_v4:
+            - 192.168.133.1
+        dns_v6: []
+        gw_v4: 192.168.133.1
+        mtu: 1500
+        network_name: ctlplane2
+        network_v4: 192.168.133.0/24
+        search_domain: ctlplane2.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                    - end: 192.168.133.90
+                      end_host: 90
+                      length: 11
+                      start: 192.168.133.80
+                      start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                    - end: 192.168.133.70
+                      end_host: 70
+                      length: 41
+                      start: 192.168.133.30
+                      start_host: 30
+                ipv4_routes: []
+                ipv6_ranges: []
+                ipv6_routes: []
+            netconfig:
+                ipv4_ranges:
+                    - end: 192.168.133.120
+                      end_host: 120
+                      length: 21
+                      start: 192.168.133.100
+                      start_host: 100
+                    - end: 192.168.133.170
+                      end_host: 170
+                      length: 21
+                      start: 192.168.133.150
+                      start_host: 150
+                ipv6_ranges: []
+    external:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1500
+        network_name: external
+        network_v4: 10.0.0.0/24
+        search_domain: external.example.com
+        tools:
+            netconfig:
+                ipv4_ranges:
+                    - end: 10.0.0.250
+                      end_host: 250
+                      length: 151
+                      start: 10.0.0.100
+                      start_host: 100
+                ipv6_ranges: []
+        vlan_id: 22
+    external2:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1500
+        network_name: external2
+        network_v4: 10.10.0.0/24
+        search_domain: external2.example.com
+        tools:
+            netconfig:
+                ipv4_ranges:
+                    - end: 10.10.0.250
+                      end_host: 250
+                      length: 151
+                      start: 10.10.0.100
+                      start_host: 100
+                ipv6_ranges: []
+        vlan_id: 32
+    internalapi:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: internalapi
+        network_v4: 172.17.0.0/24
+        search_domain: internalapi.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                    - end: 172.17.0.90
+                      end_host: 90
+                      length: 11
+                      start: 172.17.0.80
+                      start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                    - end: 172.17.0.70
+                      end_host: 70
+                      length: 41
+                      start: 172.17.0.30
+                      start_host: 30
+                ipv4_routes: []
+                ipv6_ranges: []
+                ipv6_routes: []
+            netconfig:
+                ipv4_ranges:
+                    - end: 172.17.0.250
+                      end_host: 250
+                      length: 151
+                      start: 172.17.0.100
+                      start_host: 100
+                ipv6_ranges: []
+        vlan_id: 20
+    internalapi2:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: internalapi2
+        network_v4: 172.17.10.0/24
+        search_domain: internalapi2.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                    - end: 172.17.10.90
+                      end_host: 90
+                      length: 11
+                      start: 172.17.10.80
+                      start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                    - end: 172.17.10.70
+                      end_host: 70
+                      length: 41
+                      start: 172.17.10.30
+                      start_host: 30
+                ipv4_routes: []
+                ipv6_ranges: []
+                ipv6_routes: []
+            netconfig:
+                ipv4_ranges:
+                    - end: 172.17.10.250
+                      end_host: 250
+                      length: 151
+                      start: 172.17.10.100
+                      start_host: 100
+                ipv6_ranges: []
+        vlan_id: 30
+    ocpbm:
+        dns_v4: []
+        dns_v6: []
+        network_name: ocpbm
+        network_v4: 192.168.111.0/24
+        search_domain: ocpbm.example.com
+        tools: {}
+    storage:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: storage
+        network_v4: 172.18.0.0/24
+        search_domain: storage.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                    - end: 172.18.0.90
+                      end_host: 90
+                      length: 11
+                      start: 172.18.0.80
+                      start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                    - end: 172.18.0.70
+                      end_host: 70
+                      length: 41
+                      start: 172.18.0.30
+                      start_host: 30
+                ipv4_routes: []
+                ipv6_ranges: []
+                ipv6_routes: []
+            netconfig:
+                ipv4_ranges:
+                    - end: 172.18.0.250
+                      end_host: 250
+                      length: 151
+                      start: 172.18.0.100
+                      start_host: 100
+                ipv6_ranges: []
+        vlan_id: 21
+    storage2:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: storage2
+        network_v4: 172.18.10.0/24
+        search_domain: storage2.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                    - end: 172.18.10.90
+                      end_host: 90
+                      length: 11
+                      start: 172.18.10.80
+                      start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                    - end: 172.18.10.70
+                      end_host: 70
+                      length: 41
+                      start: 172.18.10.30
+                      start_host: 30
+                ipv4_routes: []
+                ipv6_ranges: []
+                ipv6_routes: []
+            netconfig:
+                ipv4_ranges:
+                    - end: 172.18.10.250
+                      end_host: 250
+                      length: 151
+                      start: 172.18.10.100
+                      start_host: 100
+                ipv6_ranges: []
+        vlan_id: 31
+    tenant:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: tenant
+        network_v4: 172.19.0.0/24
+        search_domain: tenant.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                    - end: 172.19.0.90
+                      end_host: 90
+                      length: 11
+                      start: 172.19.0.80
+                      start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                    - end: 172.19.0.70
+                      end_host: 70
+                      length: 41
+                      start: 172.19.0.30
+                      start_host: 30
+                ipv4_routes: []
+                ipv6_ranges: []
+                ipv6_routes: []
+            netconfig:
+                ipv4_ranges:
+                    - end: 172.19.0.250
+                      end_host: 250
+                      length: 151
+                      start: 172.19.0.100
+                      start_host: 100
+                ipv6_ranges: []
+        vlan_id: 22
+    tenant2:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: tenant2
+        network_v4: 172.19.10.0/24
+        search_domain: tenant2.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                    - end: 172.19.10.90
+                      end_host: 90
+                      length: 11
+                      start: 172.19.10.80
+                      start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                    - end: 172.19.10.70
+                      end_host: 70
+                      length: 41
+                      start: 172.19.10.30
+                      start_host: 30
+                ipv4_routes: []
+                ipv6_ranges: []
+                ipv6_routes: []
+            netconfig:
+                ipv4_ranges:
+                    - end: 172.19.10.250
+                      end_host: 250
+                      length: 151
+                      start: 172.19.10.100
+                      start_host: 100
+                ipv6_ranges: []
+        vlan_id: 32
+routers: {}

--- a/automation/vars/multi-namespace.yaml
+++ b/automation/vars/multi-namespace.yaml
@@ -1,0 +1,169 @@
+---
+vas:
+  multi-namespace:
+    stages:
+      - name: namespace-configuration    # stage 0
+        path: examples/va/multi-namespace/namespace
+        wait_conditions:
+          - >-
+            oc -n default wait ns openstack2
+            --for jsonpath='{.status.phase}'=Active
+            --timeout=5m
+        values:
+          - name: namespace-values
+            src_file: values.yaml
+        build_output: namespace.yaml
+
+      - name: nncp-configuration    # stage 1
+        path: examples/va/multi-namespace/control-plane/networking/nncp
+        wait_conditions:
+          # We don't wait for these NNCPs at this stage, because we'll wait for
+          # both namespaces in the next stage so that they can deploy in parallel
+          # to save time
+          - >-
+            oc -n default wait ns openstack2
+            --for jsonpath='{.status.phase}'=Active
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - name: nncp-configuration2    # stage 2
+        path: examples/va/multi-namespace/control-plane2/networking/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=5m
+        values:
+          - name: network-values2
+            src_file: values.yaml
+        build_output: nncp2.yaml
+
+      - name: network-configuration    # stage 3
+        path: examples/va/multi-namespace/control-plane/networking
+        wait_conditions:
+          - >-
+            oc -n metallb-system wait pod
+            -l app=metallb -l component=speaker
+            --for condition=Ready
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: network.yaml
+
+      - name: network-configuration2    # stage 4
+        path: examples/va/multi-namespace/control-plane2/networking
+        wait_conditions:
+          - >-
+            oc -n metallb-system wait pod
+            -l app=metallb -l component=speaker
+            --for condition=Ready
+            --timeout=5m
+        values:
+          - name: network-values2
+            src_file: nncp/values.yaml
+        build_output: network2.yaml
+
+      - name: control-plane    # stage 5
+        path: examples/va/multi-namespace/control-plane
+        wait_conditions:
+          # We don't wait for this namespace's OpenStackControlPlane at
+          # this stage, because we'll wait for both namespaces in the next
+          # stage so that they can deploy in parallel to save time
+          - >-
+            oc -n default wait ns openstack2
+            --for jsonpath='{.status.phase}'=Active
+            --timeout=5m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: network-values
+            src_file: networking/nncp/values.yaml
+        build_output: ../control-plane.yaml
+
+      - name: control-plane2    # stage 6
+        path: examples/va/multi-namespace/control-plane2
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane --for condition=Ready
+            --timeout=60m
+          - >-
+            oc -n openstack2 wait osctlplane controlplane --for condition=Ready
+            --timeout=60m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: network-values2
+            src_file: networking/nncp/values.yaml
+        build_output: ../control-plane2.yaml
+
+      - name: edpm-nodeset    # stage 7
+        path: examples/va/multi-namespace/edpm/nodeset
+        wait_conditions:
+          # We don't wait for this namespace's OpenStackDataPlaneNodeSet at
+          # this stage, because we'll wait for both namespaces in the next
+          # stage so that they can deploy in parallel to save time
+          - >-
+            oc -n default wait ns openstack2
+            --for jsonpath='{.status.phase}'=Active
+            --timeout=5m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset.yaml
+
+      - pre_stage_run:    # stage 8
+          - name: Get OpenStackDataPlaneServices for openstack2 namespace
+            type: playbook
+            source: "../../playbooks/multi-namespace/ns2_osdp_services.yaml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+        name: edpm-nodeset2
+        path: examples/va/multi-namespace/edpm2/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=10m
+          - >-
+            oc -n openstack2 wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=10m
+        values:
+          - name: edpm-nodeset2-values
+            src_file: values.yaml
+        build_output: nodeset2.yaml
+
+      - name: edpm-deployment    # stage 9
+        path: examples/va/multi-namespace/edpm
+        wait_conditions:
+          # We don't wait for this namespace's OpenStackDataPlaneDeployment at
+          # this stage, because we'll wait for both namespaces in the next
+          # stage so that they can deploy in parallel to save time
+          - >-
+            oc -n default wait ns openstack2
+            --for jsonpath='{.status.phase}'=Active
+            --timeout=5m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment.yaml
+
+      - name: edpm-deployment2    # stage 10
+        path: examples/va/multi-namespace/edpm2
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=30m
+          - >-
+            oc -n openstack2 wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=30m
+        values:
+          - name: edpm-deployment2-values
+            src_file: values.yaml
+        build_output: deployment2.yaml

--- a/examples/va/multi-namespace/.gitignore
+++ b/examples/va/multi-namespace/.gitignore
@@ -1,0 +1,11 @@
+namespace.yaml
+nncp.yaml
+nncp2.yaml
+networking.yaml
+networking2.yaml
+control-plane.yaml
+control-plane2.yaml
+nodeset.yaml
+nodeset2.yaml
+deployment.yaml
+deployment2.yaml

--- a/examples/va/multi-namespace/README.md
+++ b/examples/va/multi-namespace/README.md
@@ -1,0 +1,35 @@
+# Dual OpenStack deployments in separate namespaces
+
+**Based on OpenStack K8S operators from the "main" branch of the [OpenStack Operator repo](https://github.com/openstack-k8s-operators/openstack-operator/commit/b0944fc30a9387cf41d019165c5dbc6a8f128597) on Apr 25th, 2025**
+
+This is a collection of CR templates that represent a validated Red Hat OpenStack Services on OpenShift deployment that has the following characteristics:
+
+- 3 master/worker combo-node OpenShift cluster
+- 2 OSP control and data plane deployments (2 separate clouds in different namespaces)
+
+Per cloud:
+
+- 3-replica Galera database
+- RabbitMQ
+- OVN networking
+- Network isolation over a single NIC
+- 3 compute nodes
+
+## Considerations
+
+1. These CRs are validated for the overall functionality of the OSP cloud deployed, but they nonetheless require customization for the particular environment in which they are utilized.  In this sense they are _templates_ meant to be consumed and tweaked to fit the specific constraints of the hardware available.
+
+2. The CRs are applied against an OpenShift cluster in _stages_.  That is, there is an ordering in which each grouping of CRs is fed to the cluster.  It is _not_ a case of simply taking all CRs from all stages and applying them all at once.
+
+3. [kustomize](https://kustomize.io/) is used to genereate the control plane CRs dynamically. The `control-plane/networking/nncp/values.yaml`, `control-plane/service-values.yaml`, `control-plane2/networking/nncp/values.yaml` and `control-plane2/service-values.yaml` file(s) must be updated to fit your environment. kustomize version 5 or newer required.
+
+4. [kustomize](https://kustomize.io/) is used to generate the dataplane CRs dynamically. The `edpm/nodeset/values.yaml` and `edpm2/nodeset/values.yaml` files must be updated to fit your environment. kustomize version 5 or newer required.
+
+## Stages
+
+All stages must be executed in the order listed below. Everything is required unless otherwise indicated.
+
+1. [Install the OpenStack K8S operators and their dependencies](../../common/)
+2. [Create the second namespace](namespace.md)
+3. [Configuring networking and deploy the OpenStack control planes](control-plane.md)
+4. [Deploy the data planes](dataplane.md)

--- a/examples/va/multi-namespace/control-plane.md
+++ b/examples/va/multi-namespace/control-plane.md
@@ -1,0 +1,115 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `local-storage` should already exist.
+
+## Initialize
+
+Change to the multi-namespace directory
+```
+cd architecture/examples/va/multi-namespace
+```
+
+## Control plane one
+
+Edit the [control-plane/networking/nncp/values.yaml](control-plane/networking/nncp/values.yaml) and
+[control-plane/service-values.yaml](control-plane/service-values.yaml) files to suit 
+your environment.
+```
+vi control-plane/networking/nncp/values.yaml
+vi control-plane/service-values.yaml
+```
+
+### Apply node network configuration
+
+Generate the node network configuration
+```
+kustomize build control-plane/networking/nncp > nncp.yaml
+```
+Apply the NNCP CRs
+```
+oc apply -f nncp.yaml
+```
+Wait for NNCPs to be available
+```
+oc wait -n openstack nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=300s
+```
+
+### Apply networking configuration
+
+Generate the networking configuration
+```
+kustomize build control-plane/networking > networking.yaml
+```
+Apply the networking CRs
+```
+oc apply -f networking.yaml
+```
+
+### Apply control-plane configuration
+
+Generate the control-plane and networking CRs.
+```
+kustomize build control-plane > control-plane.yaml
+```
+Apply the CRs
+```
+oc apply -f control-plane.yaml
+```
+
+Wait for control plane to be available
+```
+oc wait -n openstack osctlplane controlplane --for condition=Ready --timeout=600s
+```
+
+## Control plane two
+
+Edit the [control-plane2/networking/nncp/values.yaml](control-plane2/networking/nncp/values.yaml) and
+[control-plane2/service-values.yaml](control-plane2/service-values.yaml) files to suit 
+your environment.
+```
+vi control-plane2/networking/nncp/values.yaml
+vi control-plane2/service-values.yaml
+```
+
+### Apply node network configuration
+
+Generate the node network configuration
+```
+kustomize build control-plane2/networking/nncp > nncp2.yaml
+```
+Apply the NNCP CRs
+```
+oc apply -f nncp2.yaml
+```
+Wait for NNCPs to be available
+```
+oc wait -n openstack2 nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=300s
+```
+
+### Apply networking configuration
+
+Generate the networking configuration
+```
+kustomize build control-plane2/networking > networking2.yaml
+```
+Apply the networking CRs
+```
+oc apply -f networking2.yaml
+```
+
+### Apply control-plane configuration
+
+Generate the control-plane and networking CRs.
+```
+kustomize build control-plane2 > control-plane2.yaml
+```
+Apply the CRs
+```
+oc apply -f control-plane2.yaml
+```
+
+Wait for control plane to be available
+```
+oc wait -n openstack2 osctlplane controlplane --for condition=Ready --timeout=600s

--- a/examples/va/multi-namespace/control-plane/.gitignore
+++ b/examples/va/multi-namespace/control-plane/.gitignore
@@ -1,0 +1,3 @@
+nncp.yaml
+networking.yaml
+control-plane.yaml

--- a/examples/va/multi-namespace/control-plane/kustomization.yaml
+++ b/examples/va/multi-namespace/control-plane/kustomization.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/control-plane
+
+resources:
+  - networking/nncp/values.yaml
+  - service-values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.barbican.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.barbican.template.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderAPI.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderAPI.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.default.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.swift.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.swift.enabled
+        options:
+          create: true

--- a/examples/va/multi-namespace/control-plane/networking/kustomization.yaml
+++ b/examples/va/multi-namespace/control-plane/networking/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+
+components:
+  - ../../../../../lib/networking
+
+resources:
+  - nncp/values.yaml

--- a/examples/va/multi-namespace/control-plane/networking/nncp/.gitignore
+++ b/examples/va/multi-namespace/control-plane/networking/nncp/.gitignore
@@ -1,0 +1,1 @@
+nncp.yaml

--- a/examples/va/multi-namespace/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/va/multi-namespace/control-plane/networking/nncp/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../../lib/nncp
+
+resources:
+  - values.yaml

--- a/examples/va/multi-namespace/control-plane/networking/nncp/values.yaml
+++ b/examples/va/multi-namespace/control-plane/networking/nncp/values.yaml
@@ -1,0 +1,199 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # nodes
+  node_0:
+    name: ostest-master-0
+    internalapi_ip: 172.17.0.5
+    tenant_ip: 172.19.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+  node_1:
+    name: ostest-master-1
+    internalapi_ip: 172.17.0.6
+    tenant_ip: 172.19.0.6
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.6
+  node_2:
+    name: ostest-master-2
+    internalapi_ip: 172.17.0.7
+    tenant_ip: 172.19.0.7
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.7
+
+  # networks
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet1
+    prefix-length: 24
+    iface: enp6s0
+    mtu: 1500
+    lb_addresses:
+      - 192.168.122.80-192.168.122.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "macvlan",
+        "master": "ospbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.122.0/24",
+          "range_start": "192.168.122.30",
+          "range_end": "192.168.122.70"
+        }
+      }
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "macvlan",
+        "master": "internalapi",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 1500
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "macvlan",
+        "master": "storage",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+  tenant:
+    dnsDomain: tenant.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        name: subnet1
+        vlan: 22
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "macvlan",
+        "master": "tenant",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70"
+        }
+      }
+  external:
+    dnsDomain: external.example.com
+    subnets:
+      - allocationRanges:
+          - end: 10.0.0.250
+            start: 10.0.0.100
+        cidr: 10.0.0.0/24
+        gateway: 10.0.0.1
+        name: subnet1
+    mtu: 1500
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config: []
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr

--- a/examples/va/multi-namespace/control-plane/service-values.yaml
+++ b/examples/va/multi-namespace/control-plane/service-values.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  preserveJobs: false
+  barbican:
+    enabled: false
+  cinderAPI:
+    replicas: 1
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:swift
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+    default:
+      replicas: 1
+  swift:
+    enabled: true

--- a/examples/va/multi-namespace/control-plane2/.gitignore
+++ b/examples/va/multi-namespace/control-plane2/.gitignore
@@ -1,0 +1,3 @@
+nncp2.yaml
+networking2.yaml
+control-plane2.yaml

--- a/examples/va/multi-namespace/control-plane2/kustomization.yaml
+++ b/examples/va/multi-namespace/control-plane2/kustomization.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack2 on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack2
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/control-plane
+
+resources:
+  - networking/nncp/values.yaml
+  - service-values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.barbican.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.barbican.template.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderAPI.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderAPI.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.default.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.swift.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.swift.enabled
+        options:
+          create: true

--- a/examples/va/multi-namespace/control-plane2/networking/kustomization.yaml
+++ b/examples/va/multi-namespace/control-plane2/networking/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  # Set namespace to OpenStack2 on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack2
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../va/multi-namespace/control-plane2/networking
+
+resources:
+  - nncp/values.yaml

--- a/examples/va/multi-namespace/control-plane2/networking/nncp/kustomization.yaml
+++ b/examples/va/multi-namespace/control-plane2/networking/nncp/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack2
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../../va/multi-namespace/control-plane2/networking/nncp
+
+resources:
+  - values.yaml

--- a/examples/va/multi-namespace/control-plane2/networking/nncp/values.yaml
+++ b/examples/va/multi-namespace/control-plane2/networking/nncp/values.yaml
@@ -1,0 +1,200 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # nodes
+  node_0:
+    name: ostest-master-0
+    internalapi_ip: 172.17.10.5
+    tenant_ip: 172.19.10.5
+    ctlplane_ip: 192.168.133.10
+    storage_ip: 172.18.10.5
+  node_1:
+    name: ostest-master-1
+    internalapi_ip: 172.17.10.6
+    tenant_ip: 172.19.10.6
+    ctlplane_ip: 192.168.133.11
+    storage_ip: 172.18.10.6
+  node_2:
+    name: ostest-master-2
+    internalapi_ip: 172.17.10.7
+    tenant_ip: 172.19.10.7
+    ctlplane_ip: 192.168.133.12
+    storage_ip: 172.18.10.7
+
+  # networks
+  ctlplane:
+    dnsDomain: ctlplane2.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.133.120
+            start: 192.168.133.100
+          - end: 192.168.133.200
+            start: 192.168.133.150
+        cidr: 192.168.133.0/24
+        gateway: 192.168.133.1
+        name: subnet1
+    prefix-length: 24
+    iface: enp8s0
+    vlan: 30
+    mtu: 1500
+    lb_addresses:
+      - 192.168.133.80-192.168.133.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane2
+      metallb.universe.tf/allow-shared-ip: ctlplane2
+      metallb.universe.tf/loadBalancerIPs: 192.168.133.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "macvlan",
+        "master": "ospbr2",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.133.0/24",
+          "range_start": "192.168.133.30",
+          "range_end": "192.168.133.70"
+        }
+      }
+  internalapi:
+    dnsDomain: internalapi2.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.10.250
+            start: 172.17.10.100
+        cidr: 172.17.10.0/24
+        name: subnet1
+        vlan: 30
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi2
+    vlan: 30
+    base_iface: enp8s0
+    lb_addresses:
+      - 172.17.10.80-172.17.10.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi2
+      metallb.universe.tf/allow-shared-ip: internalapi2
+      metallb.universe.tf/loadBalancerIPs: 172.17.10.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "macvlan",
+        "master": "internalapi2",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.10.0/24",
+          "range_start": "172.17.10.30",
+          "range_end": "172.17.10.70"
+        }
+      }
+  storage:
+    dnsDomain: storage2.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.10.250
+            start: 172.18.10.100
+        cidr: 172.18.10.0/24
+        name: subnet1
+        vlan: 31
+    mtu: 1500
+    prefix-length: 24
+    iface: storage2
+    vlan: 31
+    base_iface: enp8s0
+    lb_addresses:
+      - 172.18.10.80-172.18.10.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "macvlan",
+        "master": "storage2",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.10.0/24",
+          "range_start": "172.18.10.30",
+          "range_end": "172.18.10.70"
+        }
+      }
+  tenant:
+    dnsDomain: tenant2.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.10.250
+            start: 172.19.10.100
+        cidr: 172.19.10.0/24
+        name: subnet1
+        vlan: 32
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant2
+    vlan: 32
+    base_iface: enp8s0
+    lb_addresses:
+      - 172.19.10.80-172.19.10.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "macvlan",
+        "master": "tenant2",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.10.0/24",
+          "range_start": "172.19.10.30",
+          "range_end": "172.19.10.70"
+        }
+      }
+  external:
+    dnsDomain: external2.example.com
+    subnets:
+      - allocationRanges:
+          - end: 10.10.0.250
+            start: 10.10.0.100
+        cidr: 10.10.0.0/24
+        gateway: 10.10.0.1
+        name: subnet1
+    mtu: 1500
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "macvlan",
+        "bridge": "ospbr2",
+        "ipam": {}
+      }
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.133.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.133.1
+
+  routes:
+    config: []
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi2
+      metallb.universe.tf/loadBalancerIPs: 172.17.10.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi2
+      metallb.universe.tf/loadBalancerIPs: 172.17.10.86
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr2

--- a/examples/va/multi-namespace/control-plane2/service-values.yaml
+++ b/examples/va/multi-namespace/control-plane2/service-values.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  preserveJobs: false
+  barbican:
+    enabled: false
+  cinderAPI:
+    replicas: 1
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:swift
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+    default:
+      replicas: 1
+  swift:
+    enabled: true

--- a/examples/va/multi-namespace/dataplane.md
+++ b/examples/va/multi-namespace/dataplane.md
@@ -1,0 +1,88 @@
+# Configuring and deploying the dataplanes
+
+## Assumptions
+
+- The [control plane](control-plane.md) for both OSP clouds have been created and successfully deployed
+
+## Initialize
+
+Change to the multi-namespace directory
+```
+cd architecture/examples/va/multi-namespace
+```
+
+## Dataplane one
+
+### Prepare CRs
+Edit the [edpm/nodeset/values.yaml](edpm/nodeset/values.yaml) and [edpm/values.yaml](edpm/values.yaml) files to suit 
+your environment.
+```
+vi edpm/nodeset/values.yaml
+vi edpm/values.yaml
+```
+Generate the dataplane nodeset CR.
+```
+kustomize build edpm/nodeset > nodeset.yaml
+```
+Generate the dataplane deployment CR.
+```
+kustomize build edpm > deployment.yaml
+```
+
+### Apply CRs
+Create the nodeset CR
+```
+oc apply -f nodeset.yaml
+```
+Wait for dataplane nodeset setup to finish
+```
+oc wait -n openstack osdpns openstack-edpm --for condition=SetupReady --timeout=600s
+```
+
+Start the deployment
+```
+oc apply -f deployment.yaml
+```
+
+Wait for dataplane deployment to finish
+```
+oc wait -n openstack osdpns openstack-edpm --for condition=Ready --timeout=40m
+```
+
+## Dataplane two
+
+### Prepare CRs
+Edit the [edpm2/nodeset/values.yaml](edpm2/nodeset/values.yaml) and [edpm2/values.yaml](edpm2/values.yaml) files to suit 
+your environment.
+```
+vi edpm/2nodeset/values.yaml
+vi edpm2/values.yaml
+```
+Generate the dataplane nodeset CR.
+```
+kustomize build edpm2/nodeset > nodeset2.yaml
+```
+Generate the dataplane deployment CR.
+```
+kustomize build edpm2 > deployment2.yaml
+```
+
+### Apply CRs
+Create the nodeset CR
+```
+oc apply -f nodeset2.yaml
+```
+Wait for dataplane nodeset setup to finish
+```
+oc wait -n openstack2 osdpns openstack-edpm --for condition=SetupReady --timeout=600s
+```
+
+Start the deployment
+```
+oc apply -f deployment2.yaml
+```
+
+Wait for dataplane deployment to finish
+```
+oc wait -n openstack2 osdpns openstack-edpm --for condition=Ready --timeout=40m
+```

--- a/examples/va/multi-namespace/edpm/.gitignore
+++ b/examples/va/multi-namespace/edpm/.gitignore
@@ -1,0 +1,2 @@
+nodeset.yaml
+deployment.yaml

--- a/examples/va/multi-namespace/edpm/kustomization.yaml
+++ b/examples/va/multi-namespace/edpm/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../lib/dataplane/deployment
+
+resources:
+  - values.yaml

--- a/examples/va/multi-namespace/edpm/nodeset/kustomization.yaml
+++ b/examples/va/multi-namespace/edpm/nodeset/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../../lib/dataplane/nodeset
+
+resources:
+  - values.yaml

--- a/examples/va/multi-namespace/edpm/nodeset/values.yaml
+++ b/examples/va/multi-namespace/edpm/nodeset/values.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  ssh_keys:
+    authorized: _replaced_
+    private: _replaced_
+    public: _replaced_
+
+  nova:
+    migration:
+      ssh_keys:
+        private: _replaced_
+        public: _replaced_
+
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            mtu: {{ min_viable_mtu }}
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            mtu: {{ min_viable_mtu }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            members:
+            - type: interface
+              name: nic2
+              mtu: {{ min_viable_mtu }}
+              # force the MAC address of the bridge to this interface
+              primary: true
+          {% for network in nodeset_networks %}
+            - type: vlan
+              mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+              vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+              addresses:
+              - ip_netmask:
+                  {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+              routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth0
+
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+
+        edpm_sshd_configure_firewall: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+
+        gather_facts: false
+
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
+
+    nodes:
+      edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.122.100
+        hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+
+      edpm-compute-1:
+        ansible:
+          ansibleHost: 192.168.122.101
+        hostName: edpm-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+
+    services:
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - libvirt
+      - nova

--- a/examples/va/multi-namespace/edpm/values.yaml
+++ b/examples/va/multi-namespace/edpm/values.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data: {}

--- a/examples/va/multi-namespace/edpm2/.gitignore
+++ b/examples/va/multi-namespace/edpm2/.gitignore
@@ -1,0 +1,2 @@
+nodeset2.yaml
+deployment2.yaml

--- a/examples/va/multi-namespace/edpm2/kustomization.yaml
+++ b/examples/va/multi-namespace/edpm2/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack2
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../va/multi-namespace/edpm2
+
+resources:
+  - values.yaml

--- a/examples/va/multi-namespace/edpm2/nodeset/kustomization.yaml
+++ b/examples/va/multi-namespace/edpm2/nodeset/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack2
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../../va/multi-namespace/edpm2/nodeset
+
+resources:
+  - values.yaml

--- a/examples/va/multi-namespace/edpm2/nodeset/values.yaml
+++ b/examples/va/multi-namespace/edpm2/nodeset/values.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  ssh_keys:
+    authorized: _replaced_
+    private: _replaced_
+    public: _replaced_
+
+  nova:
+    migration:
+      ssh_keys:
+        private: _replaced_
+        public: _replaced_
+
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            mtu: {{ min_viable_mtu }}
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            mtu: {{ min_viable_mtu }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            members:
+            - type: interface
+              name: nic2
+              mtu: {{ min_viable_mtu }}
+              # force the MAC address of the bridge to this interface
+              primary: true
+          {% for network in nodeset_networks %}
+            - type: vlan
+              mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+              vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+              addresses:
+              - ip_netmask:
+                  {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+              routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth0
+
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+
+        edpm_sshd_configure_firewall: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.133.0/24
+
+        gather_facts: false
+
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
+
+    nodes:
+      edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.133.100
+        hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.133.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+
+      edpm-compute-1:
+        ansible:
+          ansibleHost: 192.168.133.101
+        hostName: edpm-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.133.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+
+    services:
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - libvirt
+      - nova

--- a/examples/va/multi-namespace/edpm2/values.yaml
+++ b/examples/va/multi-namespace/edpm2/values.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data: {}

--- a/examples/va/multi-namespace/namespace.md
+++ b/examples/va/multi-namespace/namespace.md
@@ -1,0 +1,17 @@
+# Create the second namespace (openstack2)
+
+## Apply namespace
+
+Change to the multi-namespace directory
+```
+cd architecture/examples/va/multi-namespace
+```
+
+Generate the namespace YAML
+```
+kustomize build namespace > namespace.yaml
+```
+Apply the YAML
+```
+oc apply -f namespace.yaml
+```

--- a/examples/va/multi-namespace/namespace/.gitignore
+++ b/examples/va/multi-namespace/namespace/.gitignore
@@ -1,0 +1,1 @@
+namespace.yaml

--- a/examples/va/multi-namespace/namespace/kustomization.yaml
+++ b/examples/va/multi-namespace/namespace/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../va/multi-namespace/namespace

--- a/examples/va/multi-namespace/namespace/values.yaml
+++ b/examples/va/multi-namespace/namespace/values.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: namespace-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data: {}

--- a/va/multi-namespace/control-plane2/networking/kustomization.yaml
+++ b/va/multi-namespace/control-plane2/networking/kustomization.yaml
@@ -1,0 +1,116 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack2 on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack2
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/networking
+
+patches:
+  # IPAddressPools
+  - target:
+      kind: IPAddressPool
+      name: ctlplane
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ctlplane2
+  - target:
+      kind: IPAddressPool
+      name: internalapi
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: internalapi2
+  - target:
+      kind: IPAddressPool
+      name: storage
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: storage2
+  - target:
+      kind: IPAddressPool
+      name: tenant
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: tenant2
+
+  # L2Advertisements
+  - target:
+      kind: L2Advertisement
+      name: ctlplane
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ctlplane2
+      - op: replace
+        path: /spec/ipAddressPools
+        value:
+          - ctlplane2
+  - target:
+      kind: L2Advertisement
+      name: internalapi
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: internalapi2
+      - op: replace
+        path: /spec/ipAddressPools
+        value:
+          - internalapi2
+  - target:
+      kind: L2Advertisement
+      name: storage
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: storage2
+      - op: replace
+        path: /spec/ipAddressPools
+        value:
+          - storage2
+  - target:
+      kind: L2Advertisement
+      name: tenant
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: tenant2
+      - op: replace
+        path: /spec/ipAddressPools
+        value:
+          - tenant2
+
+  # NADs
+  - target:
+      kind: NetworkAttachmentDefinition
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/namespace
+        value: openstack2
+
+  # NetConfig
+  - target:
+      kind: NetConfig
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/namespace
+        value: openstack2

--- a/va/multi-namespace/control-plane2/networking/nncp/kustomization.yaml
+++ b/va/multi-namespace/control-plane2/networking/nncp/kustomization.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack2
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../lib/nncp
+
+patches:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: .*master-0
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: master-0-2
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: .*master-1
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: master-1-2
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: .*master-2
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: master-2-2
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: .*
+    patch: |-
+      - op: replace
+        path: /spec/desiredState/interfaces/0/name
+        value: internalapi2
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: .*
+    patch: |-
+      - op: replace
+        path: /spec/desiredState/interfaces/1/name
+        value: storage2
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: .*
+    patch: |-
+      - op: replace
+        path: /spec/desiredState/interfaces/2/name
+        value: tenant2

--- a/va/multi-namespace/edpm2/kustomization.yaml
+++ b/va/multi-namespace/edpm2/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack2
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../lib/dataplane/deployment
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneDeployment
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/namespace
+        value: openstack2

--- a/va/multi-namespace/edpm2/nodeset/kustomization.yaml
+++ b/va/multi-namespace/edpm2/nodeset/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack2
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../lib/dataplane/nodeset
+
+patches:
+  - target:
+      kind: Secret
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/namespace
+        value: openstack2

--- a/va/multi-namespace/namespace/kustomization.yaml
+++ b/va/multi-namespace/namespace/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - namespace.yaml

--- a/va/multi-namespace/namespace/namespace.yaml
+++ b/va/multi-namespace/namespace/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openstack2
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,6 +7,7 @@
       - rhoso-architecture-validate-dcn
       - rhoso-architecture-validate-hci
       - rhoso-architecture-validate-hci-adoption
+      - rhoso-architecture-validate-multi-namespace
       - rhoso-architecture-validate-nfv-ovs-dpdk-sriov-adoption
       - rhoso-architecture-validate-nfv-ovs-dpdk-sriov-hci
       - rhoso-architecture-validate-nova-three-cells

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -70,6 +70,27 @@
       cifmw_architecture_scenario: hci-adoption
 - job:
     files:
+    - automation/net-env/multi-namespace.yaml
+    - examples/va/multi-namespace/control-plane
+    - examples/va/multi-namespace/control-plane/networking
+    - examples/va/multi-namespace/control-plane/networking/nncp
+    - examples/va/multi-namespace/control-plane2
+    - examples/va/multi-namespace/control-plane2/networking
+    - examples/va/multi-namespace/control-plane2/networking/nncp
+    - examples/va/multi-namespace/edpm
+    - examples/va/multi-namespace/edpm/nodeset
+    - examples/va/multi-namespace/edpm2
+    - examples/va/multi-namespace/edpm2/nodeset
+    - examples/va/multi-namespace/namespace
+    - lib
+    - va/multi-namespace
+    name: rhoso-architecture-validate-multi-namespace
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: multi-namespace
+      cifmw_networking_env_def_file: automation/net-env/multi-namespace.yaml
+- job:
+    files:
     - examples/va/nfv/ovs-dpdk-sriov/nncp
     - lib
     name: rhoso-architecture-validate-nfv-ovs-dpdk-sriov-adoption


### PR DESCRIPTION
An architecture that represents a basic dual-namespace layout where a single RHOSO installation (which is, of course, the only option) is used to deploy two OSP clouds in separate namespaces (`openstack`, `openstack2`) within a single OCP cluster.

Depends-on: https://github.com/openstack-k8s-operators/ci-framework/pull/2941

Jira: [OSPRH-15434](https://issues.redhat.com//browse/OSPRH-15434)