### PR TITLE
Increase glance and cinder timeouts (haproxy+httpd (and RPC))

### DIFF
--- a/lib/control-plane/base/openstackcontrolplane.yaml
+++ b/lib/control-plane/base/openstackcontrolplane.yaml
@@ -187,6 +187,7 @@ spec:
       route: {}
     template:
       secret: osp-secret
+      apiTimeout: 600
       apiServiceTemplate:
         replicas: 3
       metadataServiceTemplate:

--- a/lib/control-plane/base/openstackcontrolplane.yaml
+++ b/lib/control-plane/base/openstackcontrolplane.yaml
@@ -98,11 +98,12 @@ spec:
     uniquePodNames: true
     apiOverrides:
       default:
-        route: {"haproxy.router.openshift.io/timeout": "60s"}
+        route: {}
     template:
       databaseInstance: openstack
       glanceAPIs:
         default:
+          apiTimeout: 600
           replicas: 0
           networkAttachments:
             - storage

--- a/lib/control-plane/base/openstackcontrolplane.yaml
+++ b/lib/control-plane/base/openstackcontrolplane.yaml
@@ -25,8 +25,9 @@ spec:
   cinder:
     uniquePodNames: true
     apiOverride:
-      route: {"haproxy.router.openshift.io/timeout": "60s"}
+      route: {}
     template:
+      apiTimeout: 600
       cinderAPI:
         replicas: 3
       customServiceConfig: |


### PR DESCRIPTION
**Increase glance haproxy+httpd timeout (for large images)**

Forward port  ec4835438049f69d6ffbc48a4b9ae402f7b6e7db to lib/control-plane/base/openstackcontrolplane.yaml
Changing the apiOverride value for the defined glanceAPI affects both
the haproxy timeout and the glance httpd timeout.
This benefit the case where large images are uploaded and for some
reasons the deployment is slow, and avoids hitting a timeout.
This also needs to be combined with a bigger timeout in the client
used (for example, the tempest client in case of tests.)

Partially inspired by: 
https://opendev.org/openstack/kolla-ansible/commit/ccb7952ddb4bf2e6e008eb15341efb0ed5355bc3
Thanks (in no particular order) Rajat Dhasmana, Francesco Pantano
and Brian Rosmaita for the help investigating some failures,
for the hints about timeouts in the client and the overall help.

This change removes the old way of configuring (though annotation) as
it seems it does not work anymore.
Even using what should be the new way, namely:

```
    apiOverrides:
      default:
        route:
          metadata:
            annotations:
              haproxy.router.openshift.io/timeout: 10m 
```

does not seem to work, as the annotation value seems to be
read only and it restores to the internally configured value.

**Increase all timeouts for cinder (haproxy+httpd+RPC)**

This is useful for example when cinder is used as a glance backend and the creation of the image takes quite some time, as the may hit resource limits (it may be overloaded or simply small for testing purposes).

Also, remove the previous haproxy override (which seems to work, but apiTimeout applies to more settings.

Glance got a similar timeout increase in a previous change.

**Increase api (and more) timeouts for nova too**

It aligns with the timeouts set in previous changes on cinder and glance.