### PR TITLE
[hci] Make the timeout for edpm post ceph deployment longer

### DIFF
--- a/automation/vars/hci.yaml
+++ b/automation/vars/hci.yaml
@@ -90,7 +90,7 @@ vas:
           - >-
             oc -n openstack wait
             osdpns openstack-edpm --for condition=Ready
-            --timeout=40m
+            --timeout=60m
         values:
           - name: edpm-deployment-values-post-ceph
             src_file: values.yaml


### PR DESCRIPTION
We see quite often jobs failing on timeout in the stage edpm-post-ceph-deployment. When checking afterwards all the deployment are fine they just took more time. The extra 20m should provide safe margin to avoid this situation. 