### PR TITLE
W/a grub2-mkconfig issue for nova04/vfio

### DIFF
--- a/dt/nova/nova04delta/edpm/nodeset/nova_gpu.yaml
+++ b/dt/nova/nova04delta/edpm/nodeset/nova_gpu.yaml
@@ -89,4 +89,6 @@ spec:
               {{ '--update-bls-cmdline'
               if check_update_bls_cmdline.rc == 0
               else '' }}
+            - tuned-adm profile {{ edpm_tuned_profile }}
+            - 'dracut --force'
           when: (_blacklist_nvidia.changed or _load_vfio.changed)


### PR DESCRIPTION
When regenerating initramfs, always re-apply the tuned profile to make sure nothing breaks its BLS snippets.

Related: [RHEL-71494](https://issues.redhat.com//browse/RHEL-71494)
Closes: [OSPRH-25603](https://issues.redhat.com//browse/OSPRH-25603)