### PR TITLE
Update Nodeset2 to intake nova-extra configuration

### DIFF
--- a/dt/uni05epsilon/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset/kustomization.yaml
@@ -360,7 +360,7 @@ replacements:
   #
   - source:
       kind: ConfigMap
-      name: service-values
+      name: edpm-nodeset-values-post-ceph
       fieldPath: data.nova-extra-config
     targets:
       - select:

--- a/dt/uni05epsilon/edpm-post-ceph/nodeset2/kustomization.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset2/kustomization.yaml
@@ -46,3 +46,19 @@ replacements:
           - spec.services
         options:
           create: true
+
+  #
+  # Nova
+  #
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset2-values-post-ceph
+      fieldPath: data.nova-extra-config
+    targets:
+      - select:
+          kind: ConfigMap
+          name: nova-custom-config
+        fieldPaths:
+          - data.55-nova-extra\.conf
+        options:
+          create: true

--- a/examples/dt/uni05epsilon/nodeset2/values.yaml
+++ b/examples/dt/uni05epsilon/nodeset2/values.yaml
@@ -30,3 +30,6 @@ data:
       - neutron-metadata
       - libvirt
       - nova-custom-cell2
+
+  nova-extra-config: |
+    # Additional overrides that can be set in environment-specific cases

--- a/examples/dt/uni05epsilon/service-values.yaml
+++ b/examples/dt/uni05epsilon/service-values.yaml
@@ -144,8 +144,5 @@ data:
       rabbitmq-cell2:
         replicas: 3
 
-  nova-extra-config: |
-    # Additional overrides that can be set in environment-specific cases
-
   swift:
     enabled: true

--- a/examples/dt/uni05epsilon/values.yaml
+++ b/examples/dt/uni05epsilon/values.yaml
@@ -30,3 +30,6 @@ data:
       - neutron-metadata
       - libvirt
       - nova-custom
+
+  nova-extra-config: |
+    # Additional overrides that can be set in environment-specific cases


### PR DESCRIPTION
Also move existing nova-extra-config from service-values
to the edpm-nodeset-values-post-ceph. This allows setting
dedicated extra config for nova-compute for each nova cell.
Before this change, the possibility of setting extra configuration
got broken, as the nova-extra-config resource was generated
in dt/uni05epsilon/edpm-post-ceph/nodeset2/kustomization.yaml
with default value again, shadowing the desired value that
was set in the previous deployment stage.