### PR TITLE
Increase glance haproxy+httpd timeout (for large images)

### DIFF
--- a/lib/control-plane/openstackcontrolplane.yaml
+++ b/lib/control-plane/openstackcontrolplane.yaml
@@ -98,11 +98,12 @@ spec:
     uniquePodNames: true
     apiOverrides:
       default:
-        route: {"haproxy.router.openshift.io/timeout": "60s"}
+        route: {}
     template:
       databaseInstance: openstack
       glanceAPIs:
         default:
+          apiTimeout: 600
           replicas: 0
           networkAttachments:
             - storage


### PR DESCRIPTION
Changing the apiOverride value for the defined glanceAPI affects both
the haproxy timeout and the glance httpd timeout.
This benefit the case where large images are uploaded and for some
reasons the deployment is slow, and avoids hitting a timeout.
This also needs to be combined with a bigger timeout in the client
used (for example, the tempest client in case of tests.)

Partially inspired by:
https://opendev.org/openstack/kolla-ansible/commit/ccb7952ddb4bf2e6e008eb15341efb0ed5355bc3
Thanks (in no particular order) Rajat Dhasmana, Francesco Pantano
and Brian Rosmaita for the help investigating some failures,
for the hints about timeouts in the client and the overall help.

This change removes the old way of configuring (though annotation) as
it seems it does not work anymore.
Even using what should be the new way, namely:

```
    apiOverrides:
      default:
        route:
          metadata:
            annotations:
              haproxy.router.openshift.io/timeout: 10m
```

does not seem to work, as the annotation value seems to be
read only and it restores to the internally configured value.