### PR TITLE
Switch uni-delta jobs to use S3 API from Ceph

### DIFF
--- a/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
@@ -45,6 +45,8 @@ data:
       store_description = "RBD backend"
       rbd_store_pool = images
       rbd_store_user = openstack
+    customServiceConfigSecrets:
+      - s3glance
     glanceAPIs:
       default:
         replicas: 3

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -70,17 +70,15 @@ data:
   glance:
     customServiceConfig: |
       [DEFAULT]
-      debug = True
-      enabled_backends = default_backend:rbd
-
+      debug=true
+      enabled_backends = default_backend:s3
       [glance_store]
       default_backend = default_backend
-
       [default_backend]
-      rbd_store_ceph_conf = /etc/ceph/ceph.conf
-      store_description = "RBD backend"
-      rbd_store_pool = images
-      rbd_store_user = openstack
+      s3_store_create_bucket_on_put = True
+      s3_store_bucket_url_format = "path"
+    customServiceConfigSecrets:
+      - s3glance
     glanceAPIs:
       default:
         replicas: 3


### PR DESCRIPTION
Glance/RBD is already covered by uni-gamma, so uni-delta could be changed to test glance/S3 instead, using the S3 API provided by ceph.

https://issues.redhat.com/browse/OSPRH-11411