### PR TITLE
Increase timeout for openstack-edpm deployment

### DIFF
--- a/automation/vars/multi-namespace.yaml
+++ b/automation/vars/multi-namespace.yaml
@@ -158,11 +158,11 @@ vas:
           - >-
             oc -n openstack wait
             osdpns openstack-edpm --for condition=Ready
-            --timeout=30m
+            --timeout=60m
           - >-
             oc -n openstack2 wait
             osdpns openstack-edpm --for condition=Ready
-            --timeout=30m
+            --timeout=60m
         values:
           - name: edpm-deployment2-values
             src_file: values.yaml


### PR DESCRIPTION
On smaller hypervisors it takes about ~32 minutes, so greater value would provide us safer boundary, while still in jobs we would not waste too much time in case of something really going wrong there.