### PR TITLE
[BGP] Set edpm_network_config_nmstate=false

### DIFF
--- a/examples/dt/bgp-l3-xl/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r0/values.yaml
@@ -37,6 +37,7 @@ data:
             nic2: 6a:fe:54:3f:8a:02  # CHANGEME
           edpm-r0-compute-1:
             nic2: 6b:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp-l3-xl/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r1/values.yaml
@@ -37,6 +37,7 @@ data:
             nic2: 6a:fe:54:3f:8a:02  # CHANGEME
           edpm-compute-1:
             nic2: 6b:fe:54:3f:8a:02
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp-l3-xl/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r2/values.yaml
@@ -37,6 +37,7 @@ data:
             nic2: 6a:fe:54:3f:8a:02  # CHANGEME
           edpm-r2-compute-1:
             nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r0/values.yaml
@@ -35,6 +35,7 @@ data:
         edpm_network_config_os_net_config_mappings:
           edpm-r0-networker-0:
             nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r1/values.yaml
@@ -35,6 +35,7 @@ data:
         edpm_network_config_os_net_config_mappings:
           edpm-r1-networker-0:
             nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r2/values.yaml
@@ -35,6 +35,7 @@ data:
         edpm_network_config_os_net_config_mappings:
           edpm-r2-networker-0:
             nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
@@ -34,6 +34,7 @@ data:
         edpm_network_config_os_net_config_mappings:
           edpm-r0-compute-0:
             nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
@@ -34,6 +34,7 @@ data:
         edpm_network_config_os_net_config_mappings:
           edpm-r1-compute-0:
             nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
@@ -34,6 +34,7 @@ data:
         edpm_network_config_os_net_config_mappings:
           edpm-r2-compute-0:
             nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
@@ -34,6 +34,7 @@ data:
         edpm_network_config_os_net_config_mappings:
           edpm-r0-networker-0:
             nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
@@ -34,6 +34,7 @@ data:
         edpm_network_config_os_net_config_mappings:
           edpm-r1-networker-0:
             nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}

--- a/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
@@ -34,6 +34,7 @@ data:
         edpm_network_config_os_net_config_mappings:
           edpm-r2-networker-0:
             nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
         edpm_network_config_template: |
           ---
           {% set mtu_list = [ctlplane_mtu] %}


### PR DESCRIPTION
Default value was changed to true (NM is used instead of ifcfg) with [1].
With the new default value, os-net-config fails on BGP setups.

Related-Bug: [OSPRH-17472](https://issues.redhat.com//browse/OSPRH-17472)

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/908