### PR TITLE
Use ceph playbook located in hooks if available

### DIFF
--- a/automation/vars/hci.yaml
+++ b/automation/vars/hci.yaml
@@ -67,7 +67,7 @@ vas:
         post_stage_run:
           - name: Deploy Ceph
             type: playbook
-            source: "../../playbooks/ceph.yml"
+            source: "../../hooks/playbooks/ceph.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
 
       - name: edpm-post-ceph-nodeset

--- a/automation/vars/osasinfra-ipv6.yaml
+++ b/automation/vars/osasinfra-ipv6.yaml
@@ -52,7 +52,7 @@ vas:
         post_stage_run:
           - name: Deploy Ceph
             type: playbook
-            source: "../../playbooks/ceph.yml"
+            source: "../../hooks/playbooks/ceph.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
 
       - path: examples/dt/osasinfra-ipv6

--- a/automation/vars/osasinfra.yaml
+++ b/automation/vars/osasinfra.yaml
@@ -50,7 +50,7 @@ vas:
         post_stage_run:
           - name: Deploy Ceph
             type: playbook
-            source: "../../playbooks/ceph.yml"
+            source: "../../hooks/playbooks/ceph.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
 
       - path: examples/dt/osasinfra

--- a/automation/vars/uni04delta-ipv6.yaml
+++ b/automation/vars/uni04delta-ipv6.yaml
@@ -68,7 +68,7 @@ vas:
         post_stage_run:
           - name: Deploy Ceph
             type: playbook
-            source: "../../playbooks/ceph.yml"
+            source: "../../hooks/playbooks/ceph.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
 
       - name: edpm-nodeset

--- a/automation/vars/uni04delta.yaml
+++ b/automation/vars/uni04delta.yaml
@@ -68,7 +68,7 @@ vas:
         post_stage_run:
           - name: Deploy Ceph
             type: playbook
-            source: "../../playbooks/ceph.yml"
+            source: "../../hooks/playbooks/ceph.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
 
       - name: edpm-nodeset

--- a/automation/vars/uni05epsilon.yaml
+++ b/automation/vars/uni05epsilon.yaml
@@ -83,7 +83,7 @@ vas:
         post_stage_run:
           - name: Deploy Ceph
             type: playbook
-            source: "../../playbooks/ceph.yml"
+            source: "../../hooks/playbooks/ceph.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
 
       - name: edpm-nodeset-post-ceph

--- a/examples/dt/uni04delta-ipv6/edpm-pre-ceph.md
+++ b/examples/dt/uni04delta-ipv6/edpm-pre-ceph.md
@@ -52,7 +52,7 @@
 
 # 11. Install Ceph
 
-    Use ci-framework/playbooks/ceph.yml and
+    Use ci-framework/hooks/playbooks/ceph.yml and
     ci-framework-data/artifacts/zuul_inventory.yml
 
 ```

--- a/examples/dt/uni04delta/edpm-pre-ceph.md
+++ b/examples/dt/uni04delta/edpm-pre-ceph.md
@@ -52,7 +52,7 @@
 
 # 11. Install Ceph
 
-    Use ci-framework/playbooks/ceph.yml and
+    Use ci-framework/hooks/playbooks/ceph.yml and
     ci-framework-data/artifacts/zuul_inventory.yml
 
 ```


### PR DESCRIPTION
The ceph playbook was moved to hooks/playbooks/ dir [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/3154

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3154