### PR TITLE
[uni07eta] Configure glance with cinder_volume_type=multiattach

### DIFF
--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -51,6 +51,7 @@ data:
       cinder_store_project_name = service
       cinder_catalog_info = volumev3::internalURL
       cinder_use_multipath = true
+      cinder_volume_type = multiattach
       [oslo_concurrency]
       lock_path = /var/lib/glance/tmp
     databaseInstance: openstack


### PR DESCRIPTION
This is configured to allow two computes to create VMs based on a common image simultaneously.

[OSPRH-16089](https://issues.redhat.com//browse/OSPRH-16089)
[OSPCIX-768](https://issues.redhat.com//browse/OSPCIX-768)