### PR TITLE
[uni06zeta][neutron] remove log_dir

### DIFF
--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -104,7 +104,6 @@ data:
       l3_ha = False
       max_l3_agents_per_router = 3
       debug = true
-      log_dir = /var/log/neutron
       control_exchange = neutron
       [agent]
       report_interval = 300


### PR DESCRIPTION
The parameter log_dir was wrongly configured and, due to this, no neutron logs were written in uni06zeta jobs.