### PR TITLE
Add databaseInstance for manila in ctlplane template

### DIFF
--- a/lib/control-plane/base/openstackcontrolplane.yaml
+++ b/lib/control-plane/base/openstackcontrolplane.yaml
@@ -155,6 +155,7 @@ spec:
       route: {"haproxy.router.openshift.io/timeout": "60s"}
     enabled: false
     template:
+      databaseInstance: openstack
       manilaAPI:
         networkAttachments:
           - internalapi


### PR DESCRIPTION
There seems to be a bug in the current controller-gen version used, which resulted in the databaseInstance in manila not to be a required paramater.
With the bump controller-gen happening as part of the golang-bump work the databaseInstance gets added as a required parameter [1]. This adds it to the ctlplane template.

[1] https://github.com/openstack-k8s-operators/manila-operator/pull/462#discussion_r2293947364