### PR TITLE
Add WatcherPassword to osp-secrets

### DIFF
--- a/lib/control-plane/osp-secrets.env
+++ b/lib/control-plane/osp-secrets.env
@@ -36,3 +36,4 @@ OctaviaPassword=12345678
 PlacementDatabasePassword=12345678
 PlacementPassword=12345678
 SwiftPassword=12345678
+WatcherPassword=12345678


### PR DESCRIPTION
Currently watcher-operator is shipped standalone operator. It is installed via custom playbook in uni03gamma job.

In order to start the deployment, we need to add watcherpassword to osp-secrets.