### PR TITLE
Update uni07eta to involve 3 compute nodes

### DIFF
--- a/examples/dt/uni07eta/README.md
+++ b/examples/dt/uni07eta/README.md
@@ -17,7 +17,7 @@ multiple backends and networker.
 | Role              | Machine Type | Count |
 | ----------------- | ------------ | ----- |
 | Compact OpenShift | vm           | 3     |
-| OpenStack Compute | vm           | 2     |
+| OpenStack Compute | vm           | 3     |
 | Networker         | vm           | 3     |
 
 ### Networks

--- a/examples/dt/uni07eta/edpm/values.yaml
+++ b/examples/dt/uni07eta/edpm/values.yaml
@@ -125,6 +125,22 @@ data:
           - name: tenant
             subnetName: subnet1
 
+      edpm-compute-2:
+        ansible:
+          ansibleHost: 192.168.122.102
+        hostName: edpm-compute-2
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.102
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+
     services:
       - bootstrap
       - download-cache


### PR DESCRIPTION
For Octavia active-standby, the testing requires
having at least 3 compute nodes, however so far
there were only 2 nodes defined in this scenario.
This commit alters the DT to match the current shape
defined in the downstream job.