### PR TITLE
Remove control-plane from nodeset definition

### DIFF
--- a/dt/uni04delta/edpm/nodeset/kustomization.yaml
+++ b/dt/uni04delta/edpm/nodeset/kustomization.yaml
@@ -17,7 +17,6 @@ transformers:
       create: true
 
 components:
-  - ../../../../lib/control-plane
   - ../../../../lib/dataplane/nodeset
 
 resources:


### PR DESCRIPTION
Including the control-plane here causes kustomizations targeting the control plane to be ovewritten.