### PR TITLE
Introduce Distributed Zone with 3rd Party Storage DT

### DIFF
--- a/automation/mocks/dz-storage.yaml
+++ b/automation/mocks/dz-storage.yaml
@@ -1,0 +1,1 @@
+bgp-l3-xl.yaml

--- a/automation/vars/dz-storage.yaml
+++ b/automation/vars/dz-storage.yaml
@@ -1,0 +1,223 @@
+---
+vas:
+  dz-storage:
+    stages:
+      - pre_stage_run:
+          - name: Apply taint on worker-9
+            type: cr
+            definition:
+              spec:
+                taints:
+                  - effect: NoSchedule
+                    key: testOperator
+                    value: 'true'
+                  - effect: NoExecute
+                    key: testOperator
+                    value: 'true'
+            kind: Node
+            resource_name: worker-9
+            state: patched
+          - name: Disable rp_filters on OCP nodes
+            type: cr
+            definition:
+              spec:
+                profile:
+                  - data: |
+                      [main]
+                      summary=Optimize systems running OpenShift (provider specific parent profile)
+                      include=-provider-${f:exec:cat:/var/lib/ocp-tuned/provider},openshift
+
+                      [sysctl]
+                      net.ipv4.conf.enp8s0.rp_filter=0
+                      net.ipv4.conf.enp9s0.rp_filter=0
+                    name: openshift-no-reapply-sysctl
+                recommend:
+                  - match:
+                      # applied to all nodes except worker-9, because worker-9 has no enp8s0
+                      - label: kubernetes.io/hostname
+                        value: worker-0
+                      - label: kubernetes.io/hostname
+                        value: worker-1
+                      - label: kubernetes.io/hostname
+                        value: worker-2
+                      - label: kubernetes.io/hostname
+                        value: worker-3
+                      - label: kubernetes.io/hostname
+                        value: worker-4
+                      - label: kubernetes.io/hostname
+                        value: worker-5
+                      - label: kubernetes.io/hostname
+                        value: worker-6
+                      - label: kubernetes.io/hostname
+                        value: worker-7
+                      - label: kubernetes.io/hostname
+                        value: worker-8
+                      - label: node-role.kubernetes.io/master
+                    operand:
+                      tunedConfig:
+                        reapply_sysctl: false
+                    priority: 15
+                    profile: openshift-no-reapply-sysctl
+            api_version: tuned.openshift.io/v1
+            kind: Tuned
+            resource_name: openshift-no-reapply-sysctl
+            namespace: openshift-cluster-node-tuning-operator
+            state: present
+        name: nncp-configuration
+        path: examples/dt/dz-storage/control-plane/networking/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=600s
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - name: networking
+        path: examples/dt/dz-storage/control-plane/networking
+        wait_conditions:
+          - >-
+            oc -n metallb-system wait pod
+            -l app=metallb -l component=speaker
+            --for condition=Ready
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: networking.yaml
+
+      - path: examples/dt/dz-storage/topology
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            --for=jsonpath='{.metadata.name}'=azone-node-affinity
+            topology/azone-node-affinity --timeout=60s
+        values:
+          - name: node-zone-labels
+            src_file: node-zone-labels.yaml
+        build_output: topology.yaml
+
+      # allow 60m (not 30m) for larger control plane on more nodes
+      - name: control-plane
+        path: examples/dt/dz-storage/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackcontrolplane
+            controlplane
+            --for condition=Ready
+            --timeout=60m
+        values:
+          - name: network-values
+            src_file: networking/nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+        post_stage_run:
+          - name: Create BGPConfiguration after controlplane is deployed
+            type: cr
+            definition:
+              spec: {}
+            api_version: network.openstack.org/v1beta1
+            kind: BGPConfiguration
+            resource_name: bgpconfiguration
+            namespace: openstack
+            state: present
+
+      - name: edpm-computes-r0-nodeset
+        path: examples/dt/dz-storage/edpm/computes/r0
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r0-compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r0-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r0-compute-nodeset.yaml
+
+      - name: edpm-computes-r1-nodeset
+        path: examples/dt/dz-storage/edpm/computes/r1
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r1-compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r1-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r1-compute-nodeset.yaml
+
+      - name: edpm-computes-r2-nodeset
+        path: examples/dt/dz-storage/edpm/computes/r2
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r2-compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r2-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r2-compute-nodeset.yaml
+
+      - name: edpm-networkers-r0-nodeset
+        path: examples/dt/dz-storage/edpm/networkers/r0
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r0-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r0-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r0-networker-nodeset.yaml
+
+      - name: edpm-networkers-r1-nodeset
+        path: examples/dt/dz-storage/edpm/networkers/r1
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r1-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r1-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r1-networker-nodeset.yaml
+
+      - name: edpm-networkers-r2-nodeset
+        path: examples/dt/dz-storage/edpm/networkers/r2
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r2-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r2-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r2-networker-nodeset.yaml
+
+      - name: edpm-deployment
+        path: examples/dt/dz-storage/edpm/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanedeployment
+            edpm-deployment
+            --for condition=Ready
+            --timeout=120m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: edpm-deployment.yaml
+        post_stage_run:
+          - name: Wait until computes are ready
+            type: playbook
+            source: "../../playbooks/bgp-l3-computes-ready.yml"
+            extra_vars:
+              num_computes: 6

--- a/examples/dt/dz-storage/README.md
+++ b/examples/dt/dz-storage/README.md
@@ -1,0 +1,86 @@
+# Distributed Zones with BGP and third party storage
+
+This Deployed Topology (DT) is the same as [bgp-l3-xl](../bgp-l3-xl)
+but it also has the following:
+
+- Three zones:
+  - zone A CoreOS: ocp-worker-0 ocp-worker-1 ocp-worker-2, ocp-master-0
+  - zone B CoreOS: ocp-worker-3 ocp-worker-4 ocp-worker-5, ocp-master-1
+  - zone C CoreOS: ocp-worker-6 ocp-worker-7 ocp-worker-8, ocp-master-2
+  - zone A RHEL: r0-compute-0, r0-compute-1, r0-networker-0, leaf-0, leaf-1
+  - zone B RHEL: r1-compute-0, r1-compute-1, r1-networker-0, leaf-2, leaf-3
+  - zone C RHEL: r2-compute-0, r2-compute-1, r2-networker-0, leaf-4, leaf-5
+- [Toplogy CRDs](https://github.com/openstack-k8s-operators/infra-operator/pull/325) are
+  used to either spread pods accross zones or keep them within a zone.
+- Self Node Remdiation and Node Health Checks
+- It is assumed that a Storage Array is physically located in each of the zones.
+  This examples uses a NetApp as an iSCSI backend for Cinder and an NFS backend for Manila.
+- Glance uses Cinder as its backend and is configured with multiple stores
+- There is a separate cinder-volume and manila-share service per zone
+
+The CRs included within this DT should be applied on an environment
+where EDPM and OCP nodes are connected through a spine/leaf
+network. The BGP protocol should be enabled on those spine and leaf
+routers. See [bgp-l3-xl](../bgp-l3-xl) for information about
+the BGP Dynamic Routing configuration.
+
+worker-9 is tained so that regular openstack workloads are not
+scheduled on it. It is not included into any rack or zone. It
+is not connected to any leaves, but to a router connected to
+the spines. It exists for running tests from outside.
+
+## Prerequisites
+
+- Chapters 2 and 6 from
+[Self Node Remdiation and Node Health Checks](https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift/24.4/html-single/remediation_fencing_and_maintenance)
+have been completed so that when the Node Health Check (NHC) Operator
+detects an unhealthy node, it creates a Self Node Remediation (SNR) CR
+with the `Automatic` strategy (which will taint an unhealthy node so
+that its pods are rescheduled).
+
+- A storage class has been created. If [LVMS](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/storage/configuring-persistent-storage#persistent-storage-using-lvms)
+is used, then if a node fails, the system does not allow the attached
+volume to be mounted on a new node because it is already assigned to
+the failed node. This prevents SNR from rescheduling pods with PVCs.
+
+## Considerations
+
+### Networking
+
+See the "Considerations/Constraints" section of [bgp-l3-xl](../bgp-l3-xl)
+
+### Block Storage Access
+
+#### Local Access
+
+In this example there is a storage array in each availability zone and a cinder-volume service pod is deployed on worker nodes in the same zone, i.e. local to that array. For example, in AZ1 the storage array with IP address 10.1.0.6 is on the local storage network 10.1.0.0/24 and a cinder-volume pod for AZ1 is configured on a worker node with access to that storage network. Compute nodes in AZ1 should be on the same network and have access to the same array.
+
+#### Remote Access
+
+It is also necessary for the storage array in each zone to be accessible by worker nodes in remote zones. For example, the glance pod in AZ1 is configured with multiple stores including the cinder-volume service in local AZ1 and the cinder-volume service in remote AZ2. This access is necessary so that an image may be uploaded to the glance store in AZ1 and then copied to the glance store in AZ2. The same access is also required to retype volumes between zones.
+
+The example here uses iSCSI and IP routing can be configured to support the remote access described above. If FC is used in place of iSCSI, then the switches need to be zoned to support the same types of remote and local access.
+
+### File Storage Access
+
+#### Local Access
+
+In this example there is a storage array in each availability zone and a manila-share service pod is deployed on worker nodes local to that array. For example, in AZ1 the storage array with IP address 10.1.0.6 is on the local storage network 10.1.0.0/24 and a manila-share pod for AZ1 is configured on a worker node with access to that storage network. Compute nodes in AZ1 should be on the same network and have access to the same array if they will use the shares hosted on that array.
+
+#### Remote Access
+
+It is also possible for the storage array in each zone to be accessible by  worker nodes in remote zones. For example, access could be granted to a share which is hosted in AZ1 to Nova instances which are hosted in AZ2. It’s possible that network latency between availability zones might affect storage performance. It’s up to the administrator to grant access to shares to ensure only local access or allow remote access.
+
+## Stages
+
+All stages must be executed in the order listed below. Everything is required unless otherwise indicated.
+
+1. [Configure taints on the OCP worker](configure-taints.md)
+2. [Disable RP filters on OCP nodes](disable-rp-filters.md)
+3. [Install the OpenStack K8S operators and their dependencies](../../common/)
+4. [Apply metallb customization required to run a speaker pod on the OCP tester node](metallb/)
+5. [Define Zones and Toplogies](topology/)
+6. [Configure networking and deploy the OpenStack control plane with storage](control-plane.md)
+7. [Create BGPConfiguration after controplane is deployed](bgp-configuration.md)
+8. [Configure and deploy the dataplane - networker and compute nodes](data-plane.md)
+9. [Validate Distributed Zone Storage](validate.md)

--- a/examples/dt/dz-storage/bgp-configuration.md
+++ b/examples/dt/dz-storage/bgp-configuration.md
@@ -1,0 +1,16 @@
+# Create BGPConfiguration after controplane is deployed
+
+An empty BGPConfiguration Openshift resource needs to be created.
+The infra-operator will detect this resource is created and will automatically
+apply the required Openshift BGP configuration.
+OCP 4.18 release is necessary for this.
+
+The following CR needs to be applied:
+```
+apiVersion: network.openstack.org/v1beta1
+kind: BGPConfiguration
+metadata:
+  name: bgpconfiguration
+  namespace: openstack
+spec: {}
+```

--- a/examples/dt/dz-storage/configure-taints.md
+++ b/examples/dt/dz-storage/configure-taints.md
@@ -1,0 +1,21 @@
+# Apply taints on OCP tester node
+
+This OCP worker node should not run any Openstack service apart from those
+created by the test-operator.
+It should also run a metallb's speaker pod, in order to obtain the proper
+network configuration.
+Due to this, taints should be configured on this worker.
+
+Execute the following command:
+```
+oc patch node/worker-9 --type merge --patch '
+  spec:
+    taints:
+      - effect: NoSchedule
+        key: testOperator
+        value: "true"
+      - effect: NoExecute
+        key: testOperator
+        value: "true"
+'
+```

--- a/examples/dt/dz-storage/control-plane.md
+++ b/examples/dt/dz-storage/control-plane.md
@@ -1,0 +1,85 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `local-storage` should already exist.
+- An infrastructure of spine/leaf routers exists, is properly connected to the
+  OCP nodes and the routers are configured to support BGP.
+
+## Initialize
+
+Switch to the "openstack" namespace
+```shell
+oc project openstack
+```
+Change to the dz-storage/control-plane directory
+```
+cd architecture/examples/dt/dz-storage/control-plane
+```
+Edit the [networking/nncp/values.yaml](control-plane/networking/nncp/values.yaml) and
+[service-values.yaml](control-plane/service-values.yaml) files to suit
+your environment.
+```shell
+vi networking/nncp/values.yaml
+vi service-values.yaml
+```
+
+Do not directly edit the secret files for Cinder matching
+`cinder-volume-secrets-az*.yaml` or Manila matching
+`manila-share-secrets-az*.yaml`. Instead edit the
+`service-values.yaml` to contain the secret content
+for Cinder and Manila to connect to the storage arrays.
+When `kustomize` is run it will then insert these values.
+
+In the `service-values.yaml` file, look for
+the sections `cinder-volume-secrets-az0`, `cinder-volume-secrets-az1`,
+`cinder-volume-secrets-az2`, `osp-secret-manila-az0`,
+`osp-secret-manila-az1`, and `osp-secret-manila-az2` and replace the
+`_replaced_` placeholders with your actual credentials and
+configuration values. Additionally, update the `netapp_server_hostname`
+values in the `cinderVolumes` sections (ontap-iscsi-az0, ontap-iscsi-az1,
+ontap-iscsi-az2) by replacing `_replaced_` with your actual NetApp
+cluster IP addresses. The example values use a NetApp
+but may be adjusted for other storage arrays.
+
+## Apply node network configuration
+
+Generate the node network configuration
+```shell
+kustomize build networking/nncp > nncp.yaml
+```
+Apply the NNCP CRs
+```shell
+oc apply -f nncp.yaml
+```
+Wait for NNCPs to be available
+```shell
+oc wait nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=300s
+```
+
+## Apply the remaining networking configuration
+
+Generate the networking CRs.
+```shell
+kustomize build networking > networking.yaml
+```
+Apply the CRs
+```shell
+oc apply -f networking.yaml
+```
+
+## Apply control-plane configuration
+
+Generate the control-plane CRs and their secrets:
+```shell
+kustomize build > control-plane.yaml
+```
+Apply the CRs
+```shell
+oc apply -f control-plane.yaml
+```
+
+Wait for control plane to be available
+```shell
+oc wait osctlplane controlplane --for condition=Ready --timeout=600s
+```

--- a/examples/dt/dz-storage/control-plane/cinder-volume-secrets-az0.yaml
+++ b/examples/dt/dz-storage/control-plane/cinder-volume-secrets-az0.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-secrets-az0
+type: Opaque
+stringData:
+  cinder-volume-secrets-az0: _replaced_

--- a/examples/dt/dz-storage/control-plane/cinder-volume-secrets-az1.yaml
+++ b/examples/dt/dz-storage/control-plane/cinder-volume-secrets-az1.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-secrets-az1
+type: Opaque
+stringData:
+  cinder-volume-secrets-az1: _replaced_

--- a/examples/dt/dz-storage/control-plane/cinder-volume-secrets-az2.yaml
+++ b/examples/dt/dz-storage/control-plane/cinder-volume-secrets-az2.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-secrets-az2
+type: Opaque
+stringData:
+  cinder-volume-secrets-az2: _replaced_

--- a/examples/dt/dz-storage/control-plane/kustomization.yaml
+++ b/examples/dt/dz-storage/control-plane/kustomization.yaml
@@ -1,0 +1,397 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/bgp/
+
+resources:
+  - networking/nncp/values.yaml
+  - service-values.yaml
+  - cinder-volume-secrets-az0.yaml
+  - cinder-volume-secrets-az1.yaml
+  - cinder-volume-secrets-az2.yaml
+  - manila-share-secrets-az0.yaml
+  - manila-share-secrets-az1.yaml
+  - manila-share-secrets-az2.yaml
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+replacements:
+  # disable OCP workers as gateway nodes
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.ovn.ovnController.external-ids
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ovn.template.ovnController.external-ids
+        options:
+          create: true
+  # configure neutron customServiceConfig
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.neutron.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.neutron.template.customServiceConfig
+        options:
+          create: true
+
+  # add topologyRef.name to spread all pods across zones
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.topologyRef.name
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.topologyRef.name
+        options:
+          create: true
+
+  # manila
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.template.manilaAPI.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaAPI.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.template.manilaShares
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaShares
+        options:
+          create: true
+  # set manila api replcias to 3 (unlike in cinder)
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.template.manilaAPI.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaAPI.replicas
+        options:
+          create: true
+  # set manila scheduler replcias to 3 (unlike in cinder)
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.manila.template.manilaScheduler.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.manila.template.manilaScheduler.replicas
+        options:
+          create: true
+
+  # GLANCE
+  # optional: external storage true for testing failover with LVMS
+  # - source:
+  #     kind: ConfigMap
+  #     name: service-values
+  #     fieldPath: data.glance.glanceAPIs.default.storage
+  #   targets:
+  #     - select:
+  #         kind: OpenStackControlPlane
+  #       fieldPaths:
+  #         - spec.glance.template.glanceAPIs.default.storage
+  #       options:
+  #         create: true
+
+  # Set glance template keystoneEndpoint
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.keystoneEndpoint
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.keystoneEndpoint
+        options:
+          create: true
+
+  # Set all four glanceAPIs (default, az{0,1,2})
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.glanceAPIs
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs
+        options:
+          create: true
+
+  # memcached
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.memcached.templates
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.memcached.templates
+        options:
+          create: true
+
+  # Nova cells
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.metadataServiceTemplate
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.metadataServiceTemplate
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cellTemplates
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.galera.templates
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.galera.templates
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.rabbitmq.templates
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates
+        options:
+          create: true
+
+  # topologyRef.name will be added to cinderVolumes under each volume.
+  # For example everything under `ontap-iscsi-az0` is injected already
+  # and the service-values.yaml already has a topologyRef.
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderVolumes
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderVolumes
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderAPI.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderAPI.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinder.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.customServiceConfig
+        options:
+          create: true
+
+  # Set topologyRef.name for cinderBackup
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.topologyRef.name
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.topologyRef.name
+        options:
+          create: true
+
+  # Set storageClass globally for OpenStackControlPlane
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.storageClass
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.storageClass
+          - spec.glance.template.storage.storageClass
+          - spec.designate.template.designateBackendbind9.storageClass
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageClass
+        options:
+          create: true
+
+  # Cinder volume secrets - populate from ConfigMap
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinder-volume-secrets-az0
+    targets:
+      - select:
+          kind: Secret
+          name: cinder-volume-secrets-az0
+        fieldPaths:
+          - stringData.cinder-volume-secrets-az0
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinder-volume-secrets-az1
+    targets:
+      - select:
+          kind: Secret
+          name: cinder-volume-secrets-az1
+        fieldPaths:
+          - stringData.cinder-volume-secrets-az1
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinder-volume-secrets-az2
+    targets:
+      - select:
+          kind: Secret
+          name: cinder-volume-secrets-az2
+        fieldPaths:
+          - stringData.cinder-volume-secrets-az2
+        options:
+          create: true
+
+  # Manila share secrets - populate from ConfigMap
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.osp-secret-manila-az0
+    targets:
+      - select:
+          kind: Secret
+          name: osp-secret-manila-az0
+        fieldPaths:
+          - stringData.[netapp-secrets.conf]
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.osp-secret-manila-az1
+    targets:
+      - select:
+          kind: Secret
+          name: osp-secret-manila-az1
+        fieldPaths:
+          - stringData.[netapp-secrets.conf]
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.osp-secret-manila-az2
+    targets:
+      - select:
+          kind: Secret
+          name: osp-secret-manila-az2
+        fieldPaths:
+          - stringData.[netapp-secrets.conf]
+        options:
+          create: true

--- a/examples/dt/dz-storage/control-plane/manila-share-secrets-az0.yaml
+++ b/examples/dt/dz-storage/control-plane/manila-share-secrets-az0.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: manila
+    component: manila-share
+  name: osp-secret-manila-az0
+type: Opaque
+stringData:
+  netapp-secrets.conf: _replaced_

--- a/examples/dt/dz-storage/control-plane/manila-share-secrets-az1.yaml
+++ b/examples/dt/dz-storage/control-plane/manila-share-secrets-az1.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: manila
+    component: manila-share
+  name: osp-secret-manila-az1
+type: Opaque
+stringData:
+  netapp-secrets.conf: _replaced_

--- a/examples/dt/dz-storage/control-plane/manila-share-secrets-az2.yaml
+++ b/examples/dt/dz-storage/control-plane/manila-share-secrets-az2.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: manila
+    component: manila-share
+  name: osp-secret-manila-az2
+type: Opaque
+stringData:
+  netapp-secrets.conf: _replaced_

--- a/examples/dt/dz-storage/control-plane/networking/kustomization.yaml
+++ b/examples/dt/dz-storage/control-plane/networking/kustomization.yaml
@@ -1,0 +1,317 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bgp/networking
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+resources:
+  - nncp/values.yaml
+  - metallb_bgppeers.yaml
+  - ocp_networks_netattach.yaml
+
+patches:
+  # Add BGPPeer to BGPAdvertisement
+  - target:
+      kind: BGPAdvertisement
+    patch: |-
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-3-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-3-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-4-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-4-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-5-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-5-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-6-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-6-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-7-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-7-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-8-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-8-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-9-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-9-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-10-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-10-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-11-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-11-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-12-0
+  - target:
+      kind: NetworkAttachmentDefinition
+      labelSelector: "osp/net-attach-def-type=bgp"
+    path: ocp_network_template.yaml
+
+  # All L2Advertisements are removed
+  - target:
+      kind: L2Advertisement
+    patch: |-
+      kind: L2Advertisement
+      metadata:
+        name: .*
+      $patch: delete
+
+replacements:
+  # BGP peer IP addresses
+  # node3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-3-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-3-1
+        fieldPaths:
+          - spec.peerAddress
+  # node4
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-4-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-4-1
+        fieldPaths:
+          - spec.peerAddress
+  # node5
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-5-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-5-1
+        fieldPaths:
+          - spec.peerAddress
+  # node6
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-6-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-6-1
+        fieldPaths:
+          - spec.peerAddress
+  # node7
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-7-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-7-1
+        fieldPaths:
+          - spec.peerAddress
+  # node8
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-8-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-8-1
+        fieldPaths:
+          - spec.peerAddress
+  # node9
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-9-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-9-1
+        fieldPaths:
+          - spec.peerAddress
+  # node10
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-10-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-10-1
+        fieldPaths:
+          - spec.peerAddress
+  # node11
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-11-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-11-1
+        fieldPaths:
+          - spec.peerAddress
+  # node12
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-12-0
+        fieldPaths:
+          - spec.peerAddress
+
+  # BGP NetworkAttachmentDefinition customization
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node12
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-worker-9
+        fieldPaths:
+          - spec.config

--- a/examples/dt/dz-storage/control-plane/networking/metallb_bgppeers.yaml
+++ b/examples/dt/dz-storage/control-plane/networking/metallb_bgppeers.yaml
@@ -1,0 +1,304 @@
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-3-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-0"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-3-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-0"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-4-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-1"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-4-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-1"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-5-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-2"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-5-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-2"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-6-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-3"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-6-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-3"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-7-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-4"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-7-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-4"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-8-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-5"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-8-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-5"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-9-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-6"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-9-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-6"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-10-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-7"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-10-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-7"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-11-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-8"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-11-1
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-8"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-12-0
+  namespace: metallb-system
+spec:
+  myASN: 64999
+  peerASN: 64999
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-9"]  # worker-9 has only one bgp-peer

--- a/examples/dt/dz-storage/control-plane/networking/nncp/.gitignore
+++ b/examples/dt/dz-storage/control-plane/networking/nncp/.gitignore
@@ -1,0 +1,1 @@
+nncp.yaml

--- a/examples/dt/dz-storage/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/dt/dz-storage/control-plane/networking/nncp/kustomization.yaml
@@ -1,0 +1,1329 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../../../lib/nncp-l3
+
+resources:
+  - values.yaml
+  - ocp_worker_nodes_nncp.yaml
+
+patches:
+  # Add BGP and octavia interfaces
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 1
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "master-.*"
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "node-[3-9]"
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "node-10"
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "node-11"
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: loopback interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          name: _replaced_
+          mtu: 65536
+          state: up
+  # Fix roles on masters
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "master-.*"
+    patch: |-
+      - op: add
+        path: /spec/nodeSelector/node-role.kubernetes.io~1master
+        value: ""
+      - op: remove
+        path: /spec/nodeSelector/node-role.kubernetes.io~1worker
+
+replacements:
+  # Node names (workers)
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-4
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-5
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-6
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-7
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-8
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-9
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-10
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-11
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-12
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+
+  # BGP master-0/node-0 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP master-1/node-1 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP master-2/node-2 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-0/node-3 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-1/node-4 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-2/node-5 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-3/node-6 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-4/node-7 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-5/node-8 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-6/node-9 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-7/node_10 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-8/node_11 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-9/node-12 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv6.address.0.ip
+
+
+  # BGP values
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.ifaces.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.4.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.ifaces.1
+    targets:  # target all nodes except worker-9 (regexs do not seem to work on select.name value)
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.iface
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:  # in case of worker-9, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.prefix-length
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:  # in case of worker-9, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.prefix-length
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:  # in case of worker-9, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.prefix-length-ipv6
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:  # in case of worker-9, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv6.address.0.prefix-length
+
+  # Overwrite worker-9 base routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.routes
+
+
+  # ROUTES
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_7.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-4
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_8.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-5
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_9.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-6
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_10.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-7
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_11.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-8
+        fieldPaths:
+          - spec.desiredState.routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_12.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-9
+        fieldPaths:
+          - spec.desiredState.routes

--- a/examples/dt/dz-storage/control-plane/networking/nncp/ocp_worker_nodes_nncp.yaml
+++ b/examples/dt/dz-storage/control-plane/networking/nncp/ocp_worker_nodes_nncp.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-3
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-4
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-5
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-6
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-7
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-8
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-9
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-10
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-11
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-12
+  labels:
+    osp/nncm-config-type: standard

--- a/examples/dt/dz-storage/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/dz-storage/control-plane/networking/nncp/values.yaml
@@ -1,0 +1,883 @@
+---
+# local-config: referenced, but not emitted by kustomize
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # nodes
+  node_0:
+    name: master-0
+    internalapi_ip: 172.17.0.5
+    tenant_ip: 172.19.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+    bgp_ip:
+      - 100.64.0.14
+      - 100.65.0.14
+    bgp_peers:
+      - 100.64.0.13
+      - 100.65.0.13
+    loopback_ip: 99.99.0.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:13
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.13
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.13
+          next-hop-interface: enp9s0
+  node_1:
+    name: master-1
+    internalapi_ip: 172.17.0.6
+    tenant_ip: 172.19.0.6
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.6
+    bgp_ip:
+      - 100.64.1.14
+      - 100.65.1.14
+    bgp_peers:
+      - 100.64.1.13
+      - 100.65.1.13
+    loopback_ip: 99.99.1.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:23
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.13
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.13
+          next-hop-interface: enp9s0
+  node_2:
+    name: master-2
+    internalapi_ip: 172.17.0.7
+    tenant_ip: 172.19.0.7
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.7
+    bgp_ip:
+      - 100.64.2.14
+      - 100.65.2.14
+    bgp_peers:
+      - 100.64.2.13
+      - 100.65.2.13
+    loopback_ip: 99.99.2.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:33
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.13
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.13
+          next-hop-interface: enp9s0
+  node_3:
+    name: worker-0
+    internalapi_ip: 172.17.0.8
+    tenant_ip: 172.19.0.8
+    ctlplane_ip: 192.168.122.13
+    storage_ip: 172.18.0.8
+    bgp_ip:
+      - 100.64.0.18
+      - 100.65.0.18
+    bgp_peers:
+      - 100.64.0.17
+      - 100.65.0.17
+    loopback_ip: 99.99.0.4
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:14
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.17
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.17
+          next-hop-interface: enp9s0
+  node_4:
+    name: worker-1
+    internalapi_ip: 172.17.0.9
+    tenant_ip: 172.19.0.9
+    ctlplane_ip: 192.168.122.14
+    storage_ip: 172.18.0.9
+    bgp_ip:
+      - 100.64.0.22
+      - 100.65.0.22
+    bgp_peers:
+      - 100.64.0.21
+      - 100.65.0.21
+    loopback_ip: 99.99.0.5
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:24
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.21
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.21
+          next-hop-interface: enp9s0
+  node_5:
+    name: worker-2
+    internalapi_ip: 172.17.0.10
+    tenant_ip: 172.19.0.10
+    ctlplane_ip: 192.168.122.15
+    storage_ip: 172.18.0.10
+    bgp_ip:
+      - 100.64.0.26
+      - 100.65.0.26
+    bgp_peers:
+      - 100.64.0.25
+      - 100.65.0.25
+    loopback_ip: 99.99.0.6
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.25
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.25
+          next-hop-interface: enp9s0
+  node_6:
+    name: worker-3
+    internalapi_ip: 172.17.0.11
+    tenant_ip: 172.19.0.11
+    ctlplane_ip: 192.168.122.16
+    storage_ip: 172.18.0.11
+    bgp_ip:
+      - 100.64.1.18
+      - 100.65.1.18
+    bgp_peers:
+      - 100.64.1.17
+      - 100.65.1.17
+    loopback_ip: 99.99.1.4
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.17
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.17
+          next-hop-interface: enp9s0
+
+  node_7:
+    name: worker-4
+    internalapi_ip: 172.17.0.12
+    tenant_ip: 172.19.0.12
+    ctlplane_ip: 192.168.122.17
+    storage_ip: 172.18.0.12
+    bgp_ip:
+      - 100.64.1.22
+      - 100.65.1.22
+    bgp_peers:
+      - 100.64.1.21
+      - 100.65.1.21
+    loopback_ip: 99.99.1.5
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.21
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.21
+          next-hop-interface: enp9s0
+  node_8:
+    name: worker-5
+    internalapi_ip: 172.17.0.13
+    tenant_ip: 172.19.0.13
+    ctlplane_ip: 192.168.122.18
+    storage_ip: 172.18.0.13
+    bgp_ip:
+      - 100.64.1.26
+      - 100.65.1.26
+    bgp_peers:
+      - 100.64.1.25
+      - 100.65.1.25
+    loopback_ip: 99.99.1.6
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.25
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.25
+          next-hop-interface: enp9s0
+  node_9:
+    name: worker-6
+    internalapi_ip: 172.17.0.14
+    tenant_ip: 172.19.0.14
+    ctlplane_ip: 192.168.122.19
+    storage_ip: 172.18.0.14
+    bgp_ip:
+      - 100.64.2.18
+      - 100.65.2.18
+    bgp_peers:
+      - 100.64.2.17
+      - 100.65.2.17
+    loopback_ip: 99.99.2.4
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.17
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.17
+          next-hop-interface: enp9s0
+  node_10:
+    name: worker-7
+    internalapi_ip: 172.17.0.15
+    tenant_ip: 172.19.0.15
+    ctlplane_ip: 192.168.122.20
+    storage_ip: 172.18.0.15
+    bgp_ip:
+      - 100.64.2.22
+      - 100.65.2.22
+    bgp_peers:
+      - 100.64.2.21
+      - 100.65.2.21
+    loopback_ip: 99.99.2.5
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.21
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.21
+          next-hop-interface: enp9s0
+  node_11:
+    name: worker-8
+    internalapi_ip: 172.17.0.16
+    tenant_ip: 172.19.0.16
+    ctlplane_ip: 192.168.122.21
+    storage_ip: 172.18.0.16
+    bgp_ip:
+      - 100.64.2.26
+      - 100.65.2.26
+    bgp_peers:
+      - 100.64.2.25
+      - 100.65.2.25
+    loopback_ip: 99.99.2.6
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.25
+          next-hop-interface: enp8s0
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.25
+          next-hop-interface: enp9s0
+  # test worker
+  node_12:
+    name: worker-9
+    internalapi_ip: 172.17.0.17
+    tenant_ip: 172.19.0.17
+    ctlplane_ip: 192.168.122.22
+    storage_ip: 172.18.0.17
+    bgp_ip:
+      - 100.64.10.2
+    bgp_peers:
+      - 100.64.10.1
+    loopback_ip: 99.99.10.2
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:43
+    base_if: enp7s0
+    routes:
+      config:
+        - destination: 192.168.133.0/24
+          next-hop-address: 100.64.10.1
+          next-hop-interface: enp8s0
+
+  # networks
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet0
+        routes:
+          - destination: 192.168.123.0/24
+            nexthop: 192.168.122.1
+          - destination: 192.168.124.0/24
+            nexthop: 192.168.122.1
+      - allocationRanges:
+          - end: 192.168.123.120
+            start: 192.168.123.100
+          - end: 192.168.123.170
+            start: 192.168.123.150
+        cidr: 192.168.123.0/24
+        gateway: 192.168.123.1
+        name: subnet1
+        routes:
+          - destination: 192.168.122.0/24
+            nexthop: 192.168.123.1
+          - destination: 192.168.124.0/24
+            nexthop: 192.168.123.1ØØ
+      - allocationRanges:
+          - end: 192.168.124.120
+            start: 192.168.124.100
+          - end: 192.168.124.170
+            start: 192.168.124.150
+        cidr: 192.168.124.0/24
+        gateway: 192.168.124.1
+        name: subnet2
+        routes:
+          - destination: 192.168.122.0/24
+            nexthop: 192.168.124.1
+          - destination: 192.168.123.0/24
+            nexthop: 192.168.124.1
+    prefix-length: 24
+    iface: enp7s0
+    mtu: 1500
+    lb_addresses:
+      - 192.168.125.80-192.168.125.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.125.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "bridge",
+        "bridge": "ctlplane",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.125.0/24",
+          "range_start": "192.168.125.30",
+          "range_end": "192.168.125.70"
+        }
+      }
+
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "bridge",
+        "bridge": "internalapi",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 1500
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "bridge",
+        "bridge": "storage",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+  tenant:
+    dnsDomain: tenant.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        name: subnet1
+        vlan: 22
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "bridge",
+        "bridge": "tenant",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70"
+        }
+      }
+  octavia:
+    dnsDomain: octavia.openstack.lab
+    mtu: 1500
+    vlan: 23
+    base_iface: enp7s0
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "octavia",
+        "type": "bridge",
+        "bridge": "octbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.23.0.0/24",
+          "range_start": "172.23.0.30",
+          "range_end": "172.23.0.70",
+          "routes": [
+            {
+              "dst": "172.24.0.0/16",
+              "gw": "172.23.0.150"
+            }
+          ]
+        }
+      }
+  external:
+    dnsDomain: external.example.com
+    subnets:
+      - allocationRanges:
+          - end: 10.0.0.250
+            start: 10.0.0.100
+        cidr: 10.0.0.0/24
+        gateway: 10.0.0.1
+        name: subnet1
+    mtu: 1500
+
+  bgp:
+    prefix-length: 30
+    ifaces:
+      - enp8s0
+      - enp9s0
+    asn: 64999
+    peer_asn: 64999
+    subnets:
+      bgpnet0:
+        - name: subnet0
+          allocationRanges:
+            - end: 100.64.0.36
+              start: 100.64.0.1
+          cidr: 100.64.0.0/24
+          gateway: 100.64.0.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.0.1
+        - name: subnet1
+          allocationRanges:
+            - end: 100.64.1.36
+              start: 100.64.1.1
+          cidr: 100.64.1.0/24
+          gateway: 100.64.1.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.1.1
+        - name: subnet2
+          allocationRanges:
+            - end: 100.64.2.36
+              start: 100.64.2.1
+          cidr: 100.64.2.0/24
+          gateway: 100.64.2.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.2.1
+      bgpnet1:
+        - name: subnet0
+          allocationRanges:
+            - end: 100.65.0.36
+              start: 100.65.0.1
+          cidr: 100.65.0.0/24
+          gateway: 100.65.0.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.0.1
+        - name: subnet1
+          allocationRanges:
+            - end: 100.65.1.36
+              start: 100.65.1.1
+          cidr: 100.65.1.0/24
+          gateway: 100.65.1.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.1.1
+        - name: subnet2
+          allocationRanges:
+            - end: 100.65.2.36
+              start: 100.65.2.1
+          cidr: 100.65.2.0/24
+          gateway: 100.65.2.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.2.1
+      bgpmainnet:
+        - name: subnet0
+          cidr: 99.99.0.0/24
+          allocationRanges:
+            - end: 99.99.0.14
+              start: 99.99.0.2
+        - name: subnet1
+          cidr: 99.99.1.0/24
+          allocationRanges:
+            - end: 99.99.1.14
+              start: 99.99.1.2
+        - name: subnet2
+          cidr: 99.99.2.0/24
+          allocationRanges:
+            - end: 99.99.2.14
+              start: 99.99.2.2
+        - name: subnet10
+          cidr: 99.99.10.0/24
+          allocationRanges:
+            - end: 99.99.10.14
+              start: 99.99.10.2
+      bgpmainnetv6:
+        - name: subnet0
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0010/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:001e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
+        - name: subnet1
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0020/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:002e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0022
+        - name: subnet2
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0030/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:003e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0032
+        - name: subnet3
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0040/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:004e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0042
+    bgpdefs:
+      node0:
+        bgpnet0:
+          bgp_peer: 100.64.0.13
+          bgp_ip: 100.64.0.14
+        bgpnet1:
+          bgp_peer: 100.65.0.13
+          bgp_ip: 100.65.0.14
+        loopback_ip: 99.99.0.3
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:13
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.13
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.13
+              next-hop-interface: enp9s0
+      node1:
+        bgpnet0:
+          bgp_peer: 100.64.1.13
+          bgp_ip: 100.64.1.14
+        bgpnet1:
+          bgp_peer: 100.65.1.13
+          bgp_ip: 100.65.1.14
+        loopback_ip: 99.99.1.3
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:23
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.13
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.13
+              next-hop-interface: enp9s0
+      node2:
+        bgpnet0:
+          bgp_peer: 100.64.2.13
+          bgp_ip: 100.64.2.14
+        bgpnet1:
+          bgp_peer: 100.65.2.13
+          bgp_ip: 100.65.2.14
+        loopback_ip: 99.99.2.3
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:33
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.13
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.13
+              next-hop-interface: enp9s0
+      node3:
+        bgpnet0:
+          bgp_peer: 100.64.0.17
+          bgp_ip: 100.64.0.18
+        bgpnet1:
+          bgp_peer: 100.65.0.17
+          bgp_ip: 100.65.0.18
+        loopback_ip: 99.99.0.4
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:14
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.17
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.17
+              next-hop-interface: enp9s0
+      node4:
+        bgpnet0:
+          bgp_peer: 100.64.0.21
+          bgp_ip: 100.64.0.22
+        bgpnet1:
+          bgp_peer: 100.65.0.21
+          bgp_ip: 100.65.0.22
+        loopback_ip: 99.99.0.5
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:15
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.21
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.21
+              next-hop-interface: enp9s0
+      node5:
+        bgpnet0:
+          bgp_peer: 100.64.0.25
+          bgp_ip: 100.64.0.26
+        bgpnet1:
+          bgp_peer: 100.65.0.25
+          bgp_ip: 100.65.0.26
+        loopback_ip: 99.99.0.6
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:16
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.25
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.25
+              next-hop-interface: enp9s0
+      node6:
+        bgpnet0:
+          bgp_peer: 100.64.1.17
+          bgp_ip: 100.64.1.18
+        bgpnet1:
+          bgp_peer: 100.65.1.17
+          bgp_ip: 100.65.1.18
+        loopback_ip: 99.99.1.4
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:24
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.17
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.17
+              next-hop-interface: enp9s0
+      node7:
+        bgpnet0:
+          bgp_peer: 100.64.1.21
+          bgp_ip: 100.64.1.22
+        bgpnet1:
+          bgp_peer: 100.65.1.21
+          bgp_ip: 100.65.1.22
+        loopback_ip: 99.99.1.5
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:25
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.21
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.21
+              next-hop-interface: enp9s0
+      node8:
+        bgpnet0:
+          bgp_peer: 100.64.1.25
+          bgp_ip: 100.64.1.26
+        bgpnet1:
+          bgp_peer: 100.65.1.25
+          bgp_ip: 100.65.1.26
+        loopback_ip: 99.99.1.6
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:26
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.25
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.25
+              next-hop-interface: enp9s0
+      node9:
+        bgpnet0:
+          bgp_peer: 100.64.2.17
+          bgp_ip: 100.64.2.18
+        bgpnet1:
+          bgp_peer: 100.65.2.17
+          bgp_ip: 100.65.2.18
+        loopback_ip: 99.99.2.4
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:34
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.17
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.17
+              next-hop-interface: enp9s0
+      node10:
+        bgpnet0:
+          bgp_peer: 100.64.2.21
+          bgp_ip: 100.64.2.22
+        bgpnet1:
+          bgp_peer: 100.65.2.21
+          bgp_ip: 100.65.2.22
+        loopback_ip: 99.99.2.5
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:35
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.21
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.21
+              next-hop-interface: enp9s0
+      node11:
+        bgpnet0:
+          bgp_peer: 100.64.2.25
+          bgp_ip: 100.64.2.26
+        bgpnet1:
+          bgp_peer: 100.65.2.25
+          bgp_ip: 100.65.2.26
+        loopback_ip: 99.99.2.6
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:36
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.25
+              next-hop-interface: enp8s0
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.25
+              next-hop-interface: enp9s0
+      node12:
+        bgpnet0:
+          bgp_peer: 100.64.10.1
+          bgp_ip: 100.64.10.2
+        loopback_ip: 99.99.10.2
+        loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:43
+        routes:
+          config:
+            - destination: 192.168.133.0/24
+              next-hop-address: 100.64.10.1
+              next-hop-interface: enp8s0
+    net-attach-def:
+      node12: |
+        {
+          "cniVersion": "0.3.1",
+          "name": "bgpnet-worker-9",
+          "type": "host-device",
+          "device": "enp8s0",
+          "ipam": {
+            "type": "whereabouts",
+            "range": "100.64.10.0/30",
+            "range_start": "100.64.10.2",
+            "range_end": "100.64.10.2",
+            "routes": [{
+              "dst": "192.168.133.0/24",
+              "gw": "100.64.10.1"
+            }]
+          }
+        }
+
+  loopback:
+    prefix-length: 32
+    prefix-length-ipv6: 128
+    iface: lo
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config: []
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  bridgeName: ospbr
+  storageClass: _replaced_

--- a/examples/dt/dz-storage/control-plane/networking/ocp_network_template.yaml
+++ b/examples/dt/dz-storage/control-plane/networking/ocp_network_template.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: nmstate.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: _ignored_
+spec:
+  config: |
+    _replaced_

--- a/examples/dt/dz-storage/control-plane/networking/ocp_networks_netattach.yaml
+++ b/examples/dt/dz-storage/control-plane/networking/ocp_networks_netattach.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgpnet-worker-9
+  labels:
+    osp/net: bgpnet-worker-9
+    osp/net-attach-def-type: bgp

--- a/examples/dt/dz-storage/control-plane/service-values.yaml
+++ b/examples/dt/dz-storage/control-plane/service-values.yaml
@@ -1,0 +1,561 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  storageClass: lvms-local-storage
+  topologyRef:
+    name: default-spread-pods
+  preserveJobs: false
+
+  memcached:
+    templates:
+      memcached:
+        replicas: 3
+      memcached-azone:
+        replicas: 3
+        topologyRef:
+          name: azone-node-affinity
+      memcached-bzone:
+        replicas: 3
+        topologyRef:
+          name: bzone-node-affinity
+      memcached-czone:
+        replicas: 3
+        topologyRef:
+          name: czone-node-affinity
+  cinder:
+    customServiceConfig: |
+      [DEFAULT]
+      storage_availability_zone = az0
+  cinderAPI:
+    replicas: 3
+  cinderBackup:
+    replicas: 0
+    topologyRef:
+      name: azone-node-affinity
+    customServiceConfig: |
+      [DEFAULT]
+      # TODO:
+
+  cinderVolumes:
+    ontap-iscsi-az0:
+      topologyRef:
+        name: azone-node-affinity
+      customServiceConfigSecrets:
+        - cinder-volume-secrets-az0
+      customServiceConfig: |
+        [DEFAULT]
+        glance_api_servers = https://glance-az0-internal.openstack.svc:9292
+        [ontap-az0]
+        backend_availability_zone = az0
+        volume_backend_name=ontap-az0
+        volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
+        netapp_server_hostname=_replaced_
+        netapp_server_port=80
+        netapp_storage_protocol=iscsi
+        netapp_storage_family=ontap_cluster
+        consistencygroup_support=True
+    ontap-iscsi-az1:
+      topologyRef:
+        name: bzone-node-affinity
+      customServiceConfigSecrets:
+        - cinder-volume-secrets-az1
+      customServiceConfig: |
+        [DEFAULT]
+        glance_api_servers = https://glance-az1-internal.openstack.svc:9292
+        [ontap-az1]
+        backend_availability_zone = az1
+        volume_backend_name=ontap-az1
+        volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
+        netapp_server_hostname=_replaced_
+        netapp_server_port=80
+        netapp_storage_protocol=iscsi
+        netapp_storage_family=ontap_cluster
+        consistencygroup_support=True
+    ontap-iscsi-az2:
+      topologyRef:
+        name: czone-node-affinity
+      customServiceConfigSecrets:
+        - cinder-volume-secrets-az2
+      customServiceConfig: |
+        [DEFAULT]
+        glance_api_servers = https://glance-az2-internal.openstack.svc:9292
+        [ontap-az2]
+        backend_availability_zone = az2
+        volume_backend_name=ontap-az2
+        volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
+        netapp_server_hostname=_replaced_
+        netapp_server_port=80
+        netapp_storage_protocol=iscsi
+        netapp_storage_family=ontap_cluster
+        consistencygroup_support=True
+
+  glance:
+    # This glance.customServiceConfig is only here
+    # to pacify ../../../../dt/bgp/ and is ignored
+    # since a separate customServiceConfig is in
+    # place for each glance
+    customServiceConfig: ""
+    # This glance.default.replicas is only here
+    # to pacify ../../../../dt/bgp/ and is ignored;
+    # replicas are set separately for each glance
+    default:
+      replicas: 0
+    # Ensure keystoneEndpoint is set
+    keystoneEndpoint: default
+    # There are 4 glanceAPIs keys below (default, az{0,1,2})
+    glanceAPIs:
+      az0:
+        customServiceConfig: |
+          [DEFAULT]
+          enabled_backends = az0:cinder
+          debug = true
+          [glance_store]
+          default_backend = az0
+          [az0]
+          store_description = AZ0 iscsi cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+          cinder_do_extend_attached = true
+          cinder_volume_type = glance-iscsi-az0
+        networkAttachments:
+          - storage
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.81
+              spec:
+                type: LoadBalancer
+        replicas: 2
+        topologyRef:
+          name: azone-node-affinity
+        type: edge
+      az1:
+        customServiceConfig: |
+          [DEFAULT]
+          enabled_backends = az0:cinder,az1:cinder
+          [glance_store]
+          default_backend = az1
+          [az1]
+          store_description = AZ1 iscsi cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+          cinder_do_extend_attached = true
+          cinder_volume_type = glance-iscsi-az1
+          [az0]
+          store_description = AZ0 iscsi cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+          cinder_do_extend_attached = true
+          cinder_volume_type = glance-iscsi-az0
+        networkAttachments:
+          - storage
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.82
+              spec:
+                type: LoadBalancer
+        replicas: 2
+        topologyRef:
+          name: bzone-node-affinity
+        type: edge
+      az2:
+        customServiceConfig: |
+          [DEFAULT]
+          enabled_backends = az0:cinder,az2:cinder
+          [glance_store]
+          default_backend = az2
+          [az2]
+          store_description = AZ2 iscsi cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+          cinder_do_extend_attached = true
+          cinder_volume_type = glance-iscsi-az2
+          [az0]
+          store_description = AZ0 iscsi cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+          cinder_do_extend_attached = true
+          cinder_volume_type = glance-iscsi-az0
+        networkAttachments:
+          - storage
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.83
+              spec:
+                type: LoadBalancer
+        replicas: 2
+        topologyRef:
+          name: czone-node-affinity
+        type: edge
+      default:
+        customServiceConfig: |
+          [DEFAULT]
+          enabled_backends = az0:cinder,az1:cinder,az2:cinder
+          [glance_store]
+          default_backend = az0
+          [az0]
+          store_description = AZ0 iscsi cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+          cinder_do_extend_attached = true
+          cinder_volume_type = glance-iscsi-az0
+          [az1]
+          store_description = AZ1 iscsi cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+          cinder_do_extend_attached = true
+          cinder_volume_type = glance-iscsi-az1
+          [az2]
+          store_description = AZ2 iscsi cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+          cinder_do_extend_attached = true
+          cinder_volume_type = glance-iscsi-az2
+
+  manila:
+    apiOverride:
+      route:
+        haproxy.router.openshift.io/timeout: 60s
+    enabled: true
+    template:
+      manilaAPI:
+        customServiceConfig: |
+          [DEFAULT]
+          storage_availability_zone = az0,az1,az2
+          default_share_type = nfs-multiaz
+          enabled_share_protocols=nfs
+          debug = true
+        networkAttachments:
+          - internalapi
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
+        replicas: 3
+      manilaScheduler:
+        replicas: 3
+      manilaShares:
+        az0:
+          customServiceConfigSecrets:
+            - osp-secret-manila-az0
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_share_backends = nfs_az0
+            enabled_share_protocols = nfs
+            [nfs_az0]
+            driver_handles_share_servers = True
+            share_backend_name = nfs_az
+            backend_availability_zone = az0
+            share_driver=manila.share.drivers.netapp.common.NetAppDriver
+            netapp_storage_family=ontap_cluster
+            netapp_transport_type=http
+          networkAttachments:
+            - storage
+          replicas: 1
+          topologyRef:
+            name: azone-node-affinity
+        az1:
+          customServiceConfigSecrets:
+            - osp-secret-manila-az1
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_share_backends = nfs_az1
+            enabled_share_protocols = nfs
+            [nfs_az1]
+            driver_handles_share_servers = True
+            share_backend_name = nfs_az
+            backend_availability_zone = az1
+            share_driver=manila.share.drivers.netapp.common.NetAppDriver
+            netapp_storage_family=ontap_cluster
+            netapp_transport_type=http
+          networkAttachments:
+            - storage
+          replicas: 1
+          topologyRef:
+            name: bzone-node-affinity
+        az2:
+          customServiceConfigSecrets:
+            - osp-secret-manila-az2
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_share_backends = nfs_az2
+            enabled_share_protocols = nfs
+            [nfs_az2]
+            driver_handles_share_servers = True
+            share_backend_name = nfs_az
+            backend_availability_zone = az2
+            share_driver=manila.share.drivers.netapp.common.NetAppDriver
+            netapp_storage_family=ontap_cluster
+            netapp_transport_type=http
+          networkAttachments:
+            - storage
+          replicas: 1
+          topologyRef:
+            name: czone-node-affinity
+
+  swift:
+    enabled: false
+
+  octavia:
+    enabled: false
+    amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image
+    apacheContainerImage: registry.redhat.io/ubi9/httpd-24:latest
+    octaviaAPI:
+      networkAttachments:
+        - internalapi
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+    octaviaHousekeeping:
+      networkAttachments:
+        - octavia
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+    octaviaHealthManager:
+      networkAttachments:
+        - octavia
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+    octaviaWorker:
+      networkAttachments:
+        - octavia
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+
+  ovn:
+    ovnController:
+      external-ids:
+        enable-chassis-as-gateway: false
+
+  neutron:
+    customServiceConfig: |
+      [DEFAULT]
+      vlan_transparent = true
+      debug = true
+      [ovs]
+      igmp_snooping_enable = true
+
+  nova:
+    customServiceConfig: |
+      [DEFAULT]
+      default_schedule_zone=az0
+    metadataServiceTemplate:
+      enabled: true
+      # if cells per zone, set false
+      # enabled: false
+    cellTemplates:
+      cell0:
+        cellDatabaseAccount: nova-cell0
+        hasAPIAccess: true
+      # if cells per zone, uncomment topologyRef
+      cell1:
+        # topologyRef:
+        #   name: azone-node-affinity
+        cellDatabaseInstance: openstack-cell1
+        cellDatabaseAccount: nova-cell1
+        cellMessageBusInstance: rabbitmq-cell1
+        conductorServiceTemplate:
+          replicas: 1
+        hasAPIAccess: true
+        # if cells per zone, uncomment to deploy metadataService per zone
+        # metadataServiceTemplate:
+        #   enabled: true
+        #   replicas: 3
+        # if cells per zone, uncomment cell2 and cell3
+        # cell2:
+        #   topologyRef:
+        #     name: bzone-node-affinity
+        #   cellDatabaseInstance: openstack-cell2
+        #   cellDatabaseAccount: nova-cell2
+        #   cellMessageBusInstance: rabbitmq-cell2
+        #   conductorServiceTemplate:
+        #     replicas: 1
+        #   hasAPIAccess: true
+        #   metadataServiceTemplate:
+        #     enabled: true
+        #     replicas: 3
+        # cell3:
+        #   topologyRef:
+        #     name: czone-node-affinity
+        #   cellDatabaseInstance: openstack-cell3
+        #   cellDatabaseAccount: nova-cell3
+        #   cellMessageBusInstance: rabbitmq-cell3
+        #   conductorServiceTemplate:
+        #     replicas: 1
+        #   hasAPIAccess: true
+        #   metadataServiceTemplate:
+        #     enabled: true
+        #     replicas: 3
+  rabbitmq:
+    templates:
+      rabbitmq:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+            spec:
+              type: LoadBalancer
+        replicas: 3
+      rabbitmq-cell1:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+            spec:
+              type: LoadBalancer
+        replicas: 3
+        # if cells per zone, uncomment topologyRef
+        # topologyRef:
+        #   name: azone-node-affinity
+        # if cells per zone, uncomment cell2 and cell2
+        # rabbitmq-cell2:
+        #   override:
+        #     service:
+        #       metadata:
+        #         annotations:
+        #           metallb.universe.tf/address-pool: internalapi
+        #           metallb.universe.tf/loadBalancerIPs: 172.17.0.87
+        #       spec:
+        #         type: LoadBalancer
+        #   replicas: 3
+        #   topologyRef:
+        #     name: bzone-node-affinity
+        # rabbitmq-cell3:
+        #   override:
+        #     service:
+        #       metadata:
+        #         annotations:
+        #           metallb.universe.tf/address-pool: internalapi
+        #           metallb.universe.tf/loadBalancerIPs: 172.17.0.88
+        #       spec:
+        #         type: LoadBalancer
+        #   replicas: 3
+        #   topologyRef:
+        #     name: czone-node-affinity
+  galera:
+    templates:
+      openstack:
+        replicas: 3
+        secret: osp-secret
+        storageRequest: 5G
+      openstack-cell1:
+        replicas: 3
+        secret: osp-secret
+        storageRequest: 5G
+        # if cells per zone, uncomment cell1 and cell3
+        # openstack-cell2:
+        #   replicas: 3
+        #   secret: osp-secret
+        #   storageRequest: 5G
+        # openstack-cell3:
+        #   replicas: 3
+        #   secret: osp-secret
+        #   storageRequest: 5G
+
+  # Cinder volume secrets
+  cinder-volume-secrets-az0: |
+    [ontap-az0]
+    netapp_login = _replaced_
+    netapp_password = _replaced_
+    netapp_vserver = _replaced_
+    netapp_pool_name_search_pattern = _replaced_
+
+  cinder-volume-secrets-az1: |
+    [ontap-az1]
+    netapp_login = _replaced_
+    netapp_password = _replaced_
+    netapp_vserver = _replaced_
+    netapp_pool_name_search_pattern = _replaced_
+
+  cinder-volume-secrets-az2: |
+    [ontap-az2]
+    netapp_login = _replaced_
+    netapp_password = _replaced_
+    netapp_vserver = _replaced_
+    netapp_pool_name_search_pattern = _replaced_
+
+  # Manila share secrets
+  osp-secret-manila-az0: |
+    [nfs_az0]
+    netapp_server_hostname = _replaced_
+    netapp_login = _replaced_
+    netapp_password = _replaced_
+    netapp_vserver = _replaced_
+
+  osp-secret-manila-az1: |
+    [nfs_az1]
+    netapp_server_hostname = _replaced_
+    netapp_login = _replaced_
+    netapp_password = _replaced_
+    netapp_vserver = _replaced_
+
+  osp-secret-manila-az2: |
+    [nfs_az2]
+    netapp_server_hostname = _replaced_
+    netapp_login = _replaced_
+    netapp_password = _replaced_
+    netapp_vserver = _replaced_

--- a/examples/dt/dz-storage/control-plane/tuned
+++ b/examples/dt/dz-storage/control-plane/tuned
@@ -1,0 +1,29 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: default
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Optimize systems running OpenShift (provider specific parent profile)
+      include=-provider-${f:exec:cat:/var/lib/ocp-tuned/provider},openshift
+
+      [sysctl]
+      net.ipv4.conf.enp8s0.rp_filter=0
+      net.ipv4.conf.enp9s0.rp_filter=0
+    name: openshift
+  recommend:
+  - match:
+    - label: node-role.kubernetes.io/master
+    - label: node-role.kubernetes.io/infra
+    operand:
+      tunedConfig: {}
+    priority: 30
+    profile: openshift-control-plane
+  - operand:
+      tunedConfig: {}
+    priority: 40
+    profile: openshift-node
+status: {}

--- a/examples/dt/dz-storage/data-plane.md
+++ b/examples/dt/dz-storage/data-plane.md
@@ -1,0 +1,121 @@
+# Configuring and deploying the dataplane - networker and compute nodes
+
+## Assumptions
+
+- The [control plane](control-plane.md) has been created and successfully deployed
+- An infrastructure of spine/leaf routers exists, is properly connected to the
+  pre-provisioned EDPM nodes and the routers are configured to support BGP.
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the `dz-storage` directory
+```
+cd architecture/examples/dt/dz-storage/
+```
+
+## Networker Nodes
+
+Edit the networker values.yaml files corresponding to each rack (r0, r1 and r2)
+to suit your environment:
+- [edpm/networkers/r0/values.yaml](edpm/networkers/r0/values.yaml)
+- [edpm/networkers/r1/values.yaml](edpm/networkers/r1/values.yaml)
+- [edpm/networkers/r2/values.yaml](edpm/networkers/r2/values.yaml)
+```
+vi values.yaml
+```
+
+## Compute Nodes
+
+Edit the compute values.yaml files corresponding to each rack (r0, r1 and r2)
+to suit your environment:
+- [edpm/computes/r0/values.yaml](edpm/computes/r0/values.yaml)
+- [edpm/computes/r1/values.yaml](edpm/computes/r1/values.yaml)
+- [edpm/computes/r2/values.yaml](edpm/computes/r2/values.yaml)
+```
+vi values.yaml
+```
+
+## Storage Related Compute Node Overrides
+
+Edit the following file to contain any desired override to the Nova configuration:
+
+- [edpm/computes/nova-extra-config.yaml](edpm/computes/nova-extra-config.yaml)
+
+The file is prepopulated with the following:
+```ini
+[DEFAULT]
+# Triple the default of the following
+reimage_timeout_per_gb = 60
+```
+The configmap can be genereated with the following command.
+```
+kustomize build edpm/computes/
+```
+
+As per [the docs](https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/18.0/html-single/customizing_the_red_hat_openstack_services_on_openshift_deployment/index#proc_configuring-a-node-set-for-a-feature-or-workload_custom_dataplane),
+
+> The Compute service (nova) provides a default ConfigMap CR named nova-extra-config, where you can add generic configuration that applies to all the node sets that use the default nova service. If you use this default nova-extra-config ConfigMap to add generic configuration to be applied to all the node sets, then you do not need to create a custom service.
+
+The EDPM `nova` service created in the next step will apply the above configuration to all Compute nodes.
+
+## Create Networker and Compute Nodeset CRs
+
+Generate the networkers dataplane nodeset CRs for each rack.
+```
+kustomize build edpm/networkers/r0 > edpm-r0-networker-nodeset.yaml
+kustomize build edpm/networkers/r1 > edpm-r1-networker-nodeset.yaml
+kustomize build edpm/networkers/r2 > edpm-r2-networker-nodeset.yaml
+```
+Generate the computes dataplane nodeset CRs for each rack.
+```
+kustomize build edpm/computes/r0 > edpm-r0-compute-nodeset.yaml
+kustomize build edpm/computes/r1 > edpm-r1-compute-nodeset.yaml
+kustomize build edpm/computes/r2 > edpm-r2-compute-nodeset.yaml
+```
+
+## Create EDPM  Deployment CR
+Generate the dataplane deployment CR.
+```
+kustomize build edpm/deployment > edpm-deployment.yaml
+```
+
+## Apply the Nodeset CRs
+
+Apply the Networker nodeset CRs
+```
+oc apply -f edpm/networkers/r0/edpm-r0-networker-nodeset.yaml
+oc apply -f edpm/networkers/r1/edpm-r1-networker-nodeset.yaml
+oc apply -f edpm/networkers/r2/edpm-r2-networker-nodeset.yaml
+```
+Wait for Networker dataplane nodesets setup to finish
+```
+oc wait osdpns r0-networker-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r1-networker-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r2-networker-nodes --for condition=SetupReady --timeout=600s
+```
+Apply the Compute nodeset CRs
+```
+oc apply -f edpm/computes/r0/edpm-r0-compute-nodeset.yaml
+oc apply -f edpm/computes/r1/edpm-r1-compute-nodeset.yaml
+oc apply -f edpm/computes/r2/edpm-r2-compute-nodeset.yaml
+```
+Wait for Compute dataplane nodesets setup to finish
+```
+oc wait osdpns r0-compute-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r1-compute-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r2-compute-nodes --for condition=SetupReady --timeout=600s
+```
+
+## Apply the deployment
+Start the deployment
+```
+oc apply -f edpm/deployment/edpm-deployment.yaml
+```
+Wait for dataplane deployment to finish
+```
+oc wait osdpd edpm-deployment --for condition=Ready --timeout=2400s
+```

--- a/examples/dt/dz-storage/disable-rp-filters.md
+++ b/examples/dt/dz-storage/disable-rp-filters.md
@@ -1,0 +1,39 @@
+# Disable RP filters on OCP workers
+
+Reverse path filters need to be disabled on OCP workers running Openstack services.
+This is needed to make OCP workers forward traffic properly based on the BGP
+advertisements received.
+
+The following CR needs to be applied:
+```
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-no-reapply-sysctl
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Optimize systems running OpenShift (provider specific parent profile)
+      include=-provider-${f:exec:cat:/var/lib/ocp-tuned/provider},openshift
+
+      [sysctl]
+      net.ipv4.conf.enp7s0.rp_filter=0
+      net.ipv4.conf.enp8s0.rp_filter=0
+    name: openshift-no-reapply-sysctl
+  recommend:
+  - match:
+    - label: kubernetes.io/hostname
+      value: worker-0
+    - label: kubernetes.io/hostname
+      value: worker-1
+    - label: kubernetes.io/hostname
+      value: worker-2
+    - label: node-role.kubernetes.io/master
+    operand:
+      tunedConfig:
+        reapply_sysctl: false
+    priority: 15
+    profile: openshift-no-reapply-sysctl
+```

--- a/examples/dt/dz-storage/edpm/computes/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/computes/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - nova-extra-config.yaml

--- a/examples/dt/dz-storage/edpm/computes/nova-extra-config.yaml
+++ b/examples/dt/dz-storage/edpm/computes/nova-extra-config.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nova-extra-config
+data:
+  25-nova-extra.conf: |
+    [DEFAULT]
+    # Triple the default of the following
+    reimage_timeout_per_gb = 60

--- a/examples/dt/dz-storage/edpm/computes/r0/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r0/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r0-compute-nodes

--- a/examples/dt/dz-storage/edpm/computes/r0/values.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r0/values.yaml
@@ -1,0 +1,211 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r0-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+          edpm-r0-compute-1:
+            nic2: 6b:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r0-compute-0:
+        hostName: edpm-r0-compute-0
+        ansible:
+          ansibleHost: 192.168.122.100
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.0.1
+              - 100.65.0.1
+            edpm_frr_bgp_peers:
+              - 100.64.0.1
+              - 100.65.0.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.0.2
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.0.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.0.2
+          - name: BgpmainnetV6
+            subnetName: subnet0
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
+      edpm-r0-compute-1:
+        hostName: edpm-r0-compute-1
+        ansible:
+          ansibleHost: 192.168.122.101
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.0.5
+              - 100.65.0.5
+            edpm_frr_bgp_peers:
+              - 100.64.0.5
+              - 100.65.0.5
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet0
+            fixedIP: 100.64.0.6
+          - name: Bgpnet1
+            subnetName: subnet0
+            fixedIP: 100.65.0.6
+          - name: Bgpmainnet
+            subnetName: subnet0
+            fixedIP: 99.99.0.3
+          - name: BgpmainnetV6
+            subnetName: subnet0
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0013
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - install-os
+      - configure-os
+      - frr
+      - validate-network
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/dz-storage/edpm/computes/r1/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r1/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r1-compute-nodes

--- a/examples/dt/dz-storage/edpm/computes/r1/values.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r1/values.yaml
@@ -1,0 +1,211 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r1-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+          edpm-compute-1:
+            nic2: 6b:fe:54:3f:8a:02
+        edpm_network_config_nmstate: false
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r1-compute-0:
+        hostName: edpm-r1-compute-0
+        ansible:
+          ansibleHost: 192.168.123.100
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.1.1
+              - 100.65.1.1
+            edpm_frr_bgp_peers:
+              - 100.64.1.1
+              - 100.65.1.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.123.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.1.2
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.1.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.1.2
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
+      edpm-r1-compute-1:
+        ansible:
+          ansibleVars:
+            edpm_frr_bgp_peers:
+              - 100.64.1.5
+              - 100.65.1.5
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.1.5
+              - 100.65.1.5
+          host: 192.168.123.101
+        hostName: edpm-r1-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.123.101
+            name: ctlplane
+            subnetName: subnet2
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+          - fixedIP: 100.64.1.6
+            name: BgpNet0
+            subnetName: subnet1
+          - fixedIP: 100.65.1.6
+            name: BgpNet1
+            subnetName: subnet1
+          - fixedIP: 99.99.1.8
+            name: BgpMainNet
+            subnetName: subnet1
+          - fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0028
+            name: BgpMainNetV6
+            subnetName: subnet1
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - install-os
+      - configure-os
+      - frr
+      - validate-network
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/dz-storage/edpm/computes/r2/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r2/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r2-compute-nodes

--- a/examples/dt/dz-storage/edpm/computes/r2/values.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r2/values.yaml
@@ -1,0 +1,211 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r2-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+          edpm-r2-compute-1:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'storage_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r2-compute-0:
+        hostName: edpm-r2-compute-0
+        ansible:
+          ansibleHost: 192.168.124.100
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.2.1
+              - 100.65.2.1
+            edpm_frr_bgp_peers:
+              - 100.64.2.1
+              - 100.65.2.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.124.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet2
+            fixedIP: 100.64.2.2
+          - name: Bgpnet1
+            subnetName: subnet2
+            fixedIP: 100.65.2.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.2.2
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033
+      edpm-r2-compute-1:
+        ansible:
+          ansibleVars:
+            edpm_frr_bgp_peers:
+              - 100.64.2.5
+              - 100.65.2.5
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.2.5
+              - 100.65.2.5
+          host: 192.168.124.101
+        hostName: edpm-r2-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.124.101
+            name: ctlplane
+            subnetName: subnet3
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+          - fixedIP: 100.64.2.6
+            name: BgpNet0
+            subnetName: subnet2
+          - fixedIP: 100.65.2.6
+            name: BgpNet1
+            subnetName: subnet2
+          - fixedIP: 99.99.2.8
+            name: BgpMainNet
+            subnetName: subnet2
+          - fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0038
+            name: BgpMainNetV6
+            subnetName: subnet2
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - install-os
+      - configure-os
+      - frr
+      - validate-network
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/dz-storage/edpm/deployment/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/deployment/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bgp/edpm/deployment
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/deployment/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.nodeSets
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.nodeSets

--- a/examples/dt/dz-storage/edpm/deployment/values.yaml
+++ b/examples/dt/dz-storage/edpm/deployment/values.yaml
@@ -1,0 +1,16 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeSets:
+    - r0-networker-nodes
+    - r1-networker-nodes
+    - r2-networker-nodes
+    - r0-compute-nodes
+    - r1-compute-nodes
+    - r2-compute-nodes

--- a/examples/dt/dz-storage/edpm/networkers/r0/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/networkers/r0/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r0-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/dz-storage/edpm/networkers/r0/values.yaml
+++ b/examples/dt/dz-storage/edpm/networkers/r0/values.yaml
@@ -1,0 +1,174 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r0-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r0-networker-0:
+        hostName: edpm-r0-networker-0
+        ansible:
+          ansibleHost: 192.168.122.200
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.0.9
+              - 100.65.0.9
+            edpm_frr_bgp_peers:
+              - 100.64.0.9
+              - 100.65.0.9
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.200
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet0
+            fixedIP: 100.64.0.10
+          - name: Bgpnet1
+            subnetName: subnet0
+            fixedIP: 100.65.0.10
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.0.4
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0014
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - install-os
+      - configure-os
+      - frr
+      - validate-network
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/dz-storage/edpm/networkers/r1/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/networkers/r1/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r1-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/dz-storage/edpm/networkers/r1/values.yaml
+++ b/examples/dt/dz-storage/edpm/networkers/r1/values.yaml
@@ -1,0 +1,174 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r1-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r1-networker-0:
+        hostName: edpm-r1-networker-0
+        ansible:
+          ansibleHost: 192.168.123.200
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.1.9
+              - 100.65.1.9
+            edpm_frr_bgp_peers:
+              - 100.64.1.9
+              - 100.65.1.9
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.123.200
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.1.10
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.1.10
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.1.4
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0024
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - install-os
+      - configure-os
+      - frr
+      - validate-network
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/dz-storage/edpm/networkers/r2/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/networkers/r2/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r2-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/dz-storage/edpm/networkers/r2/values.yaml
+++ b/examples/dt/dz-storage/edpm/networkers/r2/values.yaml
@@ -1,0 +1,174 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ lookup('vars', 'bgpmainnet_ip') }}"
+        edpm_ovn_bgp_agent_expose_tenant_networks: false
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bfd: false
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r2-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_nmstate: false
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: interface
+            name: nic3
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet0_ip') }}/30
+          - type: interface
+            name: nic4
+            use_dhcp: false
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpnet1_ip') }}/30
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ lookup('vars', 'bgpmainnet_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'bgpmainnetv6_ip') }}/128
+            - ip_netmask: {{ lookup('vars', 'internalapi_ip') }}/32
+            - ip_netmask: {{ lookup('vars', 'tenant_ip') }}/32
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r2-networker-0:
+        hostName: edpm-r2-networker-0
+        ansible:
+          ansibleHost: 192.168.124.200
+          ansibleVars:
+            edpm_ovn_bgp_agent_local_ovn_peer_ips:
+              - 100.64.2.9
+              - 100.65.2.9
+            edpm_frr_bgp_peers:
+              - 100.64.2.9
+              - 100.65.2.9
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.124.200
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet2
+            fixedIP: 100.64.2.10
+          - name: Bgpnet1
+            subnetName: subnet2
+            fixedIP: 100.65.2.10
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.2.4
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0034
+    services:
+      - download-cache
+      - bootstrap
+      - configure-network
+      - install-os
+      - configure-os
+      - frr
+      - validate-network
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/dz-storage/metallb/README.md
+++ b/examples/dt/dz-storage/metallb/README.md
@@ -1,0 +1,16 @@
+# MetalLB
+
+Observe CRs which will be generated.
+```
+kustomize build examples/dt/bgp/bgp_dt01/metallb/
+```
+
+Apply the metallb kustomization from this directory.
+```
+oc apply -k examples/dt/bgp/bgp_dt01/metallb/
+```
+
+Then, check that a speaker is running on the OCP tester node.
+```
+oc -n metallb-system wait pod -l component=speaker --field-selector=spec.host=worker-3 --for condition=Ready --timeout=300s
+```

--- a/examples/dt/dz-storage/metallb/kustomization.yaml
+++ b/examples/dt/dz-storage/metallb/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+components:
+  - ../../../../lib/metallb
+
+patches:
+  - target:
+      kind: MetalLB
+      name: metallb
+      namespace: metallb-system
+    patch: |-
+      - op: add
+        path: /spec/speakerTolerations
+        value:
+          - key: "testOperator"
+            value: "true"
+            effect: "NoSchedule"
+          - key: "testOperator"
+            value: "true"
+            effect: "NoExecute"

--- a/examples/dt/dz-storage/topology/README.md
+++ b/examples/dt/dz-storage/topology/README.md
@@ -1,0 +1,56 @@
+# Define Zones and Toplogies
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the `dz-storage` directory
+```
+cd architecture/examples/dt/dz-storage
+```
+Observe CRs which will be generated to define zones and topologies
+```
+kustomize build topology
+```
+
+## Examine Toplogies
+
+The Distributed Zones architecture schedules pods either in a specific
+zone or ensures that a pod's replicas are spread by the scheduler
+across all zones. The `OpenStackControlPlane` CRD supports a
+`topologyRef` which may be applied to its pods. The `topologyRef`
+references a
+[Toplogy CRD](https://github.com/openstack-k8s-operators/infra-operator/pull/325)
+which should be defined before deploying he `OpenStackControlPlane`.
+
+An example of a Topology CRD which spreads pods across all zones
+is [default-spread-pods.yaml](default-spread-pods.yaml)
+
+An example of three Toplogy CRDs which schedule a pod in a specific zone
+(either A, B or C) are [azone-node-affinity.yaml](azone-node-affinity.yaml),
+[bzone-node-affinity.yaml](bzone-node-affinity.yaml) and
+[czone-node-affinity.yaml](czone-node-affinity.yaml)
+
+Adjust these toplogies to suit your needs. See the
+[Controlling pod placement onto nodes (scheduling)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/nodes/controlling-pod-placement-onto-nodes-scheduling)
+guide for examples.
+
+## Examine Zones
+
+The toplogies from the previous section assume that the OCP nodes have
+been labeled with zones. Create a variation of the example
+[node-zone-labels.yaml](node-zone-labels.yaml) in the `topology`
+directory so that your nodes are assigned into different zones.
+
+The
+[Node labels section](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#node-labels)
+of the upstream Pod Topology Spread Constraints documentation
+has more details. See also
+[kubernetes/api/core/v1/well_known_labels.go](https://github.com/kubernetes/api/blob/master/core/v1/well_known_labels.go#L26).
+
+## Define Zones and Toplogies
+
+Once you are satisfied with the zones and toplogies apply them.
+```
+oc apply -k topology
+```

--- a/examples/dt/dz-storage/topology/azone-node-affinity.yaml
+++ b/examples/dt/dz-storage/topology/azone-node-affinity.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: topology.openstack.org/v1beta1
+kind: Topology
+metadata:
+  name: azone-node-affinity
+  namespace: openstack
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                  - zoneA
+  # spread the service pods across hosts within the same zone
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      matchLabelKeys:
+        - pod-template-hash
+        - controller-revision-hash

--- a/examples/dt/dz-storage/topology/bzone-node-affinity.yaml
+++ b/examples/dt/dz-storage/topology/bzone-node-affinity.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: topology.openstack.org/v1beta1
+kind: Topology
+metadata:
+  name: bzone-node-affinity
+  namespace: openstack
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                  - zoneB
+  # spread the service pods across hosts within the same zone
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      matchLabelKeys:
+        - pod-template-hash
+        - controller-revision-hash

--- a/examples/dt/dz-storage/topology/czone-node-affinity.yaml
+++ b/examples/dt/dz-storage/topology/czone-node-affinity.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: topology.openstack.org/v1beta1
+kind: Topology
+metadata:
+  name: czone-node-affinity
+  namespace: openstack
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                  - zoneC
+  # spread the service pods across hosts within the same zone
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      matchLabelKeys:
+        - pod-template-hash
+        - controller-revision-hash

--- a/examples/dt/dz-storage/topology/default-spread-pods.yaml
+++ b/examples/dt/dz-storage/topology/default-spread-pods.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: topology.openstack.org/v1beta1
+kind: Topology
+metadata:
+  name: default-spread-pods
+  namespace: openstack
+spec:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule

--- a/examples/dt/dz-storage/topology/kustomization.yaml
+++ b/examples/dt/dz-storage/topology/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - azone-node-affinity.yaml
+  - bzone-node-affinity.yaml
+  - czone-node-affinity.yaml
+  - default-spread-pods.yaml
+  - node-zone-labels.yaml

--- a/examples/dt/dz-storage/topology/node-zone-labels.yaml
+++ b/examples/dt/dz-storage/topology/node-zone-labels.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-0
+  labels:
+    topology.kubernetes.io/zone: zoneA
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-1
+  labels:
+    topology.kubernetes.io/zone: zoneA
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-2
+  labels:
+    topology.kubernetes.io/zone: zoneA
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-3
+  labels:
+    topology.kubernetes.io/zone: zoneB
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-4
+  labels:
+    topology.kubernetes.io/zone: zoneB
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-5
+  labels:
+    topology.kubernetes.io/zone: zoneB
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-6
+  labels:
+    topology.kubernetes.io/zone: zoneC
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-7
+  labels:
+    topology.kubernetes.io/zone: zoneC
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-8
+  labels:
+    topology.kubernetes.io/zone: zoneC

--- a/examples/dt/dz-storage/validate.md
+++ b/examples/dt/dz-storage/validate.md
@@ -1,0 +1,502 @@
+
+# Validate Distributed Zone Storage
+
+This section describes how to:
+
+- Verify storage pods are running in the expected zones
+- Use Cinder Types so that Multistore Glance can copy images to specific zones
+- Confirm that storage workloads can be scheduled to the desired zone
+
+## Pod Distribution
+
+The generated `OpenStckControlPlane` CR has each pod inherit the `spread-pods` topology, defined in [section 6.4](https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/18.0/html-single/deploying_a_rhoso_environment_with_distributed_zones/index#proc_create-a-Topology-CR-that-spreads-pods-across-all-zones_distributed-control-plane), except the `cinderVolumes`, `manilaShares` and Glance edge pods, which all use `topologyRef` to run in specific availability zones. Confirm that the pods for these services are running on their expected worker nodes based on the zone those where those worker nodes were tagged.
+
+Observe the Cinder pod distribution.
+```shell
+$ oc get pods -l service=cinder -o wide
+NAME                                    READY   STATUS      RESTARTS   AGE    IP               NODE       NOMINATED NODE   READINESS GATES
+cinder-cbca0-api-0                      2/2     Running     0          45h    192.172.40.49    worker-4   <none>           <none>
+cinder-cbca0-api-1                      2/2     Running     0          45h    192.172.16.50    worker-7   <none>           <none>
+cinder-cbca0-api-2                      2/2     Running     0          45h    192.172.28.26    worker-1   <none>           <none>
+cinder-cbca0-scheduler-0                2/2     Running     0          45h    192.172.44.23    worker-5   <none>           <none>
+cinder-cbca0-volume-ontap-iscsi-az0-0   2/2     Running     0          100m   192.172.32.51    worker-2   <none>           <none>
+cinder-cbca0-volume-ontap-iscsi-az1-0   2/2     Running     0          100m   192.172.44.110   worker-5   <none>           <none>
+cinder-cbca0-volume-ontap-iscsi-az2-0   2/2     Running     0          100m   192.172.49.52    worker-8   <none>           <none>
+cinder-db-purge-29170081-s4k78          0/1     Completed   0          23h    192.172.40.57    worker-4   <none>           <none>
+$
+```
+Observe the Glance pod distribution.
+```shell
+$ oc get pods -l service=glance -o wide
+NAME                                  READY   STATUS    RESTARTS   AGE    IP               NODE       NOMINATED NODE   READINESS GATES
+glance-cbca0-az0-edge-api-0           2/2     Running   0          109m   192.172.32.50    worker-2   <none>           <none>
+glance-cbca0-az0-edge-api-1           2/2     Running   0          109m   192.172.24.41    worker-0   <none>           <none>
+glance-cbca0-az1-edge-api-0           2/2     Running   0          109m   192.172.44.109   worker-5   <none>           <none>
+glance-cbca0-az1-edge-api-1           2/2     Running   0          110m   192.172.40.59    worker-4   <none>           <none>
+glance-cbca0-az2-edge-api-0           2/2     Running   0          109m   192.172.49.50    worker-8   <none>           <none>
+glance-cbca0-az2-edge-api-1           2/2     Running   0          109m   192.172.36.41    worker-6   <none>           <none>
+glance-cbca0-default-external-api-0   2/2     Running   0          110m   192.172.44.106   worker-5   <none>           <none>
+glance-cbca0-default-external-api-1   2/2     Running   0          110m   192.172.28.35    worker-1   <none>           <none>
+glance-cbca0-default-external-api-2   2/2     Running   0          110m   192.172.49.48    worker-8   <none>           <none>
+glance-cbca0-default-internal-api-0   2/2     Running   0          110m   192.172.49.44    worker-8   <none>           <none>
+glance-cbca0-default-internal-api-1   2/2     Running   0          110m   192.172.24.39    worker-0   <none>           <none>
+glance-cbca0-default-internal-api-2   2/2     Running   0          110m   192.172.44.107   worker-5   <none>           <none>
+$
+```
+Observe the Manila pod distribution.
+```shell
+$ oc get pods -o wide -l service=manila
+NAME                             READY   STATUS      RESTARTS   AGE     IP               NODE       NOMINATED NODE   READINESS GATES
+manila-api-0                     2/2     Running     0          6d16h   192.172.45.11    worker-5   <none>           <none>
+manila-api-1                     2/2     Running     0          51s     192.172.50.187   worker-8   <none>           <none>
+manila-api-2                     2/2     Running     0          51s     192.172.32.54    worker-2   <none>           <none>
+manila-db-purge-29185921-6cptm   0/1     Completed   0          2d15h   192.172.49.178   worker-8   <none>           <none>
+manila-db-purge-29187361-pq7hl   0/1     Completed   0          39h     192.172.50.23    worker-8   <none>           <none>
+manila-db-purge-29188801-rmmpz   0/1     Completed   0          15h     192.172.45.167   worker-5   <none>           <none>
+manila-scheduler-0               2/2     Running     0          7d18h   192.172.51.102   worker-8   <none>           <none>
+manila-scheduler-1               2/2     Running     0          51s     192.172.45.185   worker-5   <none>           <none>
+manila-scheduler-2               2/2     Running     0          29s     192.172.24.54    worker-0   <none>           <none>
+manila-share-az0-0               2/2     Running     0          5d2h    192.172.28.44    worker-1   <none>           <none>
+manila-share-az1-0               2/2     Running     0          5d2h    192.172.45.37    worker-5   <none>           <none>
+manila-share-az2-0               2/2     Running     0          5d2h    192.172.48.173   worker-8   <none>           <none>
+$
+```
+
+## Cinder Volume Types
+
+When Multistore Glance is configured to use Cinder as its backend each Glance store will specify a unique `cinder_volume_type`.
+
+We do not want these volume types to be exposed to cloud users so the types will be created with the `--private` option. We do want Glance, which runs under the service project, to be able to access these types so we will set the `--project` for each type to the service project ID as identified with the following command.
+
+```
+sh-5.1$ openstack project list
++----------------------------------+---------+
+| ID                               | Name    |
++----------------------------------+---------+
+| 439f0ee839144b4c8640b9153a596a30 | admin   |
+| 7a8946c6ec7c4d0488c592f0306eaa35 | service |
++----------------------------------+---------+
+sh-5.1$
+```
+
+A type will be created for each of the three cinder-volume services in each AZ. Using [RESKEY:availability\_zones](https://opendev.org/openstack/cinder/src/commit/c948b22eace9f6aa299a0af3ac374864ff8ff163/releasenotes/notes/support-az-in-volumetype-8yt6fg67de3976ty.yaml) will result in the AZ being passed to Cinder even though Glance only passes the type when it requests a volume.
+
+Store the service user project ID for Glance in a shell variable.
+
+```
+SERVICE_PROJECT_ID=$(openstack project show service -c id -f value)
+```
+
+Create each type with its project ID and availability zone.
+
+```
+openstack volume type create --private --project "$SERVICE_PROJECT_ID" --property "RESKEY:availability_zones=az0" glance-iscsi-az0
+openstack volume type create --private --project "$SERVICE_PROJECT_ID" --property "RESKEY:availability_zones=az1" glance-iscsi-az1
+openstack volume type create --private --project "$SERVICE_PROJECT_ID" --property "RESKEY:availability_zones=az2" glance-iscsi-az2
+```
+
+### Cinder Volume Type Verification
+
+Confirm you can create volumes by AZ.
+
+```
+openstack volume create --size 1 --availability-zone az0 vol_az0
+openstack volume create --size 1 --availability-zone az1 vol_az1
+openstack volume create --size 1 --availability-zone az2 vol_az2
+```
+
+As an administrator, confirm you can create a volume in the desired AZ by passing only the type.
+
+```
+openstack volume create --size 1 --type glance-iscsi-az0 vol_az0_by_type
+openstack volume create --size 1 --type glance-iscsi-az1 vol_az1_by_type
+openstack volume create --size 1 --type glance-iscsi-az2 vol_az2_by_type
+```
+
+Make sure the volumes are available and delete them afterwards.
+
+## Multistore Glance backed by Cinder
+
+Observe available stores:
+
+```
+$ glance stores-info
++----------+----------------------------------------------------------------------------------+
+| Property | Value                                                                            |
++----------+----------------------------------------------------------------------------------+
+| stores   | [{"id": "az0", "description": "AZ0 NetApp iscsi cinder backend", "default":      |
+|          | "true"}, {"id": "az1", "description": "AZ1 NetApp iscsi cinder backend"}, {"id": |
+|          | "az2", "description": "AZ2 NetApp iscsi cinder backend"}]                        |
++----------+----------------------------------------------------------------------------------+
+$
+```
+
+Create an image without passing any store related parameters and see what happens.
+
+```
+sh-5.1$ openstack image create --disk-format qcow2 --container-format bare --public --file ./cirros-0.5.2-x86_64-disk.img cirros-default
++------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+| Field            | Value                                                                                                                                              |
++------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+| container_format | bare                                                                                                                                               |
+| created_at       | 2025-06-18T22:55:21Z                                                                                                                               |
+| disk_format      | qcow2                                                                                                                                              |
+| file             | /v2/images/10fcfc90-e178-4776-ac76-853a7082844b/file                                                                                               |
+| id               | 10fcfc90-e178-4776-ac76-853a7082844b                                                                                                               |
+| min_disk         | 0                                                                                                                                                  |
+| min_ram          | 0                                                                                                                                                  |
+| name             | cirros-default                                                                                                                                     |
+| owner            | 439f0ee839144b4c8640b9153a596a30                                                                                                                   |
+| properties       | os_hidden='False', owner_specified.openstack.md5='', owner_specified.openstack.object='images/cirros-default', owner_specified.openstack.sha256='' |
+| protected        | False                                                                                                                                              |
+| schema           | /v2/schemas/image                                                                                                                                  |
+| status           | queued                                                                                                                                             |
+| tags             |                                                                                                                                                    |
+| updated_at       | 2025-06-18T22:55:21Z                                                                                                                               |
+| visibility       | public                                                                                                                                             |
++------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+sh-5.1$
+```
+
+The image is created in az0 because that's the default.
+
+```
+sh-5.1$ openstack image show 10fcfc90-e178-4776-ac76-853a7082844b | grep stores
+| properties       | os_hash_algo='sha512', os_hash_value='6b813aa46bb90b4da216a4d19376593fa3f4fc7e617f03a92b7fe11e9a3981cbe8f0959dbebe36225e5f53dc4492341a4863cac4ed1ee0909f3fc78ef9c3e869', os_hidden='False', owner_specified.openstack.md5='', owner_specified.openstack.object='images/cirros-default', owner_specified.openstack.sha256='', stores='az0' |
+sh-5.1$
+```
+
+Create an image and pass a parameter so it goes directly into store az0.
+
+```
+$ glance image-create --disk-format raw --container-format bare --name cirros-test --file cirros-0.5.2-x86_64-disk.img --store az0
++------------------+----------------------------------------------------------------------------------+
+| Property         | Value                                                                            |
++------------------+----------------------------------------------------------------------------------+
+| checksum         | b874c39491a2377b8490f5f1e89761a4                                                 |
+| container_format | bare                                                                             |
+| created_at       | 2025-06-18T22:47:10Z                                                             |
+| disk_format      | raw                                                                              |
+| id               | 5073f3f0-e4ac-4cca-9883-fecade29a1f3                                             |
+| min_disk         | 0                                                                                |
+| min_ram          | 0                                                                                |
+| name             | cirros-test                                                                      |
+| os_hash_algo     | sha512                                                                           |
+| os_hash_value    | 6b813aa46bb90b4da216a4d19376593fa3f4fc7e617f03a92b7fe11e9a3981cbe8f0959dbebe3622 |
+|                  | 5e5f53dc4492341a4863cac4ed1ee0909f3fc78ef9c3e869                                 |
+| os_hidden        | False                                                                            |
+| owner            | 439f0ee839144b4c8640b9153a596a30                                                 |
+| protected        | False                                                                            |
+| size             | 16300544                                                                         |
+| status           | active                                                                           |
+| stores           | az0                                                                              |
+| tags             | []                                                                               |
+| updated_at       | 2025-06-18T22:48:00Z                                                             |
+| virtual_size     | 16300544                                                                         |
+| visibility       | shared                                                                           |
++------------------+----------------------------------------------------------------------------------+
+$
+```
+
+Import it into az1
+
+```
+$ glance image-import 5073f3f0-e4ac-4cca-9883-fecade29a1f3 --stores az1 --import-method copy-image
++-----------------------+----------------------------------------------------------------------------------+
+| Property              | Value                                                                            |
++-----------------------+----------------------------------------------------------------------------------+
+| checksum              | b874c39491a2377b8490f5f1e89761a4                                                 |
+| container_format      | bare                                                                             |
+| created_at            | 2025-06-18T22:47:10Z                                                             |
+| disk_format           | raw                                                                              |
+| id                    | 5073f3f0-e4ac-4cca-9883-fecade29a1f3                                             |
+| min_disk              | 0                                                                                |
+| min_ram               | 0                                                                                |
+| name                  | cirros-test                                                                      |
+| os_glance_import_task | 7a141f7f-409a-4ea9-b66f-0658a83e907b                                             |
+| os_hash_algo          | sha512                                                                           |
+| os_hash_value         | 6b813aa46bb90b4da216a4d19376593fa3f4fc7e617f03a92b7fe11e9a3981cbe8f0959dbebe3622 |
+|                       | 5e5f53dc4492341a4863cac4ed1ee0909f3fc78ef9c3e869                                 |
+| os_hidden             | False                                                                            |
+| owner                 | 439f0ee839144b4c8640b9153a596a30                                                 |
+| protected             | False                                                                            |
+| size                  | 16300544                                                                         |
+| status                | active                                                                           |
+| stores                | az0                                                                              |
+| tags                  | []                                                                               |
+| updated_at            | 2025-06-18T22:48:00Z                                                             |
+| virtual_size          | 16300544                                                                         |
+| visibility            | shared                                                                           |
++-----------------------+----------------------------------------------------------------------------------+
+$
+```
+
+Observe that the image is in the stores for az0 and az1.
+
+```
+sh-5.1$ openstack image show 5073f3f0-e4ac-4cca-9883-fecade29a1f3 | grep stores
+| properties       | os_glance_failed_import='', os_glance_importing_to_stores='', os_hash_algo='sha512', os_hash_value='6b813aa46bb90b4da216a4d19376593fa3f4fc7e617f03a92b7fe11e9a3981cbe8f0959dbebe36225e5f53dc4492341a4863cac4ed1ee0909f3fc78ef9c3e869', os_hidden='False', stores='az0,az1' |
+sh-5.1$
+```
+
+Observe the Cinder volumes in az0 and az1 which store the image ID from the previous step.
+
+```
+sh-5.1$ openstack volume list --all | grep 5073f3f0-e4ac-4cca-9883-fecade29a1f3
+| 713f25b2-accc-4f4f-b5ba-8c71e2fac3aa | image-5073f3f0-e4ac-4cca-9883-fecade29a1f3 | available |    1 |                                 |
+| b1917ec2-2d8e-42cc-b58c-55db48f1e054 | image-5073f3f0-e4ac-4cca-9883-fecade29a1f3 | available |    1 |                                 |
+sh-5.1$ 
+```
+
+Confirm the availability zone, type and host of each volume backing the image.
+
+```
+sh-5.1$ openstack volume show b1917ec2-2d8e-42cc-b58c-55db48f1e054 -c type -c availability_zone -c os-vol-host-attr:host
++-----------------------+---------------------------------------------------------------+
+| Field                 | Value                                                         |
++-----------------------+---------------------------------------------------------------+
+| availability_zone     | az0                                                           |
+| os-vol-host-attr:host | cinder-cbca0-volume-ontap-iscsi-az0-0@ontap#cinder_iscsi_pool |
+| type                  | glance-iscsi-az0                                              |
++-----------------------+---------------------------------------------------------------+
+sh-5.1$ openstack volume show 713f25b2-accc-4f4f-b5ba-8c71e2fac3aa -c type -c availability_zone -c os-vol-host-attr:host
++-----------------------+---------------------------------------------------------------+
+| Field                 | Value                                                         |
++-----------------------+---------------------------------------------------------------+
+| availability_zone     | az1                                                           |
+| os-vol-host-attr:host | cinder-cbca0-volume-ontap-iscsi-az1-0@ontap#cinder_iscsi_pool |
+| type                  | glance-iscsi-az1                                              |
++-----------------------+---------------------------------------------------------------+
+sh-5.1$ 
+```
+
+## Validate Nova’s use of Glance and Cinder 3rd party storage per Zone
+
+We assume that there are compute nodes in all three zones and that they have been put into their own aggregates using a script like the following.
+
+```shell
+function make_aggregate() {
+    OS="oc rsh openstackclient openstack"
+    AZ=az$1
+    RACK=r$1
+    $OS aggregate create $AZ
+    $OS aggregate set --zone $AZ $AZ
+    for I in $(seq 0 2); do
+        $OS aggregate add host $AZ ${RACK}-compute-${I}.ctlplane.example.com
+    done
+    $OS compute service list -c Host -c Zone
+}
+
+make_aggregate 0
+make_aggregate 1
+make_aggregate 2
+```
+
+Create an ephemeral VM in AZ0 using the image created earlier
+
+```
+openstack server create --flavor c1 --image 3ae0d8d8-18f5-452e-a58e-63fb7aba308a --nic net-id=private --availability-zone az0 vm-az0
+```
+
+Observe the VM
+
+```
+sh-5.1$ openstack server list
++--------------------------------------+--------+--------+----------------------+------------------+--------+
+| ID                                   | Name   | Status | Networks             | Image            | Flavor |
++--------------------------------------+--------+--------+----------------------+------------------+--------+
+| c1f8b608-41d4-422a-ab89-82762353a784 | vm-az0 | ACTIVE | private=192.168.0.21 | cirros-priv-type | c1     |
++--------------------------------------+--------+--------+----------------------+------------------+--------+
+```
+
+Create a volume from an image in AZ1 using the image which was imported into AZ1 earlier
+
+```
+openstack volume create --size 8 vm_root_az1 --image 3ae0d8d8-18f5-452e-a58e-63fb7aba308a --availability-zone az1
+```
+
+Observe the volume
+
+```
+sh-5.1$ openstack volume list
++--------------------------------------+-------------+-----------+------+-------------+
+| ID                                   | Name        | Status    | Size | Attached to |
++--------------------------------------+-------------+-----------+------+-------------+
+| 119958b1-0fca-4412-81d1-1d9b856ce85a | vm_root_az1 | available |    8 |             |
++--------------------------------------+-------------+-----------+------+-------------+
+```
+
+Create a VM in AZ1 whose root volume is the cinder volume from the previous step
+
+```
+openstack server create --flavor c1 --volume 119958b1-0fca-4412-81d1-1d9b856ce85a --nic net-id=private --availability-zone az1 vm-az1
+```
+
+Observe the VMs
+
+```
+sh-5.1$ openstack server list
++--------------------------------------+--------+--------+-----------------------+--------------------------+--------+
+| ID                                   | Name   | Status | Networks              | Image                    | Flavor |
++--------------------------------------+--------+--------+-----------------------+--------------------------+--------+
+| 54e1a625-08d1-4df5-838c-c8ea676d2e06 | vm-az1 | ACTIVE | private=192.168.0.138 | N/A (booted from volume) | c1     |
+| c1f8b608-41d4-422a-ab89-82762353a784 | vm-az0 | ACTIVE | private=192.168.0.21  | cirros-priv-type         | c1     |
++--------------------------------------+--------+--------+-----------------------+--------------------------+--------+
+sh-5.1$
+```
+
+## Manila Verification
+
+### Driver Handles Share Servers (DHSS)
+
+When DHSS is enabled, the driver manages the creation of share servers (Storage Virtual Machines or SVMs in ONTAP) for each tenant network, rather than having Manila handle it.
+
+The generated `OpenStackControlPlane` CR has `driver_handles_share_servers = False` so DHSS is disabled. Set it true to enable it if desired. Below are verification steps depending on if this option is enabled or disabled.
+
+### Testing with DHSS Disabled
+
+Create a share type (as the OpenStack admin).
+
+```
+openstack share type create nfs-multiaz False --extra-specs share_backend_name=nfs_az
+```
+
+Observe the share type.
+
+```
+$ openstack share type list
++--------------------------------------+--------------+------------+------------+--------------------------------------+-----------------------------+-------------+
+| ID                                   | Name         | Visibility | Is Default | Required Extra Specs                 | Optional Extra Specs        | Description |
++--------------------------------------+--------------+------------+------------+--------------------------------------+-----------------------------+-------------+
+| a63ecc00-33f5-4bd8-9d93-a1fb31f2fe79 | nfs-multiaz  | public     | False      | driver_handles_share_servers : False | share_backend_name : nfs_az | None        |
++--------------------------------------+--------------+------------+------------+--------------------------------------+-----------------------------+-------------+
+$
+```
+
+The remaining commands can be run as a normal project user.
+
+Create a share per AZ.
+
+```
+openstack share create nfs 1 --name nfsaz0 --availability-zone az0
+openstack share create nfs 1 --name nfsaz1 --availability-zone az1
+openstack share create nfs 1 --name nfsaz2 --availability-zone az2
+```
+
+Note that the `openstack share create` command did not need to pass `--share-type nfs-multiaz` because of the following from the configuration section.
+
+```
+      manilaAPI:
+        customServiceConfig: |
+          [DEFAULT]
+          storage_availability_zone = az0,az1,az2
+          default_share_type = nfs-multiaz
+```
+
+If the `default_share_type` is not set, then `--share-type nfs-multiaz` should be passed with the `openstack share create` command.
+
+Observe the shares and their AZs.
+
+```
+$ openstack share list
++--------------------------------------+--------+------+-------------+-----------+-----------+-----------------+-------------------------------+-------------------+
+| ID                                   | Name   | Size | Share Proto | Status    | Is Public | Share Type Name | Host                          | Availability Zone |
++--------------------------------------+--------+------+-------------+-----------+-----------+-----------------+-------------------------------+-------------------+
+| ef1fa319-4661-4d18-880b-a24b5e708234 | nfsaz0 |    1 | NFS         | available | False     | nfs-multiaz     | hostgroup@nfs_az0#n2_nvme_15T | az0               |
+| f91e1e59-e101-4e1f-8b92-fb49edd706cf | nfsaz1 |    1 | NFS         | available | False     | nfs-multiaz     | hostgroup@nfs_az1#n2_nvme_15T | az1               |
+| 09c9f709-1cf6-4279-ba39-8c80669b118a | nfsaz2 |    1 | NFS         | available | False     | nfs-multiaz     | hostgroup@nfs_az2#n2_nvme_15T | az2               |
++--------------------------------------+--------+------+-------------+-----------+-----------+-----------------+-------------------------------+-------------------+
+$
+```
+
+Get the NFS path(s) of a share
+
+```
+openstack share show nfsaz0
+```
+
+For example:
+
+```
+$ openstack share show nfsaz0 | grep path
+|                                       | path = 10.0.0.42:/share_9afcc8c4_2a09_4d05_8cdc_f28eb58a3dff        |
+```
+
+Grant access to the appropriate IP range based on the Nova instance to access the share:
+
+```
+openstack share access create nfsaz0 ip 10.0.0.0/24 --access-level rw
+```
+
+Mount the share from the nova instance at the desired path.
+
+```
+mount -t nfs 10.0.0.42:/share_<UUID> /mnt/share
+```
+
+### Testing with DHSS Enabled
+
+If DHSS is enabled, then `--share-network` becomes mandatory when running `openstack share create`. The share network is used to set up the share server networking and allocate the port.
+
+As the Open Stack administrator, create the share.
+
+```
+openstack share type create nfs-multiaz true --extra-specs share_backend_name='nfs_az'
+```
+
+As the project administrator, create a network and subnet for manila to use.
+
+```
+openstack network create --project rhoso --provider-network-type vlan manila_net
+openstack subnet create --network manila_net --subnet-range <subnet> --dns-nameserver <dns> manila-subnetaz1
+```
+
+As a project user, create the share network using the values from the previous step and define a share for each availability zones.
+
+```
+openstack share network create --name share_net --neutron-net-id <net_id> --neutron-subnet-id <sub_net_id>
+openstack share create nfs 1 --name nfsaz0 --share-network share_net --availability-zone az0
+openstack share create nfs 1 --name nfsaz1 --share-network share_net --availability-zone az1
+openstack share create nfs 1 --name nfsaz2 --share-network share_net --availability-zone az2
+```
+
+In this example, the created share network does not have an availability zone set, meaning that it will result in a default share network subnet being created, which spans all availability zones.
+
+It is also possible to create neutron networks and subnets for each availability zone and restrain shares on the given zones to be created on the corresponding neutron networks and subnets. To achieve such isolation level, create multiple share network subnets within the Manila share network, each one with their respective neutron network, subnet and availability zone.
+
+Note that the `openstack share create` command did not need to pass `--share-type nfs-multiaz` because of the following in the OpenStackControlPlane.
+
+```
+      manilaAPI:
+        customServiceConfig: |
+          [DEFAULT]
+          storage_availability_zone = az0,az1,az2
+          default_share_type = nfs-multiaz
+```
+
+If the `default_share_type` is not set, then `--share-type nfs-multiaz` should be passed with the `openstack share create` command.
+
+Get the NFS path(s) of a share
+
+```
+openstack share show nfsaz0
+```
+
+For example:
+
+```
+$ openstack share show nfsaz0 | grep 10.0.0.42
+|                                       | path = 10.0.0.42:/share_9afcc8c4_2a09_4d05_8cdc_f28eb58a3dff        |
+```
+
+Grant access to the appropriate IP range based on the Nova instance to access the share:
+
+```
+openstack share access create nfsaz0 ip 10.0.0.0/24 --access-level rw
+```
+
+Mount the share from the virtual machine at the desired path.
+
+```
+mount -t nfs 10.0.0.42:/share_<UUID> /mnt/share
+```

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -6,6 +6,7 @@
       - rhoso-architecture-validate-bgp_dt01
       - rhoso-architecture-validate-bmo01
       - rhoso-architecture-validate-dcn
+      - rhoso-architecture-validate-dz-storage
       - rhoso-architecture-validate-hci
       - rhoso-architecture-validate-hci-adoption
       - rhoso-architecture-validate-multi-namespace

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -65,6 +65,25 @@
       cifmw_networking_env_def_file: automation/net-env/dcn.yaml
 - job:
     files:
+    - automation/mocks/dz-storage.yaml
+    - examples/dt/dz-storage/control-plane
+    - examples/dt/dz-storage/control-plane/networking
+    - examples/dt/dz-storage/control-plane/networking/nncp
+    - examples/dt/dz-storage/edpm/computes/r0
+    - examples/dt/dz-storage/edpm/computes/r1
+    - examples/dt/dz-storage/edpm/computes/r2
+    - examples/dt/dz-storage/edpm/deployment
+    - examples/dt/dz-storage/edpm/networkers/r0
+    - examples/dt/dz-storage/edpm/networkers/r1
+    - examples/dt/dz-storage/edpm/networkers/r2
+    - examples/dt/dz-storage/topology
+    - lib
+    name: rhoso-architecture-validate-dz-storage
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: dz-storage
+- job:
+    files:
     - examples/va/hci
     - examples/va/hci/control-plane
     - examples/va/hci/control-plane/networking


### PR DESCRIPTION
This DT is the same as bgp-l3-xl but it also has three zones confgiured with topology CRDs used to either spread pods accross zones or keep them within a zone. There is a separate cinder-volume and manila-share service per zone. It uses a NetApp as an iSCSI backend for Cinder and an NFS backend for Manila. Glance uses Cinder as its backend and is configured with multiple stores.

Co-authored-by: Claude (AI Assistant) claude@anthropic.com
Jira: https://issues.redhat.com/browse/OSPRH-18447