### PR TITLE
Further increase uni03gamma timeout.

### DIFF
--- a/automation/vars/hci.yaml
+++ b/automation/vars/hci.yaml
@@ -90,7 +90,7 @@ vas:
           - >-
             oc -n openstack wait
             osdpns openstack-edpm --for condition=Ready
-            --timeout=60m
+            --timeout=80m
         values:
           - name: edpm-deployment-values-post-ceph
             src_file: values.yaml


### PR DESCRIPTION
While deploying on smaller hardware, I'm hitting that timeout now
regularly while testing update on non-trunk.

Try an even longer timeout to solve this.

Related to: [OSPRH-16618](https://issues.redhat.com/browse/OSPRH-16618)