### PR TITLE
Add some missing Kustomize APIVersion and Kind fields

### DIFF
--- a/examples/common/metallb/kustomization.yaml
+++ b/examples/common/metallb/kustomization.yaml
@@ -1,3 +1,6 @@
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 components:
   - ../../../lib/metallb

--- a/examples/common/nmstate/kustomization.yaml
+++ b/examples/common/nmstate/kustomization.yaml
@@ -1,3 +1,6 @@
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 components:
   - ../../../lib/nmstate

--- a/examples/common/olm-subscriptions/kustomization.yaml
+++ b/examples/common/olm-subscriptions/kustomization.yaml
@@ -1,4 +1,7 @@
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 components:
   - ../../../lib/olm-deps
   - ../../../lib/olm-openstack-subscriptions/overlays/default

--- a/examples/common/olm/kustomization.yaml
+++ b/examples/common/olm/kustomization.yaml
@@ -1,4 +1,7 @@
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 components:
   - ../../../lib/olm-deps
   - ../../../lib/olm-openstack

--- a/examples/common/openstack/kustomization.yaml
+++ b/examples/common/openstack/kustomization.yaml
@@ -1,3 +1,6 @@
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 components:
   - ../../../lib/openstack

--- a/examples/dt/bgp-l3-xl/metallb/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/metallb/kustomization.yaml
@@ -1,4 +1,7 @@
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 components:
   - ../../../../lib/metallb
 

--- a/examples/dt/bgp_dt01/metallb/kustomization.yaml
+++ b/examples/dt/bgp_dt01/metallb/kustomization.yaml
@@ -1,4 +1,7 @@
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 components:
   - ../../../../lib/metallb
 


### PR DESCRIPTION
Found a few `kustomization.yaml`s that were missing `APIVersion` and `Kind`.  They still work without them, but let's make sure they're canonically correct.

Co-authored-by: Claude [claude@anthropic.com](mailto:claude@anthropic.com)