### PR TITLE
Update Nodeset2 to intake nova-extra configuration

### DIFF
--- a/dt/uni05epsilon/edpm-post-ceph/nodeset2/kustomization.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset2/kustomization.yaml
@@ -46,3 +46,33 @@ replacements:
           - spec.services
         options:
           create: true
+
+  #
+  # Nova
+  #
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset2-values-post-ceph
+      fieldPath: data.nova-extra-config
+    targets:
+      - select:
+          kind: ConfigMap
+          name: nova-custom-config
+        fieldPaths:
+          - data.55-nova-extra\.conf
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset2-values-post-ceph
+      fieldPath: data.nova-custom-config
+    targets:
+      - select:
+          kind: ConfigMap
+          name: nova-custom-config
+        fieldPaths:
+          - data.25-nova-custom\.conf
+        options:
+          create: true
+

--- a/examples/dt/uni05epsilon/nodeset2/values.yaml
+++ b/examples/dt/uni05epsilon/nodeset2/values.yaml
@@ -30,3 +30,10 @@ data:
       - neutron-metadata
       - libvirt
       - nova-custom-cell2
+  nova-custom-config: |
+    [DEFAULT]
+    # Override our defaults in this dt to get coverage for metadata-api based
+    # cloud-init scenarios
+    force_config_drive = True
+  nova-extra-config: |
+    # Additional overrides that can be set in environment-specific cases


### PR DESCRIPTION
Nodeset2 was not utilizing the nova-extra-configuration being supplied to the job and instead was just applying the default value.  This updates nodeset2 to update the configmap for nova-extra and nova-custom if a value is supplied.