### PR TITLE
Add namespace replacement for openstack-catalog and subscription

### DIFF
--- a/examples/common/olm-subscriptions/values.yaml
+++ b/examples/common/olm-subscriptions/values.yaml
@@ -15,3 +15,4 @@ data:
     openstack-operator-catalog-source: "openstack-operator-index"
     openstack-operator-subscription-namespace: "openstack-operators"
     openstack-operator-version: "latest"
+    openstack-catalog-namespace: "openstack-operators"

--- a/lib/olm-openstack-subscriptions/overlays/default/kustomization.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/default/kustomization.yaml
@@ -21,6 +21,16 @@ replacements:
   - source:
       kind: ConfigMap
       name: olm-values
+      fieldPath: data.openstack-catalog-namespace
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - metadata.namespace
+  - source:
+      kind: ConfigMap
+      name: olm-values
       fieldPath: data.openstack-operator-publisher
     targets:
       - select:
@@ -99,3 +109,13 @@ replacements:
           labelSelector: category=openstack-subscription
         fieldPaths:
           - spec.startingCSV
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-catalog-namespace
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.sourceNamespace

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.3/kustomization.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.3/kustomization.yaml
@@ -42,6 +42,16 @@ replacements:
   - source:
       kind: ConfigMap
       name: olm-values
+      fieldPath: data.openstack-catalog-namespace
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - metadata.namespace
+  - source:
+      kind: ConfigMap
+      name: olm-values
       fieldPath: data.openstack-operator-publisher
     targets:
       - select:
@@ -110,3 +120,13 @@ replacements:
           labelSelector: category=openstack-subscription
         fieldPaths:
           - spec.source
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-catalog-namespace
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.sourceNamespace

--- a/lib/olm-openstack-subscriptions/overlays/v1.0.6/kustomization.yaml
+++ b/lib/olm-openstack-subscriptions/overlays/v1.0.6/kustomization.yaml
@@ -41,6 +41,16 @@ replacements:
   - source:
       kind: ConfigMap
       name: olm-values
+      fieldPath: data.openstack-catalog-namespace
+    targets:
+      - select:
+          kind: CatalogSource
+          labelSelector: category=openstack-catalog
+        fieldPaths:
+          - metadata.namespace
+  - source:
+      kind: ConfigMap
+      name: olm-values
       fieldPath: data.openstack-operator-publisher
     targets:
       - select:
@@ -109,3 +119,13 @@ replacements:
           labelSelector: category=openstack-subscription
         fieldPaths:
           - spec.source
+  - source:
+      kind: ConfigMap
+      name: olm-values
+      fieldPath: data.openstack-catalog-namespace
+    targets:
+      - select:
+          kind: Subscription
+          labelSelector: category=openstack-subscription
+        fieldPaths:
+          - spec.sourceNamespace


### PR DESCRIPTION
Only for the olm-subscription part.

In the `lib/olm-openstack/subscription.yaml` file, used for most
deployments, the `CatalogSource` is using the `openstack-operators`
namespace.

In the `lib/olm-openstack-subscriptions/base/catalogsource.yaml`, the
`CatalogSource` is using the cluster-wide `openshift-marketplace`
namespace. This configuration is used for running update CI tests.

Both configurations work, but some CI tools are hardcoded to have the
`CatalogSource` set in the `openstack-operators` namespace.

To accommodate the CI tool, we add a new variable
`openstack-catalog-namespace` that can adjust the `CatalogSource`
namespace for the `olm-openstack-subscription`.

We switch the default to `openstack-operators` so all jobs are in line.

Closes: [OSPRH-18002](https://issues.redhat.com/browse/OSPRH-18002)