### PR TITLE
Update external unideltaipv6

### DIFF
--- a/automation/net-env/uni04delta-ipv6-adoption.yaml
+++ b/automation/net-env/uni04delta-ipv6-adoption.yaml
@@ -541,7 +541,6 @@ networks:
             start: 2620:cf:cf:cf02::130
             start_host: 130
         ipv4_ranges: []
-    vlan_id: 22
   internalapi:
     dns_v4: []
     dns_v6: []

--- a/automation/net-env/uni04delta-ipv6.yaml
+++ b/automation/net-env/uni04delta-ipv6.yaml
@@ -541,7 +541,6 @@ networks:
             start: 2620:cf:cf:cf02::130
             start_host: 130
         ipv4_ranges: []
-    vlan_id: 22
   internalapi:
     dns_v4: []
     dns_v6: []


### PR DESCRIPTION
The external doesn't need the vlan.
Follow the external config:
https://github.com/openstack-k8s-operators/architecture/blob/main/examples/dt/uni04delta-ipv6/control-plane/networking/nncp/values.yaml#L179C1-L188C14