### PR TITLE
Set ovn-egress-iface=true for br-ex members

### DIFF
--- a/examples/dt/uni01alpha/edpm/values.yaml
+++ b/examples/dt/uni01alpha/edpm/values.yaml
@@ -49,6 +49,10 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni01alpha/networker/nodeset/values.yaml
+++ b/examples/dt/uni01alpha/networker/nodeset/values.yaml
@@ -65,6 +65,10 @@ data:
                   mtu: {{ min_viable_mtu }}
                   # force the MAC address of the bridge to this interface
                   primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni02beta/values.yaml
+++ b/examples/dt/uni02beta/values.yaml
@@ -49,6 +49,10 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni04delta-ipv6/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni04delta-ipv6/edpm-pre-ceph/nodeset/values.yaml
@@ -51,6 +51,10 @@ data:
               mtu: {{ min_viable_mtu }}
               # force the MAC address of the bridge to this interface
               primary: true
+              # this ovs_extra configuration fixes OSPRH-17551, but it will
+              # be not needed when FDP-1472 is resolved
+              ovs_extra:
+                - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
             - type: vlan
               mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni04delta-ipv6/values.yaml
+++ b/examples/dt/uni04delta-ipv6/values.yaml
@@ -59,6 +59,10 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni04delta/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni04delta/edpm-pre-ceph/nodeset/values.yaml
@@ -51,6 +51,10 @@ data:
               mtu: {{ min_viable_mtu }}
               # force the MAC address of the bridge to this interface
               primary: true
+              # this ovs_extra configuration fixes OSPRH-17551, but it will
+              # be not needed when FDP-1472 is resolved
+              ovs_extra:
+                - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
             - type: vlan
               mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni04delta/values.yaml
+++ b/examples/dt/uni04delta/values.yaml
@@ -59,6 +59,10 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni05epsilon/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni05epsilon/edpm-pre-ceph/nodeset/values.yaml
@@ -50,6 +50,10 @@ data:
                   mtu: {{ min_viable_mtu }}
                   # force the MAC address of the bridge to this interface
                   primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni05epsilon/nodeset2/edpm-pre-ceph/values.yaml
+++ b/examples/dt/uni05epsilon/nodeset2/edpm-pre-ceph/values.yaml
@@ -50,6 +50,10 @@ data:
                   mtu: {{ min_viable_mtu }}
                   # force the MAC address of the bridge to this interface
                   primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni06zeta/values.yaml
+++ b/examples/dt/uni06zeta/values.yaml
@@ -49,6 +49,10 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni07eta/edpm/values.yaml
+++ b/examples/dt/uni07eta/edpm/values.yaml
@@ -52,6 +52,10 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni07eta/networker/nodeset/values.yaml
+++ b/examples/dt/uni07eta/networker/nodeset/values.yaml
@@ -63,6 +63,10 @@ data:
                   mtu: {{ min_viable_mtu }}
                   # force the MAC address of the bridge to this interface
                   primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}


### PR DESCRIPTION
In order to fix [OSPRH-17551](https://issues.redhat.com//browse/OSPRH-17551) and make BW limits properly applied to physical ports (ports from neutron VLAN and flat networks), the br-ex member interfaces need to be configured with ovn-egress-iface=true.

This PR applies the change to all uni jobs.