### PR TITLE
[BGP] Run bootstrap before download-cache

### DIFF
--- a/examples/dt/bgp-l3-xl/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r0/values.yaml
@@ -189,8 +189,8 @@ data:
             subnetName: subnet0
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0013
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp-l3-xl/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r1/values.yaml
@@ -189,8 +189,8 @@ data:
             name: BgpMainNetV6
             subnetName: subnet1
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp-l3-xl/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/computes/r2/values.yaml
@@ -189,8 +189,8 @@ data:
             name: BgpMainNetV6
             subnetName: subnet2
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r0/values.yaml
@@ -153,8 +153,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0014
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r1/values.yaml
@@ -153,8 +153,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0024
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp-l3-xl/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp-l3-xl/edpm/networkers/r2/values.yaml
@@ -153,8 +153,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0034
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
@@ -152,8 +152,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
@@ -152,8 +152,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
@@ -152,8 +152,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
@@ -152,8 +152,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0013
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
@@ -152,8 +152,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
@@ -152,8 +152,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt04_ipv6/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt04_ipv6/edpm/computes/r0/values.yaml
@@ -179,8 +179,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:99:99:0:2
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt04_ipv6/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt04_ipv6/edpm/computes/r1/values.yaml
@@ -179,8 +179,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:99:99:1:2
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt04_ipv6/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt04_ipv6/edpm/computes/r2/values.yaml
@@ -179,8 +179,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:99:99:2:2
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt04_ipv6/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt04_ipv6/edpm/networkers/r0/values.yaml
@@ -179,8 +179,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:99:99:0:3
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt04_ipv6/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt04_ipv6/edpm/networkers/r1/values.yaml
@@ -179,8 +179,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:99:99:1:3
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/bgp_dt04_ipv6/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt04_ipv6/edpm/networkers/r2/values.yaml
@@ -179,8 +179,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:99:99:2:3
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/dz-storage/edpm/computes/r0/values.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r0/values.yaml
@@ -189,8 +189,8 @@ data:
             subnetName: subnet0
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0013
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/dz-storage/edpm/computes/r1/values.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r1/values.yaml
@@ -189,8 +189,8 @@ data:
             name: BgpMainNetV6
             subnetName: subnet1
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/dz-storage/edpm/computes/r2/values.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r2/values.yaml
@@ -189,8 +189,8 @@ data:
             name: BgpMainNetV6
             subnetName: subnet2
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/dz-storage/edpm/networkers/r0/values.yaml
+++ b/examples/dt/dz-storage/edpm/networkers/r0/values.yaml
@@ -153,8 +153,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0014
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/dz-storage/edpm/networkers/r1/values.yaml
+++ b/examples/dt/dz-storage/edpm/networkers/r1/values.yaml
@@ -153,8 +153,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0024
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os

--- a/examples/dt/dz-storage/edpm/networkers/r2/values.yaml
+++ b/examples/dt/dz-storage/edpm/networkers/r2/values.yaml
@@ -153,8 +153,8 @@ data:
             subnetName: subnet1
             fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0034
     services:
-      - download-cache
       - bootstrap
+      - download-cache
       - configure-network
       - install-os
       - configure-os


### PR DESCRIPTION
The BGP jobs were the only ones running download-cache EDPM service before bootstrap. This worked well until [1].
The bootstrap service has to run first, in order to generate the bootc fact.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/1018