### PR TITLE
ci_dcn_site: Set cross_az_attach at nova-api

### DIFF
--- a/examples/dt/dcn/control-plane/scaledown/service-values.yaml
+++ b/examples/dt/dcn/control-plane/scaledown/service-values.yaml
@@ -203,6 +203,8 @@ data:
     customServiceConfig: |
       [DEFAULT]
       default_schedule_zone=az0
+      [cinder]
+      cross_az_attach = False
     metadataServiceTemplate:
       enabled: false
     cellTemplates:

--- a/examples/dt/dcn/service-values.yaml
+++ b/examples/dt/dcn/service-values.yaml
@@ -275,6 +275,8 @@ data:
     customServiceConfig: |
       [DEFAULT]
       default_schedule_zone=az0
+      [cinder]
+      cross_az_attach=False
     metadataServiceTemplate:
       enabled: false
     cellTemplates:


### PR DESCRIPTION
We set the cross_az_attach to False at the
nova compute level and we should set it at
the nova api level too.