### PR TITLE
New uni09iota DT

### DIFF
--- a/automation/net-env/uni09iota.yaml
+++ b/automation/net-env/uni09iota.yaml
@@ -1,0 +1,382 @@
+---
+instances:
+  controller-0:
+    hostname: controller-0
+    name: controller-0
+    networks:
+      ctlplane:
+        interface_name: eth1
+        ip_v4: 192.168.122.9
+        mac_addr: "52:54:00:aa:40:6d"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+  ocp-0:
+    hostname: master-0
+    name: ocp-0
+    networks:
+      ctlplane:
+        interface_name: enp6s0
+        ip_v4: 192.168.122.10
+        mac_addr: "52:54:00:28:4f:f0"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi:
+        interface_name: enp6s0.120
+        ip_v4: 172.17.0.10
+        mac_addr: "52:54:00:56:0a:fb"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 120
+      storage:
+        interface_name: enp6s0.121
+        ip_v4: 172.18.0.10
+        mac_addr: "52:54:00:62:0d:a2"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 121
+      tenant:
+        interface_name: enp6s0.122
+        ip_v4: 172.19.0.10
+        mac_addr: "52:54:00:09:be:0e"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 122
+  ocp-1:
+    hostname: master-1
+    name: ocp-1
+    networks:
+      ctlplane:
+        interface_name: enp6s0
+        ip_v4: 192.168.122.11
+        mac_addr: "52:54:00:14:39:b5"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi:
+        interface_name: enp6s0.120
+        ip_v4: 172.17.0.11
+        mac_addr: "52:54:00:7a:aa:0e"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 120
+      storage:
+        interface_name: enp6s0.121
+        ip_v4: 172.18.0.11
+        mac_addr: "52:54:00:19:5b:d2"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 121
+      tenant:
+        interface_name: enp6s0.122
+        ip_v4: 172.19.0.11
+        mac_addr: "52:54:00:1b:3e:25"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 122
+  ocp-2:
+    hostname: master-2
+    name: ocp-2
+    networks:
+      ctlplane:
+        interface_name: enp6s0
+        ip_v4: 192.168.122.12
+        mac_addr: "52:54:00:de:3d:95"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi:
+        interface_name: enp6s0.120
+        ip_v4: 172.17.0.12
+        mac_addr: "52:54:00:63:20:1c"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 120
+      storage:
+        interface_name: enp6s0.121
+        ip_v4: 172.18.0.12
+        mac_addr: "52:54:00:23:e0:ff"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 121
+      tenant:
+        interface_name: enp6s0.122
+        ip_v4: 172.19.0.12
+        mac_addr: "52:54:00:29:56:10"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 122
+  compute-0:
+    hostname: compute-0
+    name: compute-0
+    networks:
+      ctlplane:
+        interface_name: eth1
+        ip_v4: 192.168.122.100
+        mac_addr: "52:54:00:17:05:43"
+        mtu: 1500
+        network_name: ctlplane
+        skip_nm: false
+      internalapi:
+        interface_name: eth1.20
+        ip_v4: 172.17.0.100
+        mac_addr: "52:54:00:05:da:ef"
+        mtu: 1500
+        network_name: internalapi
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 20
+      storage:
+        interface_name: eth1.21
+        ip_v4: 172.18.0.100
+        mac_addr: "52:54:00:59:8a:4c"
+        mtu: 1500
+        network_name: storage
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 21
+      tenant:
+        interface_name: eth1.22
+        ip_v4: 172.19.0.100
+        mac_addr: "52:54:00:0b:1c:d7"
+        mtu: 1500
+        network_name: tenant
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 22
+  compute-1:
+    hostname: compute-1
+    name: compute-1
+    networks:
+      ctlplane:
+        interface_name: eth1
+        ip_v4: 192.168.122.101
+        mac_addr: "52:54:00:17:05:44"
+        mtu: 1500
+        network_name: ctlplane
+        skip_nm: false
+      internalapi:
+        interface_name: eth1.20
+        ip_v4: 172.17.0.101
+        mac_addr: "52:54:00:05:db:00"
+        mtu: 1500
+        network_name: internalapi
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 20
+      storage:
+        interface_name: eth1.21
+        ip_v4: 172.18.0.101
+        mac_addr: "52:54:00:59:8a:4e"
+        mtu: 1500
+        network_name: storage
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 21
+      tenant:
+        interface_name: eth1.22
+        ip_v4: 172.19.0.101
+        mac_addr: "52:54:00:0b:1c:d5"
+        mtu: 1500
+        network_name: tenant
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 22
+networks:
+  ctlplane:
+    dns_v4:
+      - 192.168.122.1
+    dns_v6: []
+    gw_v4: 192.168.122.1
+    mtu: 1500
+    network_name: ctlplane
+    network_v4: 192.168.122.0/24
+    search_domain: ctlplane.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 192.168.122.90
+            end_host: 90
+            length: 11
+            start: 192.168.122.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 192.168.122.70
+            end_host: 70
+            length: 41
+            start: 192.168.122.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 192.168.122.120
+            end_host: 120
+            length: 21
+            start: 192.168.122.100
+            start_host: 100
+        ipv6_ranges: []
+  external:
+    dns_v4:
+      - 10.46.22.128
+    dns_v6: []
+    gw_v4: 10.46.22.189
+    mtu: 1500
+    network_name: external
+    network_v4: 10.46.22.128/26
+    search_domain: external.example.com
+    tools:
+      netconfig:
+        ipv4_ranges:
+          - end: 10.46.22.143
+            end_host: 15
+            length: 13
+            start: 10.46.22.131
+            start_host: 3
+        ipv6_ranges: []
+  internalapi:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: internalapi
+    network_v4: 172.17.0.0/24
+    search_domain: internalapi.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.17.0.90
+            end_host: 90
+            length: 11
+            start: 172.17.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.17.0.70
+            end_host: 70
+            length: 41
+            start: 172.17.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.17.0.250
+            end_host: 250
+            length: 151
+            start: 172.17.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 120
+  storage:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: storage
+    network_v4: 172.18.0.0/24
+    search_domain: storage.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.18.0.90
+            end_host: 90
+            length: 11
+            start: 172.18.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.18.0.70
+            end_host: 70
+            length: 41
+            start: 172.18.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.18.0.250
+            end_host: 250
+            length: 151
+            start: 172.18.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 121
+  tenant:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: tenant
+    network_v4: 172.19.0.0/24
+    search_domain: tenant.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.19.0.90
+            end_host: 90
+            length: 11
+            start: 172.19.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.19.0.70
+            end_host: 70
+            length: 41
+            start: 172.19.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.19.0.250
+            end_host: 250
+            length: 151
+            start: 172.19.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 122
+routers: {}

--- a/automation/vars/uni09iota.yaml
+++ b/automation/vars/uni09iota.yaml
@@ -1,0 +1,67 @@
+---
+vas:
+  uni09iota:
+    stages:
+      - pre_stage_run:
+          - name: Apply fc_card label on master-0
+            type: cr
+            definition:
+              metadata:
+                labels:
+                  fc_card: 'available'
+            kind: Node
+            resource_name: master-0
+            state: patched
+        name: nncp-configuration
+        path: examples/dt/uni09iota/control-plane/networking/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - name: network-configuration
+        path: examples/dt/uni09iota/control-plane/networking
+        wait_conditions:
+          - >-
+            oc -n metallb-system wait pod
+            -l app=metallb -l component=speaker
+            --for condition=Ready
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: network.yaml
+
+      - name: control-plane
+        path: examples/dt/uni09iota/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackcontrolplane
+            controlplane
+            --for condition=Ready
+            --timeout=60m
+        values:
+          - name: network-values
+            src_file: networking/nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+
+      - name: edpm-deployment
+        path: examples/dt/uni09iota
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanedeployment
+            edpm-deployment
+            --for condition=Ready
+            --timeout=40m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: edpm.yaml

--- a/dt/uni09iota/README.md
+++ b/dt/uni09iota/README.md
@@ -1,0 +1,10 @@
+# Deployment Topology - Iota
+
+If you are looking for information on how to deploy the iota based DT, then
+please see the [README](../../examples/dt/uni09iota/README.md) in the examples
+directory.
+
+This directory `dt/uni09iota/`, exists so that the
+[kustomization.yaml](../../examples/dt/uni09iota/kustomization.yaml) in
+the examples directory of uni09iota topology, reference it by path as a
+component.

--- a/dt/uni09iota/cinder-volume-pure-fc-secrets.yaml
+++ b/dt/uni09iota/cinder-volume-pure-fc-secrets.yaml
@@ -1,0 +1,13 @@
+---
+# Define the "cinder-volume-pure-fc-secrets" Secret that contains sensitive
+# information pertaining to the pure/FC backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-pure-fc-secrets
+type: Opaque
+stringData:
+  cinder-volume-pure-fc-secrets: _replaced_

--- a/dt/uni09iota/edpm/kustomization.yaml
+++ b/dt/uni09iota/edpm/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../lib/dataplane

--- a/dt/uni09iota/kustomization.yaml
+++ b/dt/uni09iota/kustomization.yaml
@@ -1,0 +1,208 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+      apiVersion: builtin
+      kind: NamespaceTransformer
+      metadata:
+        name: _ignored_
+        namespace: openstack
+      setRoleBindingSubjects: none
+      unsetOnly: true
+      fieldSpecs:
+        - path: metadata/name
+          kind: Namespace
+          create: true
+
+components:
+  - ../../lib/control-plane
+
+resources:
+  - cinder-volume-pure-fc-secrets.yaml
+
+replacements:
+  # Cinder
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderVolumes.pure-fc.nodeSelector.fc_card
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderVolumes.pure-fc.nodeSelector.fc_card
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderVolumes.pure-fc.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderVolumes.pure-fc.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderVolumes.pure-fc.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderVolumes.pure-fc.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderVolumes.pure-fc.customServiceConfigSecrets
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderVolumes.pure-fc.customServiceConfigSecrets
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderVolumes.pure-fc.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderVolumes.pure-fc.networkAttachments
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinder-volume-pure-fc-secrets
+    targets:
+      - select:
+          kind: Secret
+          name: cinder-volume-pure-fc-secrets
+        fieldPaths:
+          - stringData.cinder-volume-pure-fc-secrets
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.nodeSelector.fc_card
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.nodeSelector.fc_card
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.customServiceConfig
+        options:
+          create: true
+
+  # Glance
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.customServiceConfig
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.databaseInstance
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.databaseInstance
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.glanceAPIs.default.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.glanceAPIs.default.nodeSelector.fc_card
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.nodeSelector.fc_card
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.glanceAPIs.default.type
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.type
+        options:
+          create: true
+
+  # Swift
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.swift.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.swift.enabled
+        options:
+          create: true

--- a/dt/uni09iota/namespace.yaml
+++ b/dt/uni09iota/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: builtin
+kind: NamespaceTransformer
+metadata:
+  name: _ignored_
+  namespace: openstack
+setRoleBindingSubjects: none
+unsetOnly: true
+fieldSpecs:
+  - path: metadata/name
+    kind: Namespace
+    create: true

--- a/dt/uni09iota/networking/kustomization.yaml
+++ b/dt/uni09iota/networking/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+      apiVersion: builtin
+      kind: NamespaceTransformer
+      metadata:
+        name: _ignored_
+        namespace: openstack
+      setRoleBindingSubjects: none
+      unsetOnly: true
+      fieldSpecs:
+        - path: metadata/name
+          kind: Namespace
+          create: true
+
+components:
+  - ../../../lib/networking/metallb
+  - ../../../lib/networking/netconfig
+  - ../../../lib/networking/nad

--- a/examples/dt/uni09iota/README.md
+++ b/examples/dt/uni09iota/README.md
@@ -1,0 +1,159 @@
+# Deployed Topology - Iota
+
+This document contains a list of integration test suites that would be
+executed against the below specified topology of Red Hat OpenStack Services
+on OpenShift. It also contains a collection of custom resources (CRs) for
+deploying the test environment.
+
+## Purpose
+
+This topology is used for executing integration tests that primarly
+evaluate the FC backend for cinder-volume and glance over cinder.
+
+## Environment
+
+### Nodes
+
+| Role              | Machine Type | Count |
+| ----------------- | ------------ | ----- |
+| Compact OpenShift | vm           | 3     |
+| OpenStack Compute | vm           | 2     |
+
+All the nodes where OpenStack controller runs and all
+the OpenStack Compute needs to be configured with a dedicated
+HBA interface.
+
+### Networks
+
+| Name         | Type     | Interface | CIDR            |
+| ------------ | -------- | --------- | --------------- |
+| Provisioning | untagged | nic1      | 172.22.0.0/24   |
+| Machine      | untagged | nic2      | 192.168.32.0/20 |
+| RH OSP       | trunk    | nic3      |                 |
+
+#### VLAN networks in RH OSP
+
+| Name        | Type        | CIDR              |
+| ----------- | ----------- | ----------------- |
+| ctlplane    | untagged    | 192.168.122.0/24  |
+| internalapi | VLAN tagged | 172.17.0.0/24     |
+| storage     | VLAN tagged | 172.18.0.0/24     |
+| tenant      | VLAN tagged | 172.19.0.0/24     |
+
+### Services, enabled features and configurations
+
+| Service          | configuration            | Lock-in coverage?  |
+| ---------------- | ------------------------ | ------------------ |
+| Cinder           | FC (pure)                | Must have          |
+| Cinder Backup    | SwiftBackupDriver        | Must have          |
+| Glance           | Cinder (FC)              | Must have          |
+| Swift            | (default)                | Must have          |
+| Horizon          | N/A                      | Must have          |
+| Barbican         | (default)                | Must have          |
+| Neutron          | Geneve (OVN)             | Must have          |
+
+#### Support services
+
+The following table lists services which are not the main focus of the testing
+(which may be covered by additional scenarios), but are required for the DT to
+work properly and can be deployed with any/default configuration.
+
+| Service          | Reason                     |
+| ---------------- |--------------------------- |
+| Nova             | needed by scenario testing |
+| Keystone         | needed by all services     |
+
+### Additional configuration
+
+- Multipath service is enabled on all OpenShift nodes.
+- The cinder volume container needs to support the 'pure' driver.
+- At least master-0 and the compute nodes needs to have access to an HBA
+  in order for cinder-backup, cinder-volume and glance to access
+
+
+#### Multipath
+
+It is assumed *multipath* services are enabled in all nodes particpating in the
+Red Hat OpenShift cluster. If not, a `MachineConfig` like the one below must be
+applied. The node would be *rebooted* after applying the configuration.
+
+```YAML
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+    service: cinder
+  name: 99-master-cinder-enable-multipathd
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - path: /etc/multipath.conf
+          overwrite: false
+          # Mode must be decimal, this is 0600
+          mode: 384
+          user:
+            name: root
+          group:
+            name: root
+          contents:
+            # Source can be a http, https, tftp, s3, gs, or data as defined in rfc2397.
+            # This is the rfc2397 text/plain string format
+            source: data:,defaults%20%7B%0A%20%20user_friendly_names%20no%0A%20%20recheck_wwid%20yes%0A%20%20skip_kpartx%20yes%0A%20%20find_multipaths%20yes%0A%7D%0A%0Ablacklist%20%7B%0A%7D
+    systemd:
+      units:
+      - enabled: true
+        name: multipathd.service
+```
+
+#### Cinder volume - container
+
+The container used by the cinder-volume service must support the 'pure'
+driver with its dependencies. At this moment, this means having the
+[purestorage](https://pypi.org/project/purestorage/) python module.
+
+A way to get the official 'pure' cinder-volume container is described here:
+https://pure-storage-openstack-docs.readthedocs.io/en/latest/cinder/configuration/cinder_config_files/section_rhoso180_flasharray_configuration.html
+
+#### Cinder backend - FC protocol
+
+When a Cinder backend which supports the FiberChannel protocol is used,
+some pods and machines need to access the HBA (Host Bus Adapter) connected
+to the storage.
+
+This means that, on the OpenStack control plane, the following pods need
+access to the HBA in this scenario:
+
+- cinder-volume (the one configured for FC)
+- cinder-backup
+- all glance pods (as it is configured to use cinder)
+
+In addition, nova_compute pods running on data plane nodes need access to
+the HBAs too, but let's assume all compute nodes have an HBA.
+
+This means that:
+- the replica of the control plane services above needs to match the amount
+  of OpenShift nodes with HBA access;
+- the OpenShift nodes (schedulable masters) with HBA access needs to be
+  identified with a label, for example as `fc_card=available`
+  The label can be applied using the command:
+  `oc label node <nodename> fc_card=available`
+
+Due to hardware constraints, let's assume that only one of the OpenShift
+controllers, specifically master-0, can access an HBA.
+This means that all the OpenStack services that require access to an HBA
+(cinder-backup, cinder-volume and glance) will be restricted to master-0
+only, reducing their replica if needed.
+The topology can be easily adapted to the case where all controllers
+have access to an HBA by increasing the replica of the aforementioned
+services and applying the `fc_card=available` label to all controllers.
+
+## Workflow
+
+1. [Install the OpenStack K8S operators and their dependencies](../../common/README.md)
+2. [Configure and deploy the OpenStack control plane](control-plane.md)
+3. [Configure and deploy the OpenStack data plane](data-plane.md)

--- a/examples/dt/uni09iota/control-plane.md
+++ b/examples/dt/uni09iota/control-plane.md
@@ -1,0 +1,84 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `local-storage` should already exist.
+- Cluster observability operator is already deployed. If not, follow the
+  steps found [below](#cluster-observability-operator).
+
+# Apply the cr
+
+```bash
+oc apply -f subscription.yaml
+```
+
+# Wait for the deployment to be ready
+
+
+```bash
+oc wait deployments/observability-operator --for condition=Available \
+    --timeout=300s
+```
+
+## Initialize
+
+Switch to the "openstack" namespace
+
+```bash
+oc project openstack
+```
+
+Change to the uni09iota directory
+
+```bash
+cd architecture/examples/dt/uni09iota
+```
+
+Edit [control-plane/service-values.yaml](control-plane/service-values.yaml) and
+[control-plane/networking/nncp/values.yaml](control-plane/networking/nncp/values.yaml).
+
+Apply node network configuration
+
+```bash
+pushd control-plane/networking/nncp
+kustomize build > nncp.yaml
+oc apply -f nncp.yaml
+oc wait nncp \
+    -l osp/nncm-config-type=standard \
+    --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured \
+    --timeout=300s
+popd
+```
+
+## Apply remaining networking configuration
+
+Generate the reminaing networking configuration
+
+```bash
+kustomize build control-plane/networking > networking.yaml
+```
+Apply the networking CRs
+
+```bash
+oc apply -f networking.yaml
+```
+
+Generate the control-plane and networking CRs.
+
+```bash
+pushd control-plane
+kustomize build > control-plane.yaml
+```
+
+## Create CRs
+
+```bash
+oc apply -f control-plane.yaml
+popd
+```
+
+Wait for control plane to be available
+
+```bash
+oc wait osctlplane controlplane --for condition=Ready --timeout=600s
+```

--- a/examples/dt/uni09iota/control-plane/kustomization.yaml
+++ b/examples/dt/uni09iota/control-plane/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/uni09iota
+
+resources:
+  - networking/nncp/values.yaml
+  - service-values.yaml

--- a/examples/dt/uni09iota/control-plane/networking/kustomization.yaml
+++ b/examples/dt/uni09iota/control-plane/networking/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/uni09iota/networking
+
+resources:
+  - nncp/values.yaml

--- a/examples/dt/uni09iota/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/dt/uni09iota/control-plane/networking/nncp/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../lib/nncp
+
+resources:
+  - values.yaml

--- a/examples/dt/uni09iota/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/uni09iota/control-plane/networking/nncp/values.yaml
@@ -1,0 +1,205 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  openstack-operator-image:
+    "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
+
+  node_0:
+    name: master-0
+    internalapi_ip: 172.17.0.5
+    tenant_ip: 172.19.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+  node_1:
+    name: master-1
+    internalapi_ip: 172.17.0.6
+    tenant_ip: 172.19.0.6
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.6
+  node_2:
+    name: master-2
+    internalapi_ip: 172.17.0.7
+    tenant_ip: 172.19.0.7
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.7
+
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet1
+    prefix-length: 24
+    iface: enp6s0
+    mtu: 9000
+    lb_addresses:
+      - 192.168.122.80-192.168.122.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "macvlan",
+        "master": "ospbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.122.0/24",
+          "range_start": "192.168.122.30",
+          "range_end": "192.168.122.70"
+        }
+      }
+
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "macvlan",
+        "master": "internalapi",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 9000
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "macvlan",
+        "master": "storage",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+
+  tenant:
+    dnsDomain: tenant.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        name: subnet1
+        vlan: 22
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "macvlan",
+        "master": "tenant",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70"
+        }
+      }
+
+  external:
+    dnsDomain: external.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.250
+            start: 192.168.122.201
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet1
+    mtu: 1500
+
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config: []
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr

--- a/examples/dt/uni09iota/control-plane/service-values.yaml
+++ b/examples/dt/uni09iota/control-plane/service-values.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  preserveJobs: false
+  cinderVolumes:
+    pure-fc:
+      nodeSelector:
+        fc_card: 'available'
+      replicas: 1
+      customServiceConfig: |
+        [pure]
+        volume_backend_name=pure
+        volume_driver=cinder.volume.drivers.pure.PureFCDriver
+      customServiceConfigSecrets:
+        - cinder-volume-pure-fc-secrets
+      networkAttachments:
+        - storage
+  cinder-volume-pure-fc-secrets: |
+    [pure]
+    san_ip = _replaced_
+    pure_api_token = _replaced_
+  cinderBackup:
+    nodeSelector:
+      fc_card: 'available'
+    replicas: 1
+    customServiceConfig: |
+      [DEFAULT]
+      backup_driver = cinder.backup.drivers.swift.SwiftBackupDriver
+
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      debug=True
+      enabled_backends = default_backend:cinder
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      description = Default cinder backend
+      cinder_store_auth_address = {{ .KeystoneInternalURL }}
+      cinder_store_user_name = {{ .ServiceUser }}
+      cinder_store_password = {{ .ServicePassword }}
+      cinder_store_project_name = service
+      cinder_catalog_info = volumev3::internalURL
+      cinder_use_multipath = true
+      [oslo_concurrency]
+      lock_path = /var/lib/glance/tmp
+    databaseInstance: openstack
+    glanceAPIs:
+      default:
+        nodeSelector:
+          fc_card: 'available'
+        replicas: 1
+        type: split
+
+  swift:
+    enabled: true

--- a/examples/dt/uni09iota/data-plane.md
+++ b/examples/dt/uni09iota/data-plane.md
@@ -1,0 +1,62 @@
+# Deploying the OpenStack dataplane
+
+## Assumptions
+
+- The [control plane](control-plane.md) has been successfully deployed.
+
+## Initialize
+
+Switch to the "openstack" namespace
+
+```bash
+oc project openstack
+```
+
+Change to the iota's directory
+
+```bash
+cd architecture/examples/dt/uni09iota
+```
+
+Modify the [values.yaml](values.yaml) with the following information
+
+- SSH keys to be used for accessing the deployed compute nodes.
+- SSH keys to be use for Nova migration.
+
+> All values must be in base64 encoded format.
+
+### Compute access
+
+1. Set `data['authorized']` with the value of all OpenStack Compute host SSH
+  keys.
+2. Set `data['private']` with the contents of the SSH private key to be used
+  for accessing the dataplane compute nodes.
+3. Set `data['public']` with the contents of the SSH public key used for
+  accessing the dataplane compute nodes.
+
+### Nova migration
+
+1. Set `data['nova']['migration']['ssh_keys']['private']` with the content of
+  the SSH private key to be used for potential future migration.
+2. Set `data['nova']['migration']['ssh_keys']['public']` with the content of
+  the SSH public key to be used for potential future migration.
+
+## CRs
+
+Generate the dataplane CRs.
+
+```bash
+kustomize build > data-plane.yaml
+```
+
+## Create CRs
+
+```bash
+oc apply -f data-plane.yaml
+```
+
+Wait for dataplane deployment to finish
+
+```bash
+oc wait osdpd edpm-deployment --for condition=Ready --timeout=1200s
+```

--- a/examples/dt/uni09iota/kustomization.yaml
+++ b/examples/dt/uni09iota/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../dt/uni09iota/edpm
+
+resources:
+  - control-plane/networking/nncp/values.yaml
+  - values.yaml

--- a/examples/dt/uni09iota/values.yaml
+++ b/examples/dt/uni09iota/values.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  ssh_keys:
+    authorized: _replaced_
+    private: _replaced_
+    public: _replaced_
+
+  nova:
+    migration:
+      ssh_keys:
+        private: _replaced_
+        public: _replaced_
+
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+            - type: ovs_bridge
+              name: {{ neutron_physical_bridge_name }}
+              mtu: {{ min_viable_mtu }}
+              use_dhcp: false
+              dns_servers: {{ ctlplane_dns_nameservers }}
+              domain: {{ dns_search_domains }}
+              addresses:
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+              routes: {{ ctlplane_host_routes }}
+              members:
+                - type: interface
+                  name: nic2
+                  mtu: {{ min_viable_mtu }}
+                  primary: true
+                  # this ovs_extra configuration fixes OSPRH-17551, but it will
+                  # be not needed when FDP-1472 is resolved
+                  ovs_extra:
+                    - "set interface eth1 external-ids:ovn-egress-iface=true"
+          {% for network in nodeset_networks %}
+                - type: vlan
+                  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+                  vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+                  addresses:
+                    - ip_netmask: >-
+                        {{
+                          lookup('vars', networks_lower[network] ~ '_ip')
+                        }}/{{
+                          lookup('vars', networks_lower[network] ~ '_cidr')
+                        }}
+                  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth0
+
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+
+        edpm_sshd_configure_firewall: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+
+        gather_facts: false
+
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
+
+    nodes:
+      edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.122.100
+        hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+
+      edpm-compute-1:
+        ansible:
+          ansibleHost: 192.168.122.101
+        hostName: edpm-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+
+    services:
+      - bootstrap
+      - download-cache
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - libvirt
+      - nova

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -37,5 +37,6 @@
       - rhoso-architecture-validate-uni06zeta-adoption
       - rhoso-architecture-validate-uni07eta
       - rhoso-architecture-validate-uni07eta-adoption
+      - rhoso-architecture-validate-uni09iota
     github-gate:
       jobs: *id001

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -481,3 +481,17 @@
     parent: rhoso-architecture-base-job
     vars:
       cifmw_architecture_scenario: uni07eta-adoption
+- job:
+    files:
+    - automation/net-env/uni09iota.yaml
+    - dt/uni09iota
+    - examples/dt/uni09iota
+    - examples/dt/uni09iota/control-plane
+    - examples/dt/uni09iota/control-plane/networking
+    - examples/dt/uni09iota/control-plane/networking/nncp
+    - lib
+    name: rhoso-architecture-validate-uni09iota
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: uni09iota
+      cifmw_networking_env_def_file: automation/net-env/uni09iota.yaml


### PR DESCRIPTION
New topology meant to be used for executing integration tests
which primarly evaluate the FC backend for cinder-volume and
glance over cinder.

It has specific hardware (HBAs, which in the provided DT can
be limited to a single OCP controller in addition to the
compute nodes) and software requirements (special cinder-volume
container image).

Signed-off-by: Luigi Toscano <ltoscano@redhat.com>