### PR TITLE
18.0-fr3 Add designate to uni04delta

### DIFF
--- a/automation/net-env/uni04delta-adoption.yaml
+++ b/automation/net-env/uni04delta-adoption.yaml
@@ -191,6 +191,26 @@ instances:
         network_name: ctlplane
         prefix_length_v4: 24
         skip_nm: false
+      designate:
+        interface_name: enp6s0.24
+        ip_v4: 172.26.0.10
+        mac_addr: '52:54:00:18:b0:f6'
+        mtu: 1500
+        network_name: designate
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 24
+        prefix_length_v4: 24
+      designateext:
+        interface_name: enp6s0.34
+        ip_v4: 172.34.0.10
+        mac_addr: '52:54:00:18:c0:f6'
+        mtu: 1500
+        network_name: designateext
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 34
+        prefix_length_v4: 24
       internalapi:
         interface_name: enp6s0.120
         ip_v4: 172.17.0.10
@@ -248,6 +268,26 @@ instances:
         network_name: ctlplane
         prefix_length_v4: 24
         skip_nm: false
+      designate:
+        interface_name: enp6s0.24
+        ip_v4: 172.26.0.11
+        mac_addr: '52:54:00:18:b0:f7'
+        mtu: 1500
+        network_name: designate
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 24
+        prefix_length_v4: 24
+      designateext:
+        interface_name: enp6s0.34
+        ip_v4: 172.34.0.11
+        mac_addr: '52:54:00:18:c0:f7'
+        mtu: 1500
+        network_name: designateext
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 34
+        prefix_length_v4: 24
       internalapi:
         interface_name: enp6s0.120
         ip_v4: 172.17.0.11
@@ -305,6 +345,26 @@ instances:
         network_name: ctlplane
         prefix_length_v4: 24
         skip_nm: false
+      designate:
+        interface_name: enp6s0.24
+        ip_v4: 172.26.0.12
+        mac_addr: '52:54:00:18:b0:f8'
+        mtu: 1500
+        network_name: designate
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 24
+        prefix_length_v4: 24
+      designateext:
+        interface_name: enp6s0.34
+        ip_v4: 172.34.0.12
+        mac_addr: '52:54:00:18:c0:f8'
+        mtu: 1500
+        network_name: designateext
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 34
+        prefix_length_v4: 24
       internalapi:
         interface_name: enp6s0.120
         ip_v4: 172.17.0.12
@@ -558,6 +618,70 @@ networks:
             start: 192.168.122.100
             start_host: 100
         ipv6_ranges: []
+  designate:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: designate
+    network_v4: 172.26.0.0/24
+    search_domain: designate.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.26.0.90
+            end_host: 90
+            length: 11
+            start: 172.26.0.80
+            start_host: 80
+            ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.26.0.70
+            end_host: 70
+            length: 41
+            start: 172.26.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.26.0.200
+            end_host: 200
+            length: 101
+            start: 172.26.0.100
+        ipv6_ranges: []
+    vlan_id: 24
+  designateext:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: designateext
+    network_v4: 172.34.0.0/24
+    search_domain: designateext.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.34.0.90
+            end_host: 90
+            length: 11
+            start: 172.34.0.80
+            start_host: 80
+            ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.34.0.70
+            end_host: 70
+            length: 41
+            start: 172.34.0.30
+            start_host: 30
+            ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.34.0.200
+            end_host: 200
+            length: 101
+            start: 172.34.0.100
+        ipv6_ranges: []
+    vlan_id: 34
   external:
     dns_v4:
       - 10.46.22.128

--- a/automation/net-env/uni04delta.yaml
+++ b/automation/net-env/uni04delta.yaml
@@ -191,6 +191,26 @@ instances:
         network_name: ctlplane
         prefix_length_v4: 24
         skip_nm: false
+      designate:
+        interface_name: enp6s0.24
+        ip_v4: 172.26.0.10
+        mac_addr: '52:54:00:18:b0:f6'
+        mtu: 1500
+        network_name: designate
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 24
+        prefix_length_v4: 24
+      designateext:
+        interface_name: enp6s0.34
+        ip_v4: 172.34.0.10
+        mac_addr: '52:54:00:18:c0:f6'
+        mtu: 1500
+        network_name: designateext
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 34
+        prefix_length_v4: 24
       internalapi:
         interface_name: enp6s0.120
         ip_v4: 172.17.0.10
@@ -248,6 +268,26 @@ instances:
         network_name: ctlplane
         prefix_length_v4: 24
         skip_nm: false
+      designate:
+        interface_name: enp6s0.24
+        ip_v4: 172.26.0.11
+        mac_addr: '52:54:00:18:b0:f7'
+        mtu: 1500
+        network_name: designate
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 24
+        prefix_length_v4: 24
+      designateext:
+        interface_name: enp6s0.34
+        ip_v4: 172.34.0.11
+        mac_addr: '52:54:00:18:c0:f7'
+        mtu: 1500
+        network_name: designateext
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 34
+        prefix_length_v4: 24
       internalapi:
         interface_name: enp6s0.120
         ip_v4: 172.17.0.11
@@ -305,6 +345,26 @@ instances:
         network_name: ctlplane
         prefix_length_v4: 24
         skip_nm: false
+      designate:
+        interface_name: enp6s0.24
+        ip_v4: 172.26.0.12
+        mac_addr: '52:54:00:18:b0:f8'
+        mtu: 1500
+        network_name: designate
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 24
+        prefix_length_v4: 24
+      designateext:
+        interface_name: enp6s0.34
+        ip_v4: 172.34.0.12
+        mac_addr: '52:54:00:18:c0:f8'
+        mtu: 1500
+        network_name: designateext
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 34
+        prefix_length_v4: 24
       internalapi:
         interface_name: enp6s0.120
         ip_v4: 172.17.0.12
@@ -558,6 +618,70 @@ networks:
             start: 192.168.122.100
             start_host: 100
         ipv6_ranges: []
+  designate:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: designate
+    network_v4: 172.26.0.0/24
+    search_domain: designate.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.26.0.90
+            end_host: 90
+            length: 11
+            start: 172.26.0.80
+            start_host: 80
+            ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.26.0.70
+            end_host: 70
+            length: 41
+            start: 172.26.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.26.0.200
+            end_host: 200
+            length: 101
+            start: 172.26.0.100
+        ipv6_ranges: []
+    vlan_id: 24
+  designateext:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: designateext
+    network_v4: 172.34.0.0/24
+    search_domain: designateext.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.34.0.90
+            end_host: 90
+            length: 11
+            start: 172.34.0.80
+            start_host: 80
+            ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.34.0.70
+            end_host: 70
+            length: 41
+            start: 172.34.0.30
+            start_host: 30
+            ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.34.0.200
+            end_host: 200
+            length: 101
+            start: 172.34.0.100
+        ipv6_ranges: []
+    vlan_id: 34
   external:
     dns_v4:
       - 10.46.22.128

--- a/dt/uni04delta/kustomization.yaml
+++ b/dt/uni04delta/kustomization.yaml
@@ -31,3 +31,63 @@ replacements:
           - spec.neutron.template.customServiceConfig
         options:
           create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate-redis.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.redis.templates.designate-redis.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate-redis.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.redis.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.designate.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate.bind9Services
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.designate.template.designateBackendbind9.override
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate.nsRecords
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.designate.template.nsRecords
+        options:
+          create: true

--- a/dt/uni04delta/networking/kustomization.yaml
+++ b/dt/uni04delta/networking/kustomization.yaml
@@ -20,6 +20,10 @@ components:
   - ../../../lib/networking/metallb
   - ../../../lib/networking/netconfig
   - ../../../lib/networking/nad
+  - metallb
+
+resources:
+  - nad.yaml
 
 patches:
   - target:
@@ -32,6 +36,22 @@ patches:
         value:
           dnsDomain: _replaced_
           name: storagemgmt
+          subnets:
+            - _replaced_
+          mtu: 1500
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: designate
+          subnets:
+            - _replaced_
+          mtu: 1500
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: designateext
           subnets:
             - _replaced_
           mtu: 1500
@@ -66,3 +86,85 @@ replacements:
           kind: NetConfig
         fieldPaths:
           - spec.networks.[name=storagemgmt].subnets
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designate].dnsDomain
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designate].mtu
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designate].subnets
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designateext].dnsDomain
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designateext].mtu
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designateext].subnets
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: designate
+        fieldPaths:
+          - spec.config
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: designateext
+        fieldPaths:
+          - spec.config

--- a/dt/uni04delta/networking/metallb/kustomization.yaml
+++ b/dt/uni04delta/networking/metallb/kustomization.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - l2advertisement.yaml
+  - pools.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.lb_addresses
+    targets:
+      - select:
+          kind: IPAddressPool
+          name: designate
+        fieldPaths:
+          - spec.addresses
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.lb_addresses
+    targets:
+      - select:
+          kind: IPAddressPool
+          name: designateext
+        fieldPaths:
+          - spec.addresses
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.iface
+    targets:
+      - select:
+          group: metallb.io
+          kind: L2Advertisement
+          name: designate
+        fieldPaths:
+          - spec.interfaces.0
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.iface
+    targets:
+      - select:
+          group: metallb.io
+          kind: L2Advertisement
+          name: designateext
+        fieldPaths:
+          - spec.interfaces.0

--- a/dt/uni04delta/networking/metallb/l2advertisement.yaml
+++ b/dt/uni04delta/networking/metallb/l2advertisement.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: designate
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - designate
+  interfaces:
+    - _replaced_
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: designateext
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - designateext
+  interfaces:
+    - _replaced_

--- a/dt/uni04delta/networking/metallb/pools.yaml
+++ b/dt/uni04delta/networking/metallb/pools.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: designate
+  labels:
+    osp/lb-addresses-type: standard
+spec:
+  addresses:
+    - __replaced__
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: designateext
+  labels:
+    osp/lb-addresses-type: standard
+spec:
+  addresses:
+    - __replaced__

--- a/dt/uni04delta/networking/nad.yaml
+++ b/dt/uni04delta/networking/nad.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: designate
+  labels:
+    osp/net: designate
+    osp/net-attach-def-type: standard
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: designateext
+  labels:
+    osp/net: designateext
+    osp/net-attach-def-type: standard

--- a/dt/uni04delta/networking/nncp/kustomization.yaml
+++ b/dt/uni04delta/networking/nncp/kustomization.yaml
@@ -1,0 +1,363 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/nncp
+
+patches:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-0
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Designate vlan host interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: "24"
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          name: designate
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-1
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Designate vlan host interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: "24"
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          name: designate
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-2
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Designate vlan host interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: "24"
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          name: designate
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-0
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Designate external vlan host interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: "24"
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          name: designateext
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-1
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Designate external vlan host interface
+          name: designateext
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: "24"
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+
+
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-2
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Designate external vlan host interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: "24"
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          name: designateext
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].vlan.id
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.designate_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].vlan.id
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.designate_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].vlan.id
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.designate_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].vlan.id
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.designateext_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].vlan.id
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.designateext_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].vlan.base-iface
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].vlan.id
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.designateext_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].ipv4.address.0.ip

--- a/examples/dt/uni04delta/README.md
+++ b/examples/dt/uni04delta/README.md
@@ -38,6 +38,8 @@ and Manila OpenStack services configured with Ceph.
 | Storage | VLAN tagged |
 | Tenant | VLAN tagged |
 | StorageManagement | VLAN tagged |
+| Designate | VLAN tagged |
+| Designateext | VLAN tagged |
 
 ### Services, enabled features and configurations
 
@@ -50,6 +52,7 @@ and Manila OpenStack services configured with Ceph.
 | RGW as Swift     | ---             | Must have          |
 | Horizon          | N/A             | Must have          |
 | Barbican         |                 | Must have          |
+| Designate        |                 | Must have          |
 
 #### Support services
 

--- a/examples/dt/uni04delta/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/dt/uni04delta/control-plane/networking/nncp/kustomization.yaml
@@ -17,7 +17,7 @@ transformers:
           create: true
 
 components:
-  - ../../../../../../lib/nncp
+  - ../../../../../../dt/uni04delta/networking/nncp
 
 resources:
   - values.yaml

--- a/examples/dt/uni04delta/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/uni04delta/control-plane/networking/nncp/values.yaml
@@ -16,18 +16,24 @@ data:
     tenant_ip: 172.19.0.5
     ctlplane_ip: 192.168.122.10
     storage_ip: 172.18.0.5
+    designate_ip: 172.26.0.5
+    designateext_ip: 172.34.0.5
   node_1:
     name: master-1
     internalapi_ip: 172.17.0.6
     tenant_ip: 172.19.0.6
     ctlplane_ip: 192.168.122.11
     storage_ip: 172.18.0.6
+    designate_ip: 172.26.0.6
+    designateext_ip: 172.34.0.6
   node_2:
     name: master-2
     internalapi_ip: 172.17.0.7
     tenant_ip: 172.19.0.7
     ctlplane_ip: 192.168.122.12
     storage_ip: 172.18.0.7
+    designate_ip: 172.26.0.7
+    designateext_ip: 172.34.0.7
 
   ctlplane:
     dnsDomain: ctlplane.example.com
@@ -60,6 +66,64 @@ data:
           "range": "192.168.122.0/24",
           "range_start": "192.168.122.30",
           "range_end": "192.168.122.70"
+        }
+      }
+
+  designate:
+    dnsDomain: designate.example.com
+    mtu: 9000
+    prefix-length: 24
+    iface: designate
+    vlan: 24
+    subnets:
+      - allocationRanges:
+          - end: 172.26.0.250
+            start: 172.26.0.100
+        cidr: 172.26.0.0/24
+        name: subnet1
+    lb_addresses:
+      - 172.26.0.80-172.26.0.120
+    base_iface: enp6s0
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "designate",
+        "type": "macvlan",
+        "master": "designate",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.26.0.0/24",
+          "range_start": "172.26.0.30",
+          "range_end": "172.26.0.70"
+        }
+      }
+
+  designateext:
+    dnsDomain: designateext.example.com
+    mtu: 9000
+    prefix-length: 24
+    iface: designateext
+    vlan: 34
+    base_iface: enp6s0
+    subnets:
+      - allocationRanges:
+          - end: 172.34.0.250
+            start: 172.34.0.100
+        cidr: 172.34.0.0/24
+        name: subnet1
+    lb_addresses:
+      - 172.34.0.80-172.34.0.120
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "designateext",
+        "type": "macvlan",
+        "master": "designateext",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.34.0.0/24",
+          "range_start": "172.34.0.30",
+          "range_end": "172.34.0.70"
         }
       }
 

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -32,6 +32,41 @@ data:
         rbd_flatten_volume_from_snapshot = False
         rbd_secret_uuid = _replaced_
 
+  designate-redis:
+    enabled: true
+    replicas: 1
+
+  designate:
+    enabled: false
+    nsRecords:
+      - hostname: ns1.example.org.
+        priority: 1
+      - hostname: ns2.example.org.
+        priority: 2
+    bind9Services:
+      services:
+        - metadata:
+            annotations:
+              metallb.universe.tf/address-pool: designateext
+              metallb.universe.tf/allow-shared-ip: designateext
+              metallb.universe.tf/LoadBalancerIPs: 172.34.0.80
+          spec:
+            type: LoadBalancer
+        - metadata:
+            annotations:
+              metallb.universe.tf/address-pool: designateext
+              metallb.universe.tf/allow-shared-ip: designateext
+              metallb.universe.tf/LoadBalancerIPs: 172.34.0.81
+          spec:
+            type: LoadBalancer
+        - metadata:
+            annotations:
+              metallb.universe.tf/address-pool: designateext
+              metallb.universe.tf/allow-shared-ip: designateext
+              metallb.universe.tf/LoadBalancerIPs: 172.34.0.82
+          spec:
+            type: LoadBalancer
+
   glance:
     customServiceConfig: |
       [DEFAULT]

--- a/lib/control-plane/kustomization.yaml
+++ b/lib/control-plane/kustomization.yaml
@@ -34,6 +34,7 @@ replacements:
           - spec.nova.template.metadataServiceTemplate.override.service.metadata.annotations
           - spec.placement.template.override.service.internal.metadata.annotations
           - spec.swift.template.swiftProxy.override.service.internal.metadata.annotations
+          - spec.designate.template.designateAPI.override.service.internal.metadata.annotations
         options:
           create: true
   - source:
@@ -114,6 +115,7 @@ replacements:
           - spec.storageClass
           - spec.glance.template.storage.storageClass
           - spec.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageClass
+          - spec.designate.template.designateBackendbind9.storageClass
   - source:
       kind: ConfigMap
       name: network-values

--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -42,6 +42,43 @@ spec:
       cinderVolumes: {}
       databaseInstance: openstack
       secret: osp-secret
+  designate:
+    enabled: false
+    template:
+      customServiceConfig: |
+        [DEFAULT]
+        debug = true
+      designateAPI:
+        replicas: 3
+      designateBackendbind9:
+        networkAttachments:
+          - designate
+        replicas: 3
+        storageClass: _replaced_
+        storageRequest: 10G
+      designateCentral:
+        replicas: 1
+      designateMdns:
+        replicas: 3
+        networkAttachments:
+          - designate
+      designateProducer:
+        replicas: 2
+        networkAttachments:
+          - designate
+      designateWorker:
+        replicas: 3
+        networkAttachments:
+          - designate
+      designateUnbound:
+        replicas: 1
+        networkAttachments:
+          - designate
+      nsRecords:
+        - hostname: ns1.example.org.
+          priority: 1
+        - hostname: ns2.example.org.
+          priority: 2
   dns:
     template:
       options: []


### PR DESCRIPTION
Adds the required networking elements, enables redis instance and sets up flag for enabling designate in the dt.