### PR TITLE
Add SNR/NHC to dz-storage DT

### DIFF
--- a/automation/vars/dz-storage.yaml
+++ b/automation/vars/dz-storage.yaml
@@ -63,6 +63,12 @@ vas:
             resource_name: openshift-no-reapply-sysctl
             namespace: openshift-cluster-node-tuning-operator
             state: present
+
+          - name: Deploy SNR/NHC
+            type: playbook
+            source: "../../playbooks/snr-nhc.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+
         name: nncp-configuration
         path: examples/dt/dz-storage/control-plane/networking/nncp
         wait_conditions:

--- a/examples/dt/dz-storage/README.md
+++ b/examples/dt/dz-storage/README.md
@@ -12,7 +12,7 @@ but it also has the following:
   - zone C RHEL: r2-compute-0, r2-compute-1, r2-networker-0, leaf-4, leaf-5
 - [Toplogy CRDs](https://github.com/openstack-k8s-operators/infra-operator/pull/325) are
   used to either spread pods accross zones or keep them within a zone.
-- Self Node Remdiation and Node Health Checks
+- Self Node Remediation and Node Health Checks
 - It is assumed that a Storage Array is physically located in each of the zones.
   This examples uses a NetApp as an iSCSI backend for Cinder and an NFS backend for Manila.
 - Glance uses Cinder as its backend and is configured with multiple stores


### PR DESCRIPTION
Call the SNR (self node remediation) and NHC (node health check) playbook to configure SNR and NHC on OpenShift before deploying OpenStack for the dz-storage scenario.

Also, spell fix spelling of remediation in README.