### PR TITLE
[BGP] Replace bgp-l3-computes-ready.yml with nova_wait_for_compute_service.yml

### DIFF
--- a/automation/vars/bgp-l3-xl.yaml
+++ b/automation/vars/bgp-l3-xl.yaml
@@ -206,6 +206,7 @@ vas:
         post_stage_run:
           - name: Wait until computes are ready
             type: playbook
-            source: "../../playbooks/bgp-l3-computes-ready.yml"
+            source: "nova_wait_for_compute_service.yml"
             extra_vars:
-              num_computes: 6
+              _number_of_computes: 6
+              _cell_conductor: nova-cell0-conductor-0

--- a/automation/vars/bgp_dt01.yaml
+++ b/automation/vars/bgp_dt01.yaml
@@ -194,6 +194,7 @@ vas:
         post_stage_run:
           - name: Wait until computes are ready
             type: playbook
-            source: "../../playbooks/bgp-l3-computes-ready.yml"
+            source: "nova_wait_for_compute_service.yml"
             extra_vars:
-              num_computes: 3
+              _number_of_computes: 3
+              _cell_conductor: nova-cell0-conductor-0

--- a/automation/vars/bgp_dt04_ipv6.yaml
+++ b/automation/vars/bgp_dt04_ipv6.yaml
@@ -193,6 +193,7 @@ vas:
         post_stage_run:
           - name: Wait until computes are ready
             type: playbook
-            source: "../../playbooks/bgp-l3-computes-ready.yml"
+            source: "nova_wait_for_compute_service.yml"
             extra_vars:
-              num_computes: 3
+              _number_of_computes: 3
+              _cell_conductor: nova-cell0-conductor-0

--- a/automation/vars/dz-storage.yaml
+++ b/automation/vars/dz-storage.yaml
@@ -224,9 +224,10 @@ vas:
         post_stage_run:
           - name: "1 - Wait until computes are ready"
             type: playbook
-            source: "../../playbooks/bgp-l3-computes-ready.yml"
+            source: "nova_wait_for_compute_service.yml"
             extra_vars:
-              num_computes: 6
+              _number_of_computes: 6
+              _cell_conductor: nova-cell0-conductor-0
           - name: "2 - Setup Cinder volume types and Nova aggregates for dz-storage"
             type: playbook
             source: "../../hooks/playbooks/dz_storage_post_deploy_az.yaml"


### PR DESCRIPTION
There were some duplicate playbooks/hooks that have been removed from ci-framework.

[OSPRH-19510](https://issues.redhat.com//browse/OSPRH-19510)