### PR TITLE
Move neutron customServiceConfig back to initial controlplane config

### DIFF
--- a/dt/uni04delta/edpm/nodeset/kustomization.yaml
+++ b/dt/uni04delta/edpm/nodeset/kustomization.yaml
@@ -129,18 +129,6 @@ replacements:
 
   - source:
       kind: ConfigMap
-      name: service-values
-      fieldPath: data.neutron.customServiceConfig
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.neutron.template.customServiceConfig
-        options:
-          create: true
-
-  - source:
-      kind: ConfigMap
       name: edpm-nodeset-values
       fieldPath: data.ceph.keyring
     targets:

--- a/dt/uni04delta/kustomization.yaml
+++ b/dt/uni04delta/kustomization.yaml
@@ -18,3 +18,16 @@ transformers:
 
 components:
   - ../../lib/control-plane
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.neutron.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.neutron.template.customServiceConfig
+        options:
+          create: true


### PR DESCRIPTION
This section was moved to the "nodeset" controlplane update when adding designate in a previous commit and it is probably better to have kept it as it was in case some of that configuration is required early.

Moved in commit cbdb5150f815d2af5c6414ae98b5b66c285f98d3