### PR TITLE
[BGP] Remove ovnController

### DIFF
--- a/examples/dt/bgp-l3-xl/control-plane/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/kustomization.yaml
@@ -24,19 +24,16 @@ transformers:
         kind: Namespace
         create: true
 
+patches:
+  # with BGP, ovnController has to be disabled from OCP nodes
+  - target:
+      kind: OpenStackControlPlane
+      name: controlplane
+    patch: |-
+      - op: remove
+        path: /spec/ovn/template/ovnController
+
 replacements:
-  # disable OCP workers as gateway nodes
-  - source:
-      kind: ConfigMap
-      name: service-values
-      fieldPath: data.ovn.ovnController.external-ids
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.ovn.template.ovnController.external-ids
-        options:
-          create: true
   # configure neutron customServiceConfig
   - source:
       kind: ConfigMap

--- a/examples/dt/bgp-l3-xl/control-plane/service-values.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/service-values.yaml
@@ -55,10 +55,6 @@ data:
         [controller_worker]
         loadbalancer_topology=ACTIVE_STANDBY
 
-  ovn:
-    ovnController:
-      external-ids:
-        enable-chassis-as-gateway: false
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/bgp_dt01/control-plane/kustomization.yaml
+++ b/examples/dt/bgp_dt01/control-plane/kustomization.yaml
@@ -24,6 +24,15 @@ transformers:
         kind: Namespace
         create: true
 
+patches:
+  # with BGP, ovnController has to be disabled from OCP nodes
+  - target:
+      kind: OpenStackControlPlane
+      name: controlplane
+    patch: |-
+      - op: remove
+        path: /spec/ovn/template/ovnController
+
 replacements:
   # BGP peer IP addresses
   # node3
@@ -111,18 +120,6 @@ replacements:
           name: bgpnet-worker-3
         fieldPaths:
           - spec.config
-  # disable OCP workers as gateway nodes
-  - source:
-      kind: ConfigMap
-      name: service-values
-      fieldPath: data.ovn.ovnController.external-ids
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.ovn.template.ovnController.external-ids
-        options:
-          create: true
   # configure neutron customServiceConfig
   - source:
       kind: ConfigMap

--- a/examples/dt/bgp_dt01/control-plane/service-values.yaml
+++ b/examples/dt/bgp_dt01/control-plane/service-values.yaml
@@ -55,13 +55,6 @@ data:
         [controller_worker]
         loadbalancer_topology=ACTIVE_STANDBY
 
-  ovn:
-    ovnController:
-      nicMappings:
-        datacentre: ocpbr
-        # octavia: octbr TODO(eolivare): enable octavia
-      external-ids:
-        enable-chassis-as-gateway: false
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/bgp_dt04_ipv6/control-plane/kustomization.yaml
+++ b/examples/dt/bgp_dt04_ipv6/control-plane/kustomization.yaml
@@ -24,6 +24,15 @@ transformers:
         kind: Namespace
         create: true
 
+patches:
+  # with BGP, ovnController has to be disabled from OCP nodes
+  - target:
+      kind: OpenStackControlPlane
+      name: controlplane
+    patch: |-
+      - op: remove
+        path: /spec/ovn/template/ovnController
+
 replacements:
   # BGP peer IP addresses
   # node3
@@ -111,18 +120,6 @@ replacements:
           name: bgpnet-worker-3
         fieldPaths:
           - spec.config
-  # disable OCP workers as gateway nodes
-  - source:
-      kind: ConfigMap
-      name: service-values
-      fieldPath: data.ovn.ovnController.external-ids
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.ovn.template.ovnController.external-ids
-        options:
-          create: true
   # configure neutron customServiceConfig
   - source:
       kind: ConfigMap

--- a/examples/dt/bgp_dt04_ipv6/control-plane/service-values.yaml
+++ b/examples/dt/bgp_dt04_ipv6/control-plane/service-values.yaml
@@ -55,13 +55,6 @@ data:
         [controller_worker]
         loadbalancer_topology=ACTIVE_STANDBY
 
-  ovn:
-    ovnController:
-      nicMappings:
-        datacentre: ocpbr
-        # octavia: octbr TODO(eolivare): enable octavia
-      external-ids:
-        enable-chassis-as-gateway: false
   neutron:
     customServiceConfig: |
       [DEFAULT]

--- a/examples/dt/dz-storage/control-plane/kustomization.yaml
+++ b/examples/dt/dz-storage/control-plane/kustomization.yaml
@@ -14,6 +14,13 @@ patches:
       - op: replace
         path: /spec/glance/apiOverrides
         value: {}
+  # with BGP, ovnController has to be disabled from OCP nodes
+  - target:
+      kind: OpenStackControlPlane
+      name: controlplane
+    patch: |-
+      - op: remove
+        path: /spec/ovn/template/ovnController
 
 resources:
   - networking/nncp/values.yaml
@@ -41,18 +48,6 @@ transformers:
         create: true
 
 replacements:
-  # disable OCP workers as gateway nodes
-  - source:
-      kind: ConfigMap
-      name: service-values
-      fieldPath: data.ovn.ovnController.external-ids
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.ovn.template.ovnController.external-ids
-        options:
-          create: true
   # configure neutron customServiceConfig
   - source:
       kind: ConfigMap

--- a/examples/dt/dz-storage/control-plane/service-values.yaml
+++ b/examples/dt/dz-storage/control-plane/service-values.yaml
@@ -388,11 +388,6 @@ data:
         [controller_worker]
         loadbalancer_topology=ACTIVE_STANDBY
 
-  ovn:
-    ovnController:
-      external-ids:
-        enable-chassis-as-gateway: false
-
   neutron:
     customServiceConfig: |
       [DEFAULT]


### PR DESCRIPTION
ovnController has to be removed from controlplane ovn configuration when BGP is used because OCP nodes should not act as OVN chassis at all.