### PR TITLE
uni05epsilon - deploy rabbitmq-notifications from the start

### DIFF
--- a/dt/uni05epsilon/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/uni05epsilon/edpm-post-ceph/nodeset/kustomization.yaml
@@ -388,20 +388,6 @@ replacements:
           create: true
 
   #
-  # Notifications
-  #
-  - source:
-      kind: ConfigMap
-      name: service-values
-      fieldPath: data.rabbitmq.templates.rabbitmq-notifications
-    targets:
-      - select:
-          kind: OpenStackControlPlane
-        fieldPaths:
-          - spec.rabbitmq.templates.rabbitmq-notifications
-        options:
-          create: true
-  #
   # Telemetry
   #
   - source:

--- a/dt/uni05epsilon/kustomization.yaml
+++ b/dt/uni05epsilon/kustomization.yaml
@@ -71,6 +71,18 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.rabbitmq.templates.rabbitmq-notifications
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-notifications
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.nova.template.cellTemplates.cell2
     targets:
       - select:

--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -11,7 +11,7 @@ data:
   # --- Fields required by lib/control-plane ---
   preserveJobs: false
   notificationsBus:
-    cluster: rabbitmq
+    cluster: rabbitmq-notifications
   tls:
     caBundleSecretName: ""
 
@@ -38,6 +38,23 @@ data:
   rabbitmq:
     templates:
       rabbitmq-cell2:
+        replicas: 3
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi
+      rabbitmq-notifications:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.88
+            spec:
+              type: LoadBalancer
         replicas: 3
         resources:
           limits:


### PR DESCRIPTION
The commit moves the rabbitmq-notifications RabbitMQ instance from being deployed in the post-Ceph stage to being deployed from the start (control-plane stage).