### PR TITLE
[BGP][EDPM] Postpone validate-network after frr

### DIFF
--- a/examples/dt/bgp-l3-xl/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r0/values.yaml
@@ -78,8 +78,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
@@ -193,10 +191,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - run-os
       - reboot-os
       - install-certs

--- a/examples/dt/bgp-l3-xl/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r1/values.yaml
@@ -78,8 +78,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
@@ -193,10 +191,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - run-os
       - reboot-os
       - install-certs

--- a/examples/dt/bgp-l3-xl/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r2/values.yaml
@@ -78,8 +78,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
@@ -193,10 +191,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - run-os
       - reboot-os
       - install-certs

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r0/values.yaml
@@ -75,8 +75,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_enable_chassis_gw: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
@@ -157,10 +155,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - ssh-known-hosts
       - run-os
       - reboot-os

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r1/values.yaml
@@ -75,8 +75,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_enable_chassis_gw: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
@@ -157,10 +155,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - ssh-known-hosts
       - run-os
       - reboot-os

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r2/values.yaml
@@ -75,8 +75,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_enable_chassis_gw: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
@@ -157,10 +155,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - ssh-known-hosts
       - run-os
       - reboot-os

--- a/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
@@ -75,8 +75,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
@@ -156,10 +154,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - run-os
       - reboot-os
       - install-certs

--- a/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
@@ -75,8 +75,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
@@ -156,10 +154,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - run-os
       - reboot-os
       - install-certs

--- a/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
@@ -75,8 +75,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
@@ -156,10 +154,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - run-os
       - reboot-os
       - install-certs

--- a/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
@@ -74,8 +74,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_enable_chassis_gw: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
@@ -156,10 +154,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - ssh-known-hosts
       - run-os
       - reboot-os

--- a/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
@@ -74,8 +74,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_enable_chassis_gw: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
@@ -156,10 +154,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - ssh-known-hosts
       - run-os
       - reboot-os

--- a/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
@@ -74,8 +74,6 @@ data:
             - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
             - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
             - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
-        edpm_nodes_validation_validate_controllers_icmp: false
-        edpm_nodes_validation_validate_gateway_icmp: false
         edpm_enable_chassis_gw: true
         edpm_sshd_allowed_ranges:
           - 192.168.122.0/24
@@ -156,10 +154,10 @@ data:
       - download-cache
       - bootstrap
       - configure-network
-      - validate-network
       - install-os
       - configure-os
       - frr
+      - validate-network
       - ssh-known-hosts
       - run-os
       - reboot-os


### PR DESCRIPTION
BGP jobs started failing at "validate-network" EDPM service deployment after [1] because FQDN cannot be resolved from them after "configure-network" is run. At that point, EDPM nodes have no default routes and, due to that, they cannot resolve via DNS their own domain.

The required routes are recovered when "frr" is run. Hence, the "validate-network" serice has to be moved after "frr".

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/622