### PR TITLE
[Do NOT merge] Add nmstate yaml for dz-storage hosts

### DIFF
--- a/automation/net-env/dz-storage/hosts.yaml
+++ b/automation/net-env/dz-storage/hosts.yaml
@@ -1,0 +1,40 @@
+- ip: 192.168.111.10
+  hostnames:
+    - "master-0"
+- ip: 192.168.111.11
+  hostnames:
+    - "master-1"
+- ip: 192.168.111.12
+  hostnames:
+    - "master-2"
+- ip: 192.168.111.13
+  hostnames:
+    - "worker-0"
+- ip: 192.168.111.14
+  hostnames:
+    - "worker-1"
+- ip: 192.168.111.15
+  hostnames:
+    - "worker-2"
+- ip: 192.168.111.16
+  hostnames:
+    - "worker-3"
+- ip: 192.168.111.17
+  hostnames:
+    - "worker-4"
+- ip: 192.168.111.18
+  hostnames:
+    - "worker-5"
+- ip: 192.168.111.19
+  hostnames:
+    - "worker-6"
+- ip: 192.168.111.20
+  hostnames:
+    - "worker-7"
+- ip: 192.168.111.21
+  hostnames:
+    - "worker-8"
+- ip: 192.168.111.22
+  hostnames:
+    - "worker-9"
+

--- a/automation/net-env/dz-storage/ocp-master-0.yaml
+++ b/automation/net-env/dz-storage/ocp-master-0.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.10"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.0.18"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.0.18"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.5"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-master-1.yaml
+++ b/automation/net-env/dz-storage/ocp-master-1.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.11"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.1.18"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.1.18"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.6"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-master-2.yaml
+++ b/automation/net-env/dz-storage/ocp-master-2.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.12"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.18"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.18"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.7"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-worker-0.yaml
+++ b/automation/net-env/dz-storage/ocp-worker-0.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.13"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.0.22"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.0.22"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.8"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-worker-1.yaml
+++ b/automation/net-env/dz-storage/ocp-worker-1.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.14"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.0.26"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.0.26"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.9"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-worker-2.yaml
+++ b/automation/net-env/dz-storage/ocp-worker-2.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.15"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.0.30"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.0.30"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.10"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-worker-3.yaml
+++ b/automation/net-env/dz-storage/ocp-worker-3.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.16"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.1.22"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.1.22"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.11"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-worker-4.yaml
+++ b/automation/net-env/dz-storage/ocp-worker-4.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.17"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.1.26"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.1.26"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.12"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-worker-5.yaml
+++ b/automation/net-env/dz-storage/ocp-worker-5.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.18"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.1.30"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.1.30"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.13"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-worker-6.yaml
+++ b/automation/net-env/dz-storage/ocp-worker-6.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.19"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.22"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.22"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.14"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-worker-7.yaml
+++ b/automation/net-env/dz-storage/ocp-worker-7.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.20"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.26"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.26"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.15"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-worker-8.yaml
+++ b/automation/net-env/dz-storage/ocp-worker-8.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.21"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.30"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.30"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.16"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/net-env/dz-storage/ocp-worker-9.yaml
+++ b/automation/net-env/dz-storage/ocp-worker-9.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.22"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.10.2"
+        prefix-length: 24
+      enabled: true
+  - name: enp9s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.10.2"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.17"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/automation/vars/dz-storage.yaml
+++ b/automation/vars/dz-storage.yaml
@@ -3,7 +3,7 @@ vas:
   dz-storage:
     stages:
       - pre_stage_run:
-          - name: Apply taint on worker-9
+          - name: "1 - Apply taint on worker-9"
             type: cr
             definition:
               spec:
@@ -17,7 +17,7 @@ vas:
             kind: Node
             resource_name: worker-9
             state: patched
-          - name: Disable rp_filters on OCP nodes
+          - name: "2 - Disable rp_filters on OCP nodes"
             type: cr
             definition:
               spec:
@@ -64,7 +64,12 @@ vas:
             namespace: openshift-cluster-node-tuning-operator
             state: present
 
-          - name: Deploy SNR/NHC
+          - name: "3 - Make Pre BGP network configurations"
+            type: playbook
+            source: "../../hooks/playbooks/pre-bgp-netconf.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+
+          - name: "4 - Deploy SNR/NHC"
             type: playbook
             source: "../../playbooks/snr-nhc.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"


### PR DESCRIPTION
The dz-storage DT has automation to apply nmstate configuration. This PR adds nmstate YAML for each virtual host in the dz-storage DT and uses a pre_stage_run to call the pre-bgp-netconf.yml hook to populate it.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3264