### PR TITLE
Fix manila apiOverride route configuration haproxy timeout annotation under metadata.annotations

### DIFF
--- a/lib/control-plane/base/openstackcontrolplane.yaml
+++ b/lib/control-plane/base/openstackcontrolplane.yaml
@@ -148,7 +148,10 @@ spec:
       replicas: 3
   manila:
     apiOverride:
-      route: {"haproxy.router.openshift.io/timeout": "60s"}
+      route:
+        metadata:
+          annotations:
+            haproxy.router.openshift.io/timeout: 60s
     enabled: false
     template:
       databaseInstance: openstack


### PR DESCRIPTION
**What does this PR do?**
Fix manila apiOverride route configuration from the inline JSON format to the proper nested YAML structure with the HAProxy timeout annotation under `metadata.annotations`

**Why do we need it?**
Base openstackcontrolplane has haproxy timeout directly under route, but the CRD schema requires it to be under `route.metadata.annotations`. 

```
╰$ oc explain openstackcontrolplane.spec.manila.apiOverride --recursive
GROUP:      core.openstack.org
KIND:       OpenStackControlPlane
VERSION:    v1beta1

FIELD: apiOverride <Object>


DESCRIPTION:
    <empty>
FIELDS:
  route	<Object>
    metadata	<Object>
      annotations	<map[string]string>
      labels	<map[string]string>

```