### PR TITLE
Allow setting TLS-related options

### DIFF
--- a/examples/dt/bgp-l3-xl/control-plane/service-values.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/service-values.yaml
@@ -6,7 +6,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   glance:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/bgp_dt01/control-plane/service-values.yaml
+++ b/examples/dt/bgp_dt01/control-plane/service-values.yaml
@@ -6,7 +6,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   glance:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/bgp_dt04_ipv6/control-plane/service-values.yaml
+++ b/examples/dt/bgp_dt04_ipv6/control-plane/service-values.yaml
@@ -6,7 +6,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   glance:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/bmo01/control-plane/service-values.yaml
+++ b/examples/dt/bmo01/control-plane/service-values.yaml
@@ -8,7 +8,12 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinderVolumes:
     lvm-iscsi:
       replicas: 1

--- a/examples/dt/dcn/control-plane/scaledown/service-values.yaml
+++ b/examples/dt/dcn/control-plane/scaledown/service-values.yaml
@@ -6,7 +6,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinder:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/dcn/control-plane/service-values.yaml
+++ b/examples/dt/dcn/control-plane/service-values.yaml
@@ -6,4 +6,10 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
+  _change_me: later

--- a/examples/dt/dcn/service-values.yaml
+++ b/examples/dt/dcn/service-values.yaml
@@ -7,7 +7,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinder:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/dz-storage/control-plane/service-values.yaml
+++ b/examples/dt/dz-storage/control-plane/service-values.yaml
@@ -9,8 +9,12 @@ data:
   storageClass: lvms-local-storage
   topologyRef:
     name: default-spread-pods
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
 
+  # --- Below are VA/DT-specific data ---
   memcached:
     # consider 1 replica per worker (this example uses less for testing)
     templates:

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/service-values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/service-values.yaml
@@ -14,7 +14,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/control-plane/service-values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/control-plane/service-values.yaml
@@ -14,7 +14,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/service-values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/service-values.yaml
@@ -14,7 +14,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   swift:
     enabled: false
   cinderAPI:

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/service-values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/service-values.yaml
@@ -14,7 +14,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/nova/nova-three-cells/control-plane/service-values.yaml
+++ b/examples/dt/nova/nova-three-cells/control-plane/service-values.yaml
@@ -8,7 +8,12 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   galera:
     templates:
       openstack-cell2:

--- a/examples/dt/nova/nova01alpha/service-values.yaml
+++ b/examples/dt/nova/nova01alpha/service-values.yaml
@@ -7,7 +7,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [ml2]

--- a/examples/dt/nova/nova02beta/service-values.yaml
+++ b/examples/dt/nova/nova02beta/service-values.yaml
@@ -7,7 +7,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [ml2]

--- a/examples/dt/nova/nova04delta/control-plane/service-values.yaml
+++ b/examples/dt/nova/nova04delta/control-plane/service-values.yaml
@@ -7,7 +7,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [ml2]

--- a/examples/dt/osasinfra-ipv6/control-plane/service-values.yaml
+++ b/examples/dt/osasinfra-ipv6/control-plane/service-values.yaml
@@ -6,4 +6,10 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
+  _change_me: later

--- a/examples/dt/osasinfra-ipv6/service-values.yaml
+++ b/examples/dt/osasinfra-ipv6/service-values.yaml
@@ -7,7 +7,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinderAPI:
     replicas: 3
   cinderBackup:

--- a/examples/dt/osasinfra/control-plane/service-values.yaml
+++ b/examples/dt/osasinfra/control-plane/service-values.yaml
@@ -6,4 +6,10 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
+  _change_me: later

--- a/examples/dt/osasinfra/service-values.yaml
+++ b/examples/dt/osasinfra/service-values.yaml
@@ -7,7 +7,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinderAPI:
     replicas: 3
   cinderBackup:

--- a/examples/dt/perfscale/scalelab/service-values.yaml
+++ b/examples/dt/perfscale/scalelab/service-values.yaml
@@ -6,7 +6,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/pidone/service-values.yaml
+++ b/examples/dt/pidone/service-values.yaml
@@ -7,7 +7,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   glance:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/uni01alpha/control-plane/service-values.yaml
+++ b/examples/dt/uni01alpha/control-plane/service-values.yaml
@@ -8,7 +8,12 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinderVolumes:
     lvm-iscsi:
       replicas: 1

--- a/examples/dt/uni02beta/control-plane/service-values.yaml
+++ b/examples/dt/uni02beta/control-plane/service-values.yaml
@@ -8,8 +8,12 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
 
+  # --- Below are VA/DT-specific data ---
   cinderBackup:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
@@ -6,8 +6,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
 
+  # --- Below are VA/DT-specific data ---
   cinderBackup:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/uni04delta/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta/control-plane/service-values.yaml
@@ -8,7 +8,12 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinderBackup:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -8,8 +8,12 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
 
+  # --- Below are VA/DT-specific data ---
   galera:
     templates:
       openstack-cell2:

--- a/examples/dt/uni05epsilon/service-values.yaml
+++ b/examples/dt/uni05epsilon/service-values.yaml
@@ -8,9 +8,13 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
   notificationsBusInstance: rabbitmq-notifications
+  tls:
+    caBundleSecretName: ""
 
+  # --- Below are VA/DT-specific data ---
   cinderBackup:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/uni06zeta/control-plane/service-values.yaml
+++ b/examples/dt/uni06zeta/control-plane/service-values.yaml
@@ -8,7 +8,12 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinderVolumes:
     lvm-nvme-tcp:
       replicas: 1

--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -8,7 +8,12 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinderVolumes:
     ontap-iscsi:
       customServiceConfig: |

--- a/examples/dt/uni09iota/control-plane/service-values.yaml
+++ b/examples/dt/uni09iota/control-plane/service-values.yaml
@@ -8,7 +8,12 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinderVolumes:
     pure-fc:
       nodeSelector:

--- a/examples/va/hci/control-plane/service-values.yaml
+++ b/examples/va/hci/control-plane/service-values.yaml
@@ -6,4 +6,10 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
+  _change_me: later

--- a/examples/va/hci/service-values.yaml
+++ b/examples/va/hci/service-values.yaml
@@ -7,8 +7,13 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
   notificationsBusInstance: rabbitmq-notifications
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   cinderAPI:
     replicas: 3
   cinderBackup:

--- a/examples/va/multi-namespace/control-plane/kustomization.yaml
+++ b/examples/va/multi-namespace/control-plane/kustomization.yaml
@@ -24,6 +24,7 @@ components:
   - ../../../../lib/control-plane/storage
   - ../../../../lib/control-plane/ovn-nic
   - ../../../../lib/control-plane/job-settings
+  - ../../../../lib/control-plane/tls
 
 resources:
   - networking/nncp/values.yaml

--- a/examples/va/multi-namespace/control-plane/service-values.yaml
+++ b/examples/va/multi-namespace/control-plane/service-values.yaml
@@ -6,7 +6,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   barbican:
     enabled: false
   cinderAPI:

--- a/examples/va/multi-namespace/control-plane2/kustomization.yaml
+++ b/examples/va/multi-namespace/control-plane2/kustomization.yaml
@@ -24,6 +24,7 @@ components:
   - ../../../../lib/control-plane/storage
   - ../../../../lib/control-plane/ovn-nic
   - ../../../../lib/control-plane/job-settings
+  - ../../../../lib/control-plane/tls
 
 resources:
   - networking/nncp/values.yaml

--- a/examples/va/multi-namespace/control-plane2/service-values.yaml
+++ b/examples/va/multi-namespace/control-plane2/service-values.yaml
@@ -6,7 +6,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   barbican:
     enabled: false
   cinderAPI:

--- a/examples/va/nfv/ovs-dpdk-networker/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-networker/service-values.yaml
@@ -14,7 +14,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
@@ -14,7 +14,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/va/nfv/ovs-dpdk/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk/service-values.yaml
@@ -14,7 +14,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/va/nfv/sriov/service-values.yaml
+++ b/examples/va/nfv/sriov/service-values.yaml
@@ -7,7 +7,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [ml2]

--- a/examples/va/nvidia-mdev/control-plane/service-values.yaml
+++ b/examples/va/nvidia-mdev/control-plane/service-values.yaml
@@ -6,7 +6,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/va/nvidia-vfio-passthrough/control-plane/service-values.yaml
+++ b/examples/va/nvidia-vfio-passthrough/control-plane/service-values.yaml
@@ -7,7 +7,12 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
+  # --- Fields required by lib/control-plane ---
   preserveJobs: false
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
   neutron:
     customServiceConfig: |
       [ml2]

--- a/lib/control-plane/base/openstackcontrolplane.yaml
+++ b/lib/control-plane/base/openstackcontrolplane.yaml
@@ -296,3 +296,4 @@ spec:
       logging:
         enabled: false
         port: 10514
+  tls: {}

--- a/lib/control-plane/kustomization.yaml
+++ b/lib/control-plane/kustomization.yaml
@@ -9,3 +9,4 @@ components:
   - storage
   - ovn-bridge
   - job-settings
+  - tls

--- a/lib/control-plane/tls/kustomization.yaml
+++ b/lib/control-plane/tls/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.tls
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.tls
+        options:
+          create: true

--- a/va/hci/kustomization.yaml
+++ b/va/hci/kustomization.yaml
@@ -24,3 +24,4 @@ components:
   - ../../lib/control-plane/storage
   - ../../lib/control-plane/ovn-nic
   - ../../lib/control-plane/job-settings
+  - ../../lib/control-plane/tls


### PR DESCRIPTION
This would allow us to define settings, such as `caBundleSecretName`,
which are useful in case of deployments that require establishing
connections with internal/local services, for example that utilize
self-signed certificates.