### PR TITLE
Add nova05epsilon for DCN with BM SNO+EDPM

### DIFF
--- a/automation/vars/nova05epsilon.yaml
+++ b/automation/vars/nova05epsilon.yaml
@@ -1,0 +1,134 @@
+---
+vas:
+  nova05epsilon:
+    stages:
+      - name: nncp-configuration
+        path: examples/dt/nova/nova05epsilon/control-plane/networking/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - name: network-configuration
+        path: examples/dt/nova/nova05epsilon/control-plane/networking
+        wait_conditions:
+          - >-
+            oc -n metallb-system wait pod
+            -l app=metallb -l component=speaker
+            --for condition=Ready
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: network.yaml
+
+      - name: control-plane
+        path: examples/dt/nova/nova05epsilon/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane
+            --for condition=OpenStackControlPlaneDNSReadyCondition
+            --timeout=20m
+        values:
+          - name: network-values
+            src_file: networking/nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+
+      - name: dns-configuration
+        path: examples/dt/nova/nova05epsilon/control-plane/networking/dns
+        wait_conditions:
+          - >-
+            oc -n openshift-dns wait dns.operator/default
+            --for condition=Available
+            --timeout=20m
+        values:
+          - name: dns-values
+            src_file: values.yaml
+        build_output: dns.yaml
+
+      - name: baremetalhosts-configuration
+        path: examples/dt/nova/nova05epsilon/edpm/baremetalhosts
+        wait_conditions:
+          - >-
+            oc -n openstack wait baremetalhosts.metal3.io edpm-compute-0
+            --for=jsonpath='{.status.provisioning.state}'=available
+            --timeout=20m
+          - >-
+            oc -n openstack wait osctlplane controlplane
+            --for condition=Ready
+            --timeout=20m
+        values:
+          - name: baremetalhost-values
+            src_file: values.yaml
+        build_output: baremetalhosts.yaml
+
+      - name: edpm-nodeset-pre-ceph
+        path: examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait osdpns
+            gpu-computes-edpm
+            --for condition=SetupReady
+            --timeout=10m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset-pre-ceph.yaml
+
+      - name: edpm-deployment-pre-ceph
+        path: examples/dt/nova/nova05epsilon/edpm-pre-ceph/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait osdpd
+            edpm-deployment-pre-ceph
+            --for condition=Ready
+            --timeout=40m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment-pre-ceph.yaml
+        post_stage_run:
+          - name: Deploy Ceph
+            type: playbook
+            source: "../../hooks/playbooks/ceph.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+
+      - name: edpm-nodeset-post-ceph
+        path: examples/dt/nova/nova05epsilon
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane
+            --for condition=Ready
+            --timeout=20m
+          - >-
+            oc -n openstack wait osdpns
+            gpu-computes-edpm
+            --for condition=SetupReady
+            --timeout=10m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: edpm-nodeset-values-post-ceph
+            src_file: values.yaml
+        build_output: nodeset-post-ceph.yaml
+
+      - name: edpm-deployment-post-ceph
+        path: examples/dt/nova/nova05epsilon/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait osdpd
+            edpm-deployment-post-ceph
+            --for condition=Ready
+            --timeout=40m
+        values:
+          - name: edpm-deployment-values-post-ceph
+            src_file: values.yaml
+        build_output: deployment-post-ceph.yaml

--- a/automation/vars/nova05epsilon.yaml
+++ b/automation/vars/nova05epsilon.yaml
@@ -1,0 +1,135 @@
+---
+vas:
+  nova05epsilon:
+    stages:
+      - name: nncp-configuration
+        path: examples/dt/nova/nova05epsilon/control-plane/networking/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - name: network-configuration
+        path: examples/dt/nova/nova05epsilon/control-plane/networking
+        wait_conditions:
+          - >-
+            oc -n metallb-system wait pod
+            -l app=metallb -l component=speaker
+            --for condition=Ready
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: network.yaml
+
+      - name: control-plane
+        path: examples/dt/nova/nova05epsilon/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane
+            --for condition=OpenStackControlPlaneDNSReadyCondition
+            --timeout=20m
+        values:
+          - name: network-values
+            src_file: networking/nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+
+      - name: dns-configuration
+        path: examples/dt/nova/nova05epsilon/control-plane/networking/dns
+        wait_conditions:
+          - >-
+            oc -n openshift-dns wait dns.operator/default
+            --for condition=Available
+            --timeout=20m
+        values:
+          - name: dns-values
+            src_file: values.yaml
+        build_output: dns.yaml
+
+      - name: baremetalhosts-configuration
+        path: examples/dt/nova/nova05epsilon/edpm/baremetalhosts
+        wait_conditions:
+          - >-
+            oc -n openstack wait baremetalhosts.metal3.io edpm-compute-0
+            --for=jsonpath='{.status.provisioning.state}'=available
+            --timeout=20m
+          - >-
+            oc -n openstack wait osctlplane controlplane
+            --for condition=Ready
+            --timeout=20m
+        values:
+          - name: baremetalhost-values
+            src_file: values.yaml
+        build_output: baremetalhosts.yaml
+
+      # TODO: decrease timeout after hosting the dataplane on rdu4 instead of brq2
+      - name: edpm-nodeset-pre-ceph
+        path: examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait osdpns
+            gpu-computes-edpm
+            --for condition=SetupReady
+            --timeout=90m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset-pre-ceph.yaml
+
+      - name: edpm-deployment-pre-ceph
+        path: examples/dt/nova/nova05epsilon/edpm-pre-ceph/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait osdpd
+            edpm-deployment-pre-ceph
+            --for condition=Ready
+            --timeout=90m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment-pre-ceph.yaml
+        post_stage_run:
+          - name: Deploy Ceph
+            type: playbook
+            source: "../../hooks/playbooks/ceph.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/ceph_inventory.yml"
+
+      - name: edpm-nodeset-post-ceph
+        path: examples/dt/nova/nova05epsilon
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane
+            --for condition=Ready
+            --timeout=20m
+          - >-
+            oc -n openstack wait osdpns
+            gpu-computes-edpm
+            --for condition=SetupReady
+            --timeout=10m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: edpm-nodeset-values-post-ceph
+            src_file: values.yaml
+        build_output: nodeset-post-ceph.yaml
+
+      - name: edpm-deployment-post-ceph
+        path: examples/dt/nova/nova05epsilon/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait osdpd
+            edpm-deployment-post-ceph
+            --for condition=Ready
+            --timeout=90m
+        values:
+          - name: edpm-deployment-values-post-ceph
+            src_file: values.yaml
+        build_output: deployment-post-ceph.yaml

--- a/dt/nova/nova05epsilon/README.md
+++ b/dt/nova/nova05epsilon/README.md
@@ -1,0 +1,12 @@
+# Deployed Topology - Nova/nova05epsilon
+
+If you are looking for information on how to deploy the nova05epsilon based DT, then
+please see the
+[README](../../../examples/dt/nova/nova05epsilon/README.md) in the examples
+directory.
+
+This directory, `dt/nova/nova05epsilon/`, exists so that the
+[kustomization.yaml](../../../examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/kustomization.yaml)
+in the examples directory of nova05epsilon topology, reference it by path as a
+component. Its contents are likely uninteresting unless you want to understand
+how kustomize was implemented in this repository.

--- a/dt/nova/nova05epsilon/control-plane/kustomization.yaml
+++ b/dt/nova/nova05epsilon/control-plane/kustomization.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/control-plane/base
+  - ../../../../lib/control-plane/service-endpoints
+  - ../../../../lib/control-plane/dns
+  - ../../../../lib/control-plane/storage
+  - ../../../../lib/control-plane/ovn-bridge
+  - ../../../../lib/control-plane/job-settings
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.neutron.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.neutron.template.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.ovn.ovnController.nicMappings
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ovn.template.ovnController.nicMappings
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.default.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.swift.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.swift.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.apiServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.apiServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cell0.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell0.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.cell1.conductorServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.cellTemplates.cell1.conductorServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.nova.schedulerServiceTemplate.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.nova.template.schedulerServiceTemplate.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.extraMounts
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.extraMounts
+        options:
+          create: true

--- a/dt/nova/nova05epsilon/edpm-post-ceph/deployment/kustomization.yaml
+++ b/dt/nova/nova05epsilon/edpm-post-ceph/deployment/kustomization.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../lib/dataplane/deployment
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values-post-ceph
+      fieldPath: data.deployment.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values-post-ceph
+      fieldPath: data.nodeset_name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.nodeSets.*
+        options:
+          create: true

--- a/dt/nova/nova05epsilon/edpm-post-ceph/nodeset/ceph_secret.yaml
+++ b/dt/nova/nova05epsilon/edpm-post-ceph/nodeset/ceph_secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+data:
+  ceph.client.openstack.keyring: _ignored_
+  ceph.conf: _ignored_
+kind: Secret
+metadata:
+  name: ceph-conf-files
+  namespace: openstack
+type: Opaque

--- a/dt/nova/nova05epsilon/edpm-post-ceph/nodeset/extra_mounts.yaml
+++ b/dt/nova/nova05epsilon/edpm-post-ceph/nodeset/extra_mounts.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm
+spec:
+  nodeTemplate:
+    extraMounts:
+      - extraVolType: Ceph
+        mounts:
+          - mountPath: /etc/ceph
+            name: ceph
+            readOnly: true
+        volumes:
+          - name: ceph
+            secret:
+              secretName: ceph-conf-files

--- a/dt/nova/nova05epsilon/edpm-post-ceph/nodeset/kustomization.yaml
+++ b/dt/nova/nova05epsilon/edpm-post-ceph/nodeset/kustomization.yaml
@@ -1,0 +1,144 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../control-plane/
+  - ../../../../../lib/dataplane/nodeset
+
+resources:
+  - ceph_secret.yaml
+  - nova_gpu_ceph.yaml
+  - neutron_metadata.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    path: extra_mounts.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.nodeset_name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true
+  # Ceph config files (DCN convention: ceph_conf dict -> Secret data)
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.ceph_conf
+    targets:
+      - select:
+          kind: Secret
+          name: ceph-conf-files
+        fieldPaths:
+          - data
+        options:
+          create: true
+  # Nova Ceph conf
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.nova.ceph.conf
+    targets:
+      - select:
+          kind: ConfigMap
+          name: ceph-nova
+        fieldPaths:
+          - data.03-ceph-nova\.conf
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.nova.name
+    targets:
+      - select:
+          kind: ConfigMap
+          name: ceph-nova
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.nova.dataSources
+    targets:
+      - select:
+          kind: OpenStackDataPlaneService
+          name: nova-custom-gpu-ceph
+        fieldPaths:
+          - spec.dataSources
+        options:
+          create: true
+  # Dataplane services override
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.nodeset.services
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - spec.services
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.nova.customDataplaneService.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneService
+          name: nova-custom-gpu-ceph
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.neutron-metadata.dataSources
+    targets:
+      - select:
+          kind: OpenStackDataPlaneService
+          name: neutron-metadata
+        fieldPaths:
+          - spec.dataSources
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values-post-ceph
+      fieldPath: data.neutron-metadata.customDataplaneService.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneService
+          name: neutron-metadata
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true

--- a/dt/nova/nova05epsilon/edpm-post-ceph/nodeset/neutron_metadata.yaml
+++ b/dt/nova/nova05epsilon/edpm-post-ceph/nodeset/neutron_metadata.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: neutron-metadata
+  namespace: openstack
+spec:
+  addCertMounts: false
+  caCerts: combined-ca-bundle
+  containerImageFields:
+    - EdpmNeutronMetadataAgentImage
+  dataSources:
+    - secretRef:
+        name: neutron-ovn-metadata-agent-neutron-config
+    - secretRef:
+        name: nova-cell1-metadata-neutron-config
+  edpmServiceType: neutron-metadata
+  playbook: osp.edpm.neutron_metadata
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      issuer: osp-rootca-issuer-ovn
+      keyUsages:
+        - digital signature
+        - key encipherment
+        - client auth
+      networks:
+        - ctlplane

--- a/dt/nova/nova05epsilon/edpm-post-ceph/nodeset/nova_gpu_ceph.yaml
+++ b/dt/nova/nova05epsilon/edpm-post-ceph/nodeset/nova_gpu_ceph.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-nova
+data:
+  03-ceph-nova.conf: _replaced_
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: nova-custom-gpu-ceph
+spec:
+  label: dataplane-deployment-nova-custom-gpu-ceph
+  dataSources:
+    - configMapRef:
+        name: ceph-nova
+    - configMapRef:
+        name: cpu-pinning-nova
+    - configMapRef:
+        name: gpu-nova
+    - secretRef:
+        name: nova-cell1-compute-config
+    - secretRef:
+        name: nova-migration-ssh-key
+  playbook: osp.edpm.nova
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      networks:
+        - ctlplane
+      issuer: osp-rootca-issuer-internal
+      edpmRoleServiceName: nova
+  caCerts: combined-ca-bundle
+  edpmServiceType: nova

--- a/dt/nova/nova05epsilon/edpm-pre-ceph/deployment/kustomization.yaml
+++ b/dt/nova/nova05epsilon/edpm-pre-ceph/deployment/kustomization.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../lib/dataplane/deployment
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.deployment.name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.nodeset_name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.nodeSets.*
+        options:
+          create: true

--- a/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/kustomization.yaml
+++ b/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/kustomization.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    literals:
+      - NodeRootPassword=redhat
+    options:
+      disableNameSuffixHash: true
+
+components:
+  - ../../../../../lib/dataplane/nodeset
+
+resources:
+  - network-data-secrets.yaml
+  - nova_gpu.yaml
+
+replacements:
+  # Nova compute CPU pinning customization
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.nova.compute.conf
+    targets:
+      - select:
+          kind: ConfigMap
+          name: cpu-pinning-nova
+        fieldPaths:
+          - data.25-cpu-pinning-nova\.conf
+        options:
+          create: true
+  # Nova compute PCI passthrough customization
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.nova.pci.conf
+    targets:
+      - select:
+          kind: ConfigMap
+          name: gpu-nova
+        fieldPaths:
+          - data.03-gpu-nova\.conf
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.preProvisioned
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: openstack-edpm
+        fieldPaths:
+          - spec.preProvisioned
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.baremetalSetTemplate
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+          name: openstack-edpm
+        fieldPaths:
+          - spec.baremetalSetTemplate
+        options:
+          create: true
+  # BMO root password for provisioned host
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.root_password
+    targets:
+      - select:
+          kind: Secret
+          name: baremetalset-password-secret
+        fieldPaths:
+          - data.NodeRootPassword
+        options:
+          create: true
+  # BMO networkData for provisioned host
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.baremetalHostsNetworkData.edpm-compute-0
+    targets:
+      - select:
+          kind: Secret
+          name: edpm-compute-0-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true

--- a/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/kustomization.yaml
+++ b/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/kustomization.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    literals:
+      - NodeRootPassword=redhat
+    options:
+      disableNameSuffixHash: true
+
+components:
+  - ../../../../../lib/dataplane/nodeset
+
+resources:
+  - network-data-secrets.yaml
+  - nova_gpu.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.nodeset_name
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - metadata.name
+        options:
+          create: true
+  # Nova compute CPU pinning customization
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.nova.compute.conf
+    targets:
+      - select:
+          kind: ConfigMap
+          name: cpu-pinning-nova
+        fieldPaths:
+          - data.25-cpu-pinning-nova\.conf
+        options:
+          create: true
+  # Nova compute PCI passthrough customization
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.nova.pci.conf
+    targets:
+      - select:
+          kind: ConfigMap
+          name: gpu-nova
+        fieldPaths:
+          - data.03-gpu-nova\.conf
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.preProvisioned
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - spec.preProvisioned
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.baremetalSetTemplate
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - spec.baremetalSetTemplate
+        options:
+          create: true
+  # BMO root password for provisioned host
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.root_password
+    targets:
+      - select:
+          kind: Secret
+          name: baremetalset-password-secret
+        fieldPaths:
+          - data.NodeRootPassword
+        options:
+          create: true
+  # BMO networkData for provisioned host
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.baremetalHostsNetworkData.edpm-compute-0
+    targets:
+      - select:
+          kind: Secret
+          name: edpm-compute-0-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true

--- a/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/network-data-secrets.yaml
+++ b/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/network-data-secrets.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edpm-compute-0-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}

--- a/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/nova_gpu.yaml
+++ b/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/nova_gpu.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cpu-pinning-nova
+data:
+  25-cpu-pinning-nova.conf: _replaced_
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gpu-nova
+data:
+  03-gpu-nova.conf: _replaced_
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: vfio-pci-bind
+  namespace: openstack
+spec:
+  playbookContents: |
+    - name: Bind vfio-pci to devices
+      hosts: all
+      tasks:
+        - name: Blacklist nouveau and nvidia
+          become: true
+          ansible.builtin.copy:
+            dest: "/etc/modprobe.d/blacklist-nvidia.conf"
+            mode: "0644"
+            content: |-
+              blacklist nouveau
+              blacklist nvidia
+              options nouveau modeset=0
+            force: false
+          register: _blacklist_nvidia
+
+        - name: Ensure vfio and vfio-pci modules are loaded at boot
+          become: true
+          ansible.builtin.copy:
+            dest: /etc/modules-load.d/vfio.conf
+            mode: "0644"
+            content: |
+              vfio
+              vfio-pci
+            force: false
+          register: _load_vfio
+
+        - name: Check if grub2-mkconfig has --update-bls-cmdline option
+          ansible.builtin.shell:
+            cmd: grub2-mkconfig --help | grep '\-\-update-bls-cmdline'
+          ignore_errors: true
+          register: check_update_bls_cmdline
+          changed_when: false
+
+        - name: Regenerate initramfs
+          become: true
+          ansible.builtin.command: "{{ item }}"
+          loop:
+            - 'dracut --force'
+            - >-
+              grub2-mkconfig -o /boot/grub2/grub.cfg
+              {{ '--update-bls-cmdline'
+              if check_update_bls_cmdline.rc == 0
+              else '' }}
+          when: (_blacklist_nvidia.changed or _load_vfio.changed)

--- a/dt/nova/nova05epsilon/edpm/baremetalhosts/baremetalhosts.yaml
+++ b/dt/nova/nova05epsilon/edpm/baremetalhosts/baremetalhosts.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edpm-compute-0-preprovision-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  labels: {}
+  name: edpm-compute-0
+  namespace: openstack
+  annotations:
+    inspect.metal3.io: ""
+spec:
+  architecture: x86_64
+  automatedCleaningMode: metadata
+  bmc:
+    address: _replaced_
+    credentialsName: _replaced_
+  bootMACAddress: _replaced_
+  bootMode: UEFI
+  rootDeviceHints: {}
+  online: true

--- a/dt/nova/nova05epsilon/edpm/baremetalhosts/baremetalhosts.yaml
+++ b/dt/nova/nova05epsilon/edpm/baremetalhosts/baremetalhosts.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edpm-compute-0-preprovision-network-data
+  namespace: openstack
+type: Opaque
+stringData: {}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  labels: {}
+  name: edpm-compute-0
+  namespace: openstack
+  annotations:
+    inspect.metal3.io: ""
+spec:
+  architecture: x86_64
+  automatedCleaningMode: _replaced_
+  bmc:
+    address: _replaced_
+    credentialsName: _replaced_
+  bootMACAddress: _replaced_
+  bootMode: UEFI
+  rootDeviceHints: {}
+  online: true
+  preprovisioningNetworkDataName: edpm-compute-0-preprovision-network-data

--- a/dt/nova/nova05epsilon/edpm/baremetalhosts/bmc-secret.env
+++ b/dt/nova/nova05epsilon/edpm/baremetalhosts/bmc-secret.env
@@ -1,0 +1,2 @@
+username=admin
+password=password

--- a/dt/nova/nova05epsilon/edpm/baremetalhosts/kustomization.yaml
+++ b/dt/nova/nova05epsilon/edpm/baremetalhosts/kustomization.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+secretGenerator:
+  - name: bmc-secret
+    behavior: create
+    envs:
+      - bmc-secret.env
+    options:
+      disableNameSuffixHash: true
+
+resources:
+  - baremetalhosts.yaml
+  - provisioning.yaml
+
+replacements:
+  # Labels
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.labels
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - metadata.labels
+        options:
+          create: true
+
+  # Enable/Disable Metal3 Inspection
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.metal3_inspection
+    targets:
+      - select:
+          kind: BareMetalHost
+        fieldPaths:
+          - metadata.annotations.inspect\.metal3\.io
+        options:
+          create: true
+
+  # BMC Configuration
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.bmc
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.bmc
+        options:
+          create: true
+
+  # externallyProvisioned
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.externallyProvisioned
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.externallyProvisioned
+        options:
+          create: true
+
+  # bootMACAddress
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.bootMACAddress
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.bootMACAddress
+        options:
+          create: true
+
+  # rootDeviceHints
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.rootDeviceHints
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.rootDeviceHints
+        options:
+          create: true
+
+  # preprovisioningNetworkData
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.preprovisioningNetworkData
+    targets:
+      - select:
+          kind: Secret
+          name: edpm-compute-0-preprovision-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true

--- a/dt/nova/nova05epsilon/edpm/baremetalhosts/kustomization.yaml
+++ b/dt/nova/nova05epsilon/edpm/baremetalhosts/kustomization.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+secretGenerator:
+  - name: bmc-secret
+    behavior: create
+    envs:
+      - bmc-secret.env
+    options:
+      disableNameSuffixHash: true
+
+resources:
+  - baremetalhosts.yaml
+  - provisioning.yaml
+
+replacements:
+  # Labels
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.labels
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - metadata.labels
+        options:
+          create: true
+
+  # Enable/Disable Metal3 Inspection
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.metal3_inspection
+    targets:
+      - select:
+          kind: BareMetalHost
+        fieldPaths:
+          - metadata.annotations.inspect\.metal3\.io
+        options:
+          create: true
+
+  # BMC Configuration
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.bmc
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.bmc
+        options:
+          create: true
+
+  # externallyProvisioned
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.externallyProvisioned
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.externallyProvisioned
+        options:
+          create: true
+
+  # bootMACAddress
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.bootMACAddress
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.bootMACAddress
+        options:
+          create: true
+
+  # rootDeviceHints
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.rootDeviceHints
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.rootDeviceHints
+        options:
+          create: true
+
+  # preprovisioningNetworkDataName (optional)
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.preprovisioningNetworkDataName
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.preprovisioningNetworkDataName
+        options:
+          create: true
+
+  # automatedCleaningMode
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.automatedCleaningMode
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.automatedCleaningMode
+        options:
+          create: true
+
+  # preprovisioningNetworkData
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.preprovisioningNetworkData
+    targets:
+      - select:
+          kind: Secret
+          name: edpm-compute-0-preprovision-network-data
+        fieldPaths:
+          - stringData
+        options:
+          create: true

--- a/dt/nova/nova05epsilon/edpm/baremetalhosts/provisioning.yaml
+++ b/dt/nova/nova05epsilon/edpm/baremetalhosts/provisioning.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: metal3.io/v1alpha1
+kind: Provisioning
+metadata:
+  name: provisioning-configuration
+spec:
+  provisioningDHCPRange: ""
+  provisioningIP: ""
+  provisioningInterface: ""
+  provisioningMacAddresses: []
+  provisioningNetworkCIDR: ""
+  provisioningNetwork: Disabled
+  watchAllNamespaces: true
+  virtualMediaViaExternalNetwork: true

--- a/dt/nova/nova05epsilon/kustomization.yaml
+++ b/dt/nova/nova05epsilon/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../lib/control-plane

--- a/dt/nova/nova05epsilon/namespace.yaml
+++ b/dt/nova/nova05epsilon/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: builtin
+kind: NamespaceTransformer
+metadata:
+  name: _ignored_
+  namespace: openstack
+setRoleBindingSubjects: none
+unsetOnly: true
+fieldSpecs:
+  - path: metadata/name
+    kind: Namespace
+    create: true

--- a/dt/nova/nova05epsilon/networking/dns/dns.yaml
+++ b/dt/nova/nova05epsilon/networking/dns/dns.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: DNS
+metadata:
+  name: default
+spec:
+  cache:
+    negativeTTL: 0s
+    positiveTTL: 0s
+  logLevel: Normal
+  nodePlacement: {}
+  operatorLogLevel: Normal
+  upstreamResolvers:
+    policy: Sequential
+    protocolStrategy: ""
+    transportConfig: {}
+    upstreams:
+      - port: 53
+        type: SystemResolvConf

--- a/dt/nova/nova05epsilon/networking/dns/kustomization.yaml
+++ b/dt/nova/nova05epsilon/networking/dns/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - dns.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: dns-values
+      fieldPath: data.servers
+    targets:
+      - select:
+          kind: DNS
+          name: default
+        fieldPaths:
+          - spec.servers
+        options:
+          create: true

--- a/dt/nova/nova05epsilon/networking/kustomization.yaml
+++ b/dt/nova/nova05epsilon/networking/kustomization.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/networking/metallb
+  - ../../../../lib/networking/netconfig
+  - ../../../../lib/networking/nad
+
+resources:
+  - storagemgmt-nad.yaml
+  - storagemgmt-metallb.yaml
+
+# Add storagemgmt network template, as it is needed for CephHCI
+patches:
+  - target:
+      version: v1beta1
+      kind: NetConfig
+      name: netconfig
+    patch: |-
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: storagemgmt
+          subnets:
+            - _replaced_
+          mtu: 1500
+
+# Add storagemgmt network replacements
+replacements:
+  # NetConfig dnsDomain specific to this VA
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].dnsDomain
+  # NetConfig MTU specific to this VA
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].mtu
+  # NetConfig subnets specific to this VA
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].subnets
+
+  # Storagemgmt NAD support
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: storagemgmt
+        fieldPaths:
+          - spec.config
+
+  # Storagemgmt IPAddressPool
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.lb_addresses
+    targets:
+      - select:
+          kind: IPAddressPool
+          name: storagemgmt
+        fieldPaths:
+          - spec.addresses
+
+  # Storagemgmt L2Advertisement interface
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.iface
+    targets:
+      - select:
+          kind: L2Advertisement
+          name: storagemgmt
+        fieldPaths:
+          - spec.interfaces.0
+
+  # Override ctlplane L2Advertisement to use bridgeName (ospbr) instead of ctlplane.iface
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bridgeName
+    targets:
+      - select:
+          kind: L2Advertisement
+          name: ctlplane
+        fieldPaths:
+          - spec.interfaces.0

--- a/dt/nova/nova05epsilon/networking/nncp/kustomization.yaml
+++ b/dt/nova/nova05epsilon/networking/nncp/kustomization.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../lib/nncp
+
+patches:
+  # SNO: remove the extra nodes that lib/nncp defines for 3-node clusters
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: node-1
+    patch: |
+      $patch: delete
+      apiVersion: nmstate.io/v1
+      kind: NodeNetworkConfigurationPolicy
+      metadata:
+        name: node-1
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: node-2
+    patch: |
+      $patch: delete
+      apiVersion: nmstate.io/v1
+      kind: NodeNetworkConfigurationPolicy
+      metadata:
+        name: node-2
+  # SNO: remove worker scheduling label from nodeSelector
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: node-0
+    patch: |-
+      - op: remove
+        path: /spec/nodeSelector/node-role.kubernetes.io~1worker
+  # Optional: add storagemgmt VLAN interface to the SNO node.
+  # Uncomment this patch AND node_0.storagemgmt_ip in values.yaml.
+  # Not required for CephHCI (Ceph uses storage network for OSD traffic).
+  # - target:
+  #     kind: NodeNetworkConfigurationPolicy
+  #     name: node-0
+  #   patch: |-
+  #     - op: add
+  #       path: /spec/desiredState/interfaces/-
+  #       value:
+  #         description: storagemgmt vlan host interface
+  #         name: storagemgmt
+  #         state: up
+  #         type: vlan
+  #         mtu: _replaced_
+  #         ipv4:
+  #           address:
+  #           - ip: _replaced_
+  #             prefix-length: _replaced_
+  #           dhcp: false
+  #           enabled: true
+  #         ipv6:
+  #           enabled: false
+  #         vlan:
+  #           base-iface: _replaced_
+  #           id: _replaced_
+
+# Uncomment these replacements together with the storagemgmt patch above
+# replacements:
+#   - source:
+#       kind: ConfigMap
+#       name: network-values
+#       fieldPath: data.node_0.storagemgmt_ip
+#     targets:
+#       - select:
+#           kind: NodeNetworkConfigurationPolicy
+#           name: node-0
+#         fieldPaths:
+#           - spec.desiredState.interfaces.[name=storagemgmt].ipv4.address.0.ip
+#   - source:
+#       kind: ConfigMap
+#       name: network-values
+#       fieldPath: data.storagemgmt.base_iface
+#     targets:
+#       - select:
+#           kind: NodeNetworkConfigurationPolicy
+#         fieldPaths:
+#           - spec.desiredState.interfaces.[name=storagemgmt].vlan.base-iface
+#         options:
+#           create: true
+#   - source:
+#       kind: ConfigMap
+#       name: network-values
+#       fieldPath: data.storagemgmt.vlan
+#     targets:
+#       - select:
+#           kind: NodeNetworkConfigurationPolicy
+#         fieldPaths:
+#           - spec.desiredState.interfaces.[name=storagemgmt].vlan.id
+#         options:
+#           create: true
+#   - source:
+#       kind: ConfigMap
+#       name: network-values
+#       fieldPath: data.storagemgmt.mtu
+#     targets:
+#       - select:
+#           kind: NodeNetworkConfigurationPolicy
+#         fieldPaths:
+#           - spec.desiredState.interfaces.[name=storagemgmt].mtu
+#         options:
+#           create: true
+#   - source:
+#       kind: ConfigMap
+#       name: network-values
+#       fieldPath: data.storagemgmt.prefix-length
+#     targets:
+#       - select:
+#           kind: NodeNetworkConfigurationPolicy
+#         fieldPaths:
+#           - spec.desiredState.interfaces.[name=storagemgmt].ipv4.address.0.prefix-length
+#         options:
+#           create: true

--- a/dt/nova/nova05epsilon/networking/storagemgmt-metallb.yaml
+++ b/dt/nova/nova05epsilon/networking/storagemgmt-metallb.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: storagemgmt
+  namespace: metallb-system
+  labels:
+    osp/lb-addresses-type: standard
+spec:
+  addresses:
+    - _replaced_
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: storagemgmt
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - storagemgmt
+  interfaces:
+    - _replaced_

--- a/dt/nova/nova05epsilon/networking/storagemgmt-nad.yaml
+++ b/dt/nova/nova05epsilon/networking/storagemgmt-nad.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: storagemgmt
+  labels:
+    osp/net: storagemgmt
+    osp/net-attach-def-type: standard

--- a/examples/dt/nova/nova05epsilon/.gitignore
+++ b/examples/dt/nova/nova05epsilon/.gitignore
@@ -1,0 +1,3 @@
+# Generated files
+dataplane-nodeset.yaml
+dataplane-deployment.yaml

--- a/examples/dt/nova/nova05epsilon/README.md
+++ b/examples/dt/nova/nova05epsilon/README.md
@@ -1,0 +1,60 @@
+# Nova GPU Passthrough (VFIO) on DCN with CephHCI
+
+This is a collection of CR templates that represent a Red Hat OpenStack Services on OpenShift deployment that has the following characteristics:
+
+- Single Node OpenShift (SNO) cluster with external EDPM compute nodes
+- 1-replica Galera database
+- RabbitMQ
+- OVN networking with spine-and-leaf topology (multi-subnet DCN)
+- Baremetal compute nodes with GPU passthrough via VFIO
+- CephHCI installed on compute nodes and used by various OSP services
+  - Glance using RBD for backend
+  - Nova using RBD for ephemeral storage
+- Nova configured for PCI device passthrough (NVIDIA GPUs)
+  - Host kernel configured with IOMMU and vfio-pci driver
+  - GPU PCI alias registered in Placement for scheduling
+  - CPU pinning and tuned profile for performance isolation
+- Metal3 bare metal provisioning with virtual media
+
+## Considerations
+
+1. These CRs are validated for the overall functionality of the OSP cloud deployed, but they nonetheless require customization for the particular environment in which they are utilized. In this sense they are _templates_ meant to be consumed and tweaked to fit the specific constraints of the hardware available.
+
+2. The CRs are applied against an OpenShift cluster in _stages_. That is, there is an ordering in which each grouping of CRs is fed to the cluster. It is _not_ a case of simply taking all CRs from all stages and applying them all at once.
+
+3. In stage 2 [kustomize](https://kustomize.io/) is used to generate the networking and control plane CRs dynamically. The `control-plane/networking/nncp/values.yaml`, `control-plane/networking/dns/values.yaml` and `control-plane/service-values.yaml` files must be updated to fit your environment. kustomize version 5 or newer required.
+
+4. In stages 3 and 4 [kustomize](https://kustomize.io/) is used to generate the dataplane CRs dynamically. The `edpm-pre-ceph/nodeset/values.yaml`, `values.yaml` and `service-values.yaml` files must be updated to fit your environment. kustomize version 5 or newer required.
+
+5. Between stages 3 and 4, _it is assumed that the user installs Ceph on the compute nodes._ OpenStack K8S CRDs do not provide a way to install Ceph via any sort of combination of CRs.
+
+6. For CI automation, this DT uses `automation/vars/nova05epsilon.yaml` which maps the manual stages above to 9 granular automation steps (NNCP, networking, control-plane, DNS, baremetalhosts, pre-ceph nodeset, pre-ceph deployment, post-ceph nodeset, post-ceph deployment).
+
+## Host Configuration
+
+The following parameters are crucial for host-level GPU passthrough configuration in `edpm-pre-ceph/nodeset/values.yaml`:
+
+- **`edpm_kernel_args`**: Enables IOMMU and binds NVIDIA GPUs to the `vfio-pci` driver at boot time.
+  - `intel_iommu=on iommu=pt`: Enables the IOMMU for device passthrough.
+  - `vfio-pci.ids=10de:20f1`: Claims GPU(s) by vendor and product IDs.
+  - `rd.driver.pre=vfio-pci`: Loads vfio-pci early to avoid race conditions.
+
+- **`edpm_tuned_profile`** and **`edpm_tuned_isolated_cores`**: Configure CPU isolation for performance.
+
+- **`vfio-pci-bind` service**: Blacklists `nouveau` and `nvidia` kernel modules and regenerates initramfs.
+
+## Nova Configuration
+
+A count of `X` PCI devices may be requested through `"pci_passthrough:alias"="nvidia_a2:X"` flavor extra specs:
+```
+openstack --os-compute-api=2.86 flavor set --property "pci_passthrough:alias"="nvidia_a2:1" device_passthrough
+```
+
+## Stages
+
+All stages must be executed in the order listed below. Everything is required unless otherwise indicated.
+
+1. [Install the OpenStack K8S operators and their dependencies](../../../common/)
+2. [Configuring networking and deploy the OpenStack control plane](control-plane.md)
+3. [Configure and deploy the initial data plane to prepare for Ceph installation](dataplane-pre-ceph.md)
+4. [Update the control plane and finish deploying the data plane after Ceph has been installed](dataplane-post-ceph.md)

--- a/examples/dt/nova/nova05epsilon/README.md
+++ b/examples/dt/nova/nova05epsilon/README.md
@@ -1,0 +1,120 @@
+# Nova GPU Passthrough (VFIO) on DCN with CephHCI
+
+This is a collection of CR templates that represent a Red Hat OpenStack Services on OpenShift deployment that has the following characteristics:
+
+- Single Node OpenShift (SNO) cluster with external EDPM compute nodes
+- 1-replica Galera database
+- RabbitMQ
+- OVN networking with spine-and-leaf topology (multi-subnet ready for DCN)
+- Baremetal compute nodes with GPU passthrough via VFIO
+- CephHCI installed on compute nodes and used by various OSP services
+  - Glance using RBD for backend
+  - Nova using RBD for ephemeral storage
+- Nova configured for PCI device passthrough (NVIDIA GPUs)
+  - Host kernel configured with IOMMU and vfio-pci driver
+  - GPU PCI alias registered in Placement for scheduling
+  - CPU pinning and tuned profile for performance isolation
+- Metal3 bare metal provisioning with virtual media
+
+## Considerations
+
+1. These CRs are validated for the overall functionality of the OSP cloud deployed, but they nonetheless require customization for the particular environment in which they are utilized. In this sense they are _templates_ meant to be consumed and tweaked to fit the specific constraints of the hardware available.
+
+2. The CRs are applied against an OpenShift cluster in _stages_. That is, there is an ordering in which each grouping of CRs is fed to the cluster. It is _not_ a case of simply taking all CRs from all stages and applying them all at once.
+
+3. In stage 2 [kustomize](https://kustomize.io/) is used to generate the networking and control plane CRs dynamically. The `control-plane/networking/nncp/values.yaml`, `control-plane/networking/dns/values.yaml` and `control-plane/service-values.yaml` files must be updated to fit your environment. kustomize version 5 or newer required.
+
+4. In stages 3 and 4 [kustomize](https://kustomize.io/) is used to generate the dataplane CRs dynamically. The `edpm-pre-ceph/nodeset/values.yaml`, `values.yaml` and `service-values.yaml` files must be updated to fit your environment. kustomize version 5 or newer required.
+
+5. Between stages 3 and 4, _it is assumed that the user installs Ceph on the compute nodes._ OpenStack K8S CRDs do not provide a way to install Ceph via any sort of combination of CRs.
+
+6. For CI automation, this DT uses `automation/vars/nova05epsilon.yaml` which maps the manual stages above to 9 granular automation steps (NNCP, networking, control-plane, DNS, baremetalhosts, pre-ceph nodeset, pre-ceph deployment, post-ceph nodeset, post-ceph deployment).
+
+## Host Configuration
+
+The following parameters are crucial for host-level GPU passthrough configuration in `edpm-pre-ceph/nodeset/values.yaml`:
+
+- **`edpm_kernel_args`**: Enables IOMMU and binds NVIDIA GPUs to the `vfio-pci` driver at boot time.
+  - `intel_iommu=on iommu=pt`: Enables the IOMMU for device passthrough.
+  - `vfio-pci.ids=10de:20f1`: Claims GPU(s) by vendor and product IDs.
+  - `rd.driver.pre=vfio-pci`: Loads vfio-pci early to avoid race conditions.
+
+- **`edpm_tuned_profile`** and **`edpm_tuned_isolated_cores`**: Configure CPU isolation for performance.
+
+- **`vfio-pci-bind` service**: Blacklists `nouveau` and `nvidia` kernel modules and regenerates initramfs.
+
+## Nova Configuration
+
+A count of `X` PCI devices may be requested through `"pci_passthrough:alias"="nvidia_a2:X"` flavor extra specs:
+```
+openstack --os-compute-api=2.86 flavor set --property "pci_passthrough:alias"="nvidia_a2:1" device_passthrough
+```
+
+## Stages
+
+All stages must be executed in the order listed below. Everything is required unless otherwise indicated.
+
+1. [Install the OpenStack K8S operators and their dependencies](../../../common/)
+2. [Configuring networking and deploy the OpenStack control plane](control-plane.md)
+3. [Configure and deploy the initial data plane to prepare for Ceph installation](dataplane-pre-ceph.md)
+4. [Update the control plane and finish deploying the data plane after Ceph has been installed](dataplane-post-ceph.md)
+
+## Extending to a Full DCN Deployment
+
+This topology deploys a single availability zone with computes on a
+remote L3 subnet. The multi-subnet networking (subnet1 for SNO,
+subnet2 for EDPM computes) provides the routed-networking foundation
+for DCN, but several additional changes are required to make this a
+true multi-AZ distributed compute deployment. Use
+[dt/dcn](../../dcn/README.md) as a reference.
+
+### Glance and Local Ceph Storage
+
+In this topology, it is implied that Ceph runs on remote EDPM compute
+nodes (CephHCI), but Glance runs on the control plane at another site.
+This means Glance's RBD backend is accessing a Ceph cluster over the WAN,
+which adds latency to every image operation. In a DCN deployment with
+storage, at least one Ceph cluster must be local to the control plane
+so that the central Glance instance has low-latency access to its default
+RBD store. The DCN DT achieves this by designating az0 as the central site
+with its own local Ceph cluster and configuring Glance az0 as type `split`
+with `default_backend = az0`. Edge sites use Glance type `edge` and
+replicate images from the central store on demand.
+
+### Per-AZ Ceph Configuration
+
+In `values.yaml`, switch from plain Ceph filenames (`ceph.conf`,
+`ceph.client.openstack.keyring`) to az-prefixed filenames
+(`az0.conf`, `az0.client.openstack.keyring`, `az1.conf`, etc.) so
+that each site's Ceph cluster is independently addressable. Update
+the Nova Ceph config (`nova.ceph.conf`) to reference the correct
+az-prefixed conf file for each site.
+
+### Per-AZ Glance
+
+Replace the single Glance backend with per-AZ `glanceAPIs` entries
+in `service-values.yaml`. The central site should be type `split`
+with backends for all AZs; edge sites should be type `edge` with
+backends for their own AZ plus the central AZ (for copy-on-write
+image import).
+
+### OVN Availability Zones
+
+Set `edpm_ovn_availability_zones` in the nodeset values for each
+site instead of leaving it empty. This enables OVN chassis-level AZ
+awareness for network scheduling.
+
+### Additional Networking Subnets
+
+Add a subnet per site for each network (ctlplane, internalapi,
+storage, tenant) in the network values. The current topology
+defines subnet1 and subnet2; a full DCN deployment with N sites
+needs N+1 subnets (one for the control plane site, one per edge
+site).
+
+### Per-Site Dataplane Stages
+
+The dataplane stages (pre-ceph nodeset, pre-ceph deployment, Ceph
+install, post-ceph nodeset, post-ceph deployment) must be repeated
+for each DCN site with site-specific values. Each site's computes
+should reference the appropriate cell, subnet, and AZ.

--- a/examples/dt/nova/nova05epsilon/control-plane.md
+++ b/examples/dt/nova/nova05epsilon/control-plane.md
@@ -1,0 +1,111 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `lvms-local-storage` should already exist.
+
+## Initialize
+
+Switch to the "openstack" namespace
+
+```shell
+oc project openstack
+```
+
+Change to the nova05epsilon directory
+
+```shell
+cd architecture/examples/dt/nova/nova05epsilon/control-plane
+```
+
+Edit the [networking/nncp/values.yaml](control-plane/networking/nncp/values.yaml)
+and [networking/dns/values.yaml](control-plane/networking/dns/values.yaml)
+files to suit your environment. Service values (Glance, Nova PCI, telemetry)
+are configured in the top-level [service-values.yaml](service-values.yaml)
+and applied during the post-ceph stage rebuild.
+
+```shell
+vi networking/nncp/values.yaml
+vi networking/dns/values.yaml
+```
+
+## Apply node network configuration
+
+Generate the node network configuration
+
+```shell
+kustomize build networking/nncp > nncp.yaml
+```
+
+Apply the NNCP CRs
+
+```shell
+oc apply -f nncp.yaml
+```
+
+Wait for NNCPs to be available
+
+```shell
+oc wait nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=300s
+```
+
+## Apply networking configuration
+
+Generate the networking CRs (MetalLB, NetConfig, NetworkAttachmentDefinitions).
+
+```shell
+kustomize build networking > networking.yaml
+```
+
+Apply the CRs
+
+```shell
+oc apply -f networking.yaml
+```
+
+Wait for MetalLB to be ready
+
+```shell
+oc -n metallb-system wait pod -l app=metallb -l component=speaker --for condition=Ready --timeout=300s
+```
+
+## Apply control-plane configuration
+
+Generate the control-plane CRs.
+
+```shell
+kustomize build > control-plane.yaml
+```
+
+Apply the CRs
+
+```shell
+oc apply -f control-plane.yaml
+```
+
+Wait for control plane to be available
+
+```shell
+oc wait osctlplane controlplane --for condition=Ready --timeout=600s
+```
+
+## Apply Openshift DNS configuration for ctlplane DNS zone
+
+Generate the `dns.operator/default` CR to update the ctlplane resolver
+for the DNSMasq instance created during control-plane configuration.
+
+```shell
+kustomize build networking/dns > dns.yaml
+```
+
+Apply the CRs
+
+```shell
+oc apply -f dns.yaml
+```
+
+Wait for DNS to be available
+
+```shell
+oc -n openshift-dns wait dns.operator/default --for condition=Available --timeout=300s
+```

--- a/examples/dt/nova/nova05epsilon/control-plane.md
+++ b/examples/dt/nova/nova05epsilon/control-plane.md
@@ -1,0 +1,120 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `lvms-local-storage` should already exist.
+
+## Initialize
+
+Switch to the "openstack" namespace
+
+```shell
+oc project openstack
+```
+
+Change to the nova05epsilon directory
+
+```shell
+cd architecture/examples/dt/nova/nova05epsilon/control-plane
+```
+
+Edit the [networking/nncp/values.yaml](control-plane/networking/nncp/values.yaml)
+and [networking/dns/values.yaml](control-plane/networking/dns/values.yaml)
+files to suit your environment. Service values (Glance, Nova PCI, telemetry)
+are configured in the top-level [service-values.yaml](service-values.yaml)
+and applied during the post-ceph stage rebuild.
+
+```shell
+vi networking/nncp/values.yaml
+vi networking/dns/values.yaml
+```
+
+## Apply node network configuration
+
+Generate the node network configuration
+
+```shell
+kustomize build networking/nncp > nncp.yaml
+```
+
+Apply the NNCP CRs
+
+```shell
+oc apply -f nncp.yaml
+```
+
+Wait for NNCPs to be available
+
+```shell
+oc wait nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=300s
+```
+
+## Apply networking configuration
+
+Generate the networking CRs (MetalLB, NetConfig, NetworkAttachmentDefinitions).
+
+```shell
+kustomize build networking > networking.yaml
+```
+
+Apply the CRs
+
+```shell
+oc apply -f networking.yaml
+```
+
+Wait for MetalLB to be ready
+
+```shell
+oc -n metallb-system wait pod -l app=metallb -l component=speaker --for condition=Ready --timeout=300s
+```
+
+## Apply control-plane configuration
+
+Generate the control-plane CRs.
+
+```shell
+kustomize build > control-plane.yaml
+```
+
+Apply the CRs
+
+```shell
+oc apply -f control-plane.yaml
+```
+
+Wait for the control plane DNS to be ready (the full `condition=Ready`
+is deferred until after the DNS operator configuration is applied, so that
+the two stages can proceed without waiting for all OpenStack services):
+
+```shell
+oc wait osctlplane controlplane --for condition=OpenStackControlPlaneDNSReadyCondition --timeout=1200s
+```
+
+## Apply Openshift DNS configuration for ctlplane DNS zone
+
+Generate the `dns.operator/default` CR to update the ctlplane resolver
+for the DNSMasq instance created during control-plane configuration.
+
+```shell
+kustomize build networking/dns > dns.yaml
+```
+
+Apply the CRs
+
+```shell
+oc apply -f dns.yaml
+```
+
+Wait for DNS to be available
+
+```shell
+oc -n openshift-dns wait dns.operator/default --for condition=Available --timeout=300s
+```
+
+Now wait for the full control plane readiness before proceeding to
+the data plane stages:
+
+```shell
+oc wait osctlplane controlplane --for condition=Ready --timeout=600s
+```

--- a/examples/dt/nova/nova05epsilon/control-plane/.gitignore
+++ b/examples/dt/nova/nova05epsilon/control-plane/.gitignore
@@ -1,0 +1,2 @@
+# Generated files
+control-plane.yaml

--- a/examples/dt/nova/nova05epsilon/control-plane/README.md
+++ b/examples/dt/nova/nova05epsilon/control-plane/README.md
@@ -1,0 +1,10 @@
+# Configuring networking and deploy the OpenStack control plane
+
+See [control-plane.md](../control-plane.md) for deployment instructions.
+
+The `service-values.yaml` in this directory is a minimal stub providing
+only the fields required by `lib/control-plane` (preserveJobs,
+notificationsBus, tls). The full service configuration (Glance, Nova PCI,
+telemetry, Ceph extraMounts) is in the top-level
+[service-values.yaml](../service-values.yaml) and is applied during the
+post-ceph stage rebuild.

--- a/examples/dt/nova/nova05epsilon/control-plane/kustomization.yaml
+++ b/examples/dt/nova/nova05epsilon/control-plane/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/nova/nova05epsilon/
+
+resources:
+  - networking/nncp/values.yaml
+  - service-values.yaml

--- a/examples/dt/nova/nova05epsilon/control-plane/networking/dns/.gitignore
+++ b/examples/dt/nova/nova05epsilon/control-plane/networking/dns/.gitignore
@@ -1,0 +1,2 @@
+# Generated files
+dns.yaml

--- a/examples/dt/nova/nova05epsilon/control-plane/networking/dns/kustomization.yaml
+++ b/examples/dt/nova/nova05epsilon/control-plane/networking/dns/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../../dt/nova/nova05epsilon/networking/dns
+
+resources:
+  - values.yaml

--- a/examples/dt/nova/nova05epsilon/control-plane/networking/dns/values.yaml
+++ b/examples/dt/nova/nova05epsilon/control-plane/networking/dns/values.yaml
@@ -1,0 +1,19 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dns-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  servers:
+    - name: rhoso-ctlplane
+      zones:
+        # must match the ctlplane DNS domain defined EDPM hostnames in the nodeset CR
+        - ctlplane.example.com
+      forwardPlugin:
+        policy: Sequential
+        upstreams:
+          # MetalLB VIP for the ctlplane DNSMasq service
+          - CHANGEME_SNO_CTLPLANE_LB_IP

--- a/examples/dt/nova/nova05epsilon/control-plane/networking/kustomization.yaml
+++ b/examples/dt/nova/nova05epsilon/control-plane/networking/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/nova/nova05epsilon/networking
+
+resources:
+  - nncp/values.yaml

--- a/examples/dt/nova/nova05epsilon/control-plane/networking/nncp/.gitignore
+++ b/examples/dt/nova/nova05epsilon/control-plane/networking/nncp/.gitignore
@@ -1,0 +1,2 @@
+# Generated files
+nncp.yaml

--- a/examples/dt/nova/nova05epsilon/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/dt/nova/nova05epsilon/control-plane/networking/nncp/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../../../dt/nova/nova05epsilon/networking/nncp
+  # To expose storagemgmt VLAN on the SNO node, uncomment the patch and
+  # replacements block in dt/nova/nova05epsilon/networking/nncp/kustomization.yaml
+  # and uncomment node_0.storagemgmt_ip in values.yaml.
+  # Not required for CephHCI (Ceph uses the storage network for OSD traffic).
+
+
+resources:
+  - values.yaml

--- a/examples/dt/nova/nova05epsilon/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/nova/nova05epsilon/control-plane/networking/nncp/values.yaml
@@ -1,0 +1,288 @@
+# Network values for SNO + DCN spine-leaf topology.
+#
+# Site 2 (SNO control plane): subnet1
+# Site 4 (EDPM computes): subnet2
+#
+# Replace all CHANGEME values to match your environment.
+# All subnets must share a common routable address space.
+---
+apiVersion: v1
+data:
+    bridgeName: ospbr
+    ctlplane:
+        dnsDomain: ctlplane.example.com
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: ctlplane
+            metallb.universe.tf/allow-shared-ip: ctlplane
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_CTLPLANE_LB_IP
+        iface: CHANGEME_SNO_IFACE
+        lb_addresses:
+            - CHANGEME_SNO_CTLPLANE_LB_START-CHANGEME_SNO_CTLPLANE_LB_END
+        mtu: 1500
+        net-attach-def: |
+            {
+              "cniVersion": "0.3.1",
+              "name": "ctlplane",
+              "type": "macvlan",
+              "master": "ospbr",
+              "ipam": {
+                "type": "whereabouts",
+                "range": "CHANGEME_SNO_CTLPLANE_CIDR",
+                "range_start": "CHANGEME_SNO_CTLPLANE_NAD_START",
+                "range_end": "CHANGEME_SNO_CTLPLANE_NAD_END"
+              }
+            }
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_CTLPLANE_ALLOC1_END
+                    start: CHANGEME_SNO_CTLPLANE_ALLOC1_START
+                  - end: CHANGEME_SNO_CTLPLANE_ALLOC2_END
+                    start: CHANGEME_SNO_CTLPLANE_ALLOC2_START
+              cidr: CHANGEME_SNO_CTLPLANE_CIDR
+              gateway: CHANGEME_SNO_CTLPLANE_GW
+              name: subnet1
+              vlan: CHANGEME_SNO_CTLPLANE_VLAN
+            # CHANGEME: site4 EDPM computes -- replace CIDRs/gateway/VLAN
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_CTLPLANE_END
+                    start: CHANGEME_EDPM_CTLPLANE_START
+              cidr: CHANGEME_EDPM_CTLPLANE_CIDR
+              gateway: CHANGEME_EDPM_CTLPLANE_GW
+              name: subnet2
+              vlan: CHANGEME_EDPM_CTLPLANE_VLAN
+    datacentre:
+        net-attach-def: |
+            {
+              "cniVersion": "0.3.1",
+              "name": "datacentre",
+              "type": "host-device",
+              "device": "CHANGEME_SNO_IFACE",
+              "ipam": {}
+            }
+    dns-resolver:
+        config:
+            search: []
+            server:
+                - CHANGEME_SNO_DNS_SERVER
+        options:
+            - key: server
+              values:
+                  - CHANGEME_SNO_DNS_SERVER
+    external:
+        dnsDomain: external.example.com
+        mtu: 1500
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_EXTERNAL_END
+                    start: CHANGEME_SNO_EXTERNAL_START
+              cidr: CHANGEME_SNO_EXTERNAL_CIDR
+              gateway: CHANGEME_SNO_EXTERNAL_GW
+              name: subnet1
+              vlan: CHANGEME_SNO_EXTERNAL_VLAN
+            # CHANGEME: site4 external subnet
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_EXTERNAL_END
+                    start: CHANGEME_EDPM_EXTERNAL_START
+              cidr: CHANGEME_EDPM_EXTERNAL_CIDR
+              gateway: CHANGEME_EDPM_EXTERNAL_GW
+              name: subnet2
+              vlan: CHANGEME_EDPM_EXTERNAL_VLAN
+        vlan: CHANGEME_SNO_EXTERNAL_VLAN
+    internalapi:
+        base_iface: CHANGEME_SNO_IFACE
+        dnsDomain: internalapi.example.com
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: internalapi
+            metallb.universe.tf/allow-shared-ip: internalapi
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_INTAPI_LB_IP
+        iface: internalapi
+        lb_addresses:
+            - CHANGEME_SNO_INTAPI_LB_START-CHANGEME_SNO_INTAPI_LB_END
+        mtu: 1500
+        net-attach-def: |
+            {
+              "cniVersion": "0.3.1",
+              "name": "internalapi",
+              "type": "macvlan",
+              "master": "internalapi",
+              "ipam": {
+                "type": "whereabouts",
+                "range": "CHANGEME_SNO_INTAPI_CIDR",
+                "range_start": "CHANGEME_SNO_INTAPI_NAD_START",
+                "range_end": "CHANGEME_SNO_INTAPI_NAD_END"
+              }
+            }
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_INTAPI_END
+                    start: CHANGEME_SNO_INTAPI_START
+              cidr: CHANGEME_SNO_INTAPI_CIDR
+              name: subnet1
+              vlan: CHANGEME_SNO_INTAPI_VLAN
+            # CHANGEME: site4 internalapi subnet
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_INTAPI_END
+                    start: CHANGEME_EDPM_INTAPI_START
+              cidr: CHANGEME_EDPM_INTAPI_CIDR
+              name: subnet2
+              vlan: CHANGEME_EDPM_INTAPI_VLAN
+        vlan: CHANGEME_SNO_INTAPI_VLAN
+    lbServiceType: LoadBalancer
+    # SNO: single OCP node only
+    node_0:
+        ctlplane_ip: CHANGEME_SNO_CTLPLANE_IP
+        internalapi_ip: CHANGEME_SNO_INTAPI_IP
+        name: CHANGEME_SNO_NODE_NAME
+        storage_ip: CHANGEME_SNO_STORAGE_IP
+        # storagemgmt_ip: CHANGEME_SNO_STGMGMT_IP
+        tenant_ip: CHANGEME_SNO_TENANT_IP
+    # SNO: node_1/node_2 are required by lib/nncp replacement sources
+    # even though the NNCP resources are deleted by $patch:delete.
+    node_1:
+        ctlplane_ip: _unused_
+        internalapi_ip: _unused_
+        name: node-1
+        storage_ip: _unused_
+        tenant_ip: _unused_
+    node_2:
+        ctlplane_ip: _unused_
+        internalapi_ip: _unused_
+        name: node-2
+        storage_ip: _unused_
+        tenant_ip: _unused_
+    rabbitmq:
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: internalapi
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_RABBITMQ_IP
+    rabbitmq-cell1:
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: internalapi
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_RABBITMQ_CELL1_IP
+    routes:
+        config: []
+    storage:
+        base_iface: CHANGEME_SNO_IFACE
+        dnsDomain: storage.example.com
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: storage
+            metallb.universe.tf/allow-shared-ip: storage
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_STORAGE_LB_IP
+        iface: storage
+        lb_addresses:
+            - CHANGEME_SNO_STORAGE_LB_START-CHANGEME_SNO_STORAGE_LB_END
+        mtu: 1500
+        net-attach-def: |
+            {
+              "cniVersion": "0.3.1",
+              "name": "storage",
+              "type": "macvlan",
+              "master": "storage",
+              "ipam": {
+                "type": "whereabouts",
+                "range": "CHANGEME_SNO_STORAGE_CIDR",
+                "range_start": "CHANGEME_SNO_STORAGE_NAD_START",
+                "range_end": "CHANGEME_SNO_STORAGE_NAD_END"
+              }
+            }
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_STORAGE_END
+                    start: CHANGEME_SNO_STORAGE_START
+              cidr: CHANGEME_SNO_STORAGE_CIDR
+              name: subnet1
+              vlan: CHANGEME_SNO_STORAGE_VLAN
+            # CHANGEME: site4 storage subnet
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_STORAGE_END
+                    start: CHANGEME_EDPM_STORAGE_START
+              cidr: CHANGEME_EDPM_STORAGE_CIDR
+              name: subnet2
+              vlan: CHANGEME_EDPM_STORAGE_VLAN
+        vlan: CHANGEME_SNO_STORAGE_VLAN
+    storageClass: lvms-local-storage
+    storagemgmt:
+        base_iface: CHANGEME_SNO_IFACE
+        dnsDomain: storagemgmt.example.com
+        iface: storagemgmt
+        lb_addresses:
+            - CHANGEME_SNO_STGMGMT_LB_START-CHANGEME_SNO_STGMGMT_LB_END
+        mtu: 1500
+        net-attach-def: |
+            {
+              "cniVersion": "0.3.1",
+              "name": "storagemgmt",
+              "type": "macvlan",
+              "master": "storagemgmt",
+              "ipam": {
+                "type": "whereabouts",
+                "range": "CHANGEME_SNO_STGMGMT_CIDR",
+                "range_start": "CHANGEME_SNO_STGMGMT_NAD_START",
+                "range_end": "CHANGEME_SNO_STGMGMT_NAD_END"
+              }
+            }
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_STGMGMT_END
+                    start: CHANGEME_SNO_STGMGMT_START
+              cidr: CHANGEME_SNO_STGMGMT_CIDR
+              name: subnet1
+              vlan: CHANGEME_SNO_STGMGMT_VLAN
+            # CHANGEME: site4 storagemgmt subnet
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_STGMGMT_END
+                    start: CHANGEME_EDPM_STGMGMT_START
+              cidr: CHANGEME_EDPM_STGMGMT_CIDR
+              name: subnet2
+              vlan: CHANGEME_EDPM_STGMGMT_VLAN
+        vlan: CHANGEME_SNO_STGMGMT_VLAN
+    tenant:
+        base_iface: CHANGEME_SNO_IFACE
+        dnsDomain: tenant.example.com
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: tenant
+            metallb.universe.tf/allow-shared-ip: tenant
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_TENANT_LB_IP
+        iface: tenant
+        lb_addresses:
+            - CHANGEME_SNO_TENANT_LB_START-CHANGEME_SNO_TENANT_LB_END
+        mtu: 1500
+        net-attach-def: |
+            {
+              "cniVersion": "0.3.1",
+              "name": "tenant",
+              "type": "macvlan",
+              "master": "tenant",
+              "ipam": {
+                "type": "whereabouts",
+                "range": "CHANGEME_SNO_TENANT_CIDR",
+                "range_start": "CHANGEME_SNO_TENANT_NAD_START",
+                "range_end": "CHANGEME_SNO_TENANT_NAD_END"
+              }
+            }
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_TENANT_END
+                    start: CHANGEME_SNO_TENANT_START
+              cidr: CHANGEME_SNO_TENANT_CIDR
+              name: subnet1
+              vlan: CHANGEME_SNO_TENANT_VLAN
+            # CHANGEME: site4 tenant subnet
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_TENANT_END
+                    start: CHANGEME_EDPM_TENANT_START
+              cidr: CHANGEME_EDPM_TENANT_CIDR
+              name: subnet2
+              vlan: CHANGEME_EDPM_TENANT_VLAN
+        vlan: CHANGEME_SNO_TENANT_VLAN
+
+kind: ConfigMap
+metadata:
+    annotations:
+        config.kubernetes.io/local-config: 'true'
+    name: network-values

--- a/examples/dt/nova/nova05epsilon/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/nova/nova05epsilon/control-plane/networking/nncp/values.yaml
@@ -1,0 +1,330 @@
+# Network values for SNO + DCN spine-leaf topology.
+#
+# Site 2 (SNO control plane): subnet1
+# Site 4 (EDPM computes): subnet2
+#
+# Replace all CHANGEME values to match your environment.
+# All subnets must share a common routable address space.
+---
+apiVersion: v1
+data:
+    bridgeName: ospbr
+    ctlplane:
+        dnsDomain: ctlplane.example.com
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: ctlplane
+            metallb.universe.tf/allow-shared-ip: ctlplane
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_CTLPLANE_LB_IP
+        iface: CHANGEME_SNO_IFACE
+        lb_addresses:
+            - CHANGEME_SNO_CTLPLANE_LB_START-CHANGEME_SNO_CTLPLANE_LB_END
+        mtu: 1500
+        net-attach-def: |
+            {
+              "cniVersion": "0.4.0",
+              "name": "ctlplane",
+              "plugins": [{
+                "type": "macvlan",
+                "master": "ospbr",
+                "ipam": {
+                  "type": "whereabouts",
+                  "range": "CHANGEME_SNO_CTLPLANE_CIDR",
+                  "range_start": "CHANGEME_SNO_CTLPLANE_NAD_START",
+                  "range_end": "CHANGEME_SNO_CTLPLANE_NAD_END"
+                }
+              }, {
+                "type": "tuning",
+                "sysctl": {
+                  "net.ipv6.conf.IFNAME.accept_ra": "0"
+                }
+              }]
+            }
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_CTLPLANE_ALLOC1_END
+                    start: CHANGEME_SNO_CTLPLANE_ALLOC1_START
+                  - end: CHANGEME_SNO_CTLPLANE_ALLOC2_END
+                    start: CHANGEME_SNO_CTLPLANE_ALLOC2_START
+              cidr: CHANGEME_SNO_CTLPLANE_CIDR
+              gateway: CHANGEME_SNO_CTLPLANE_GW
+              name: subnet1
+              vlan: CHANGEME_SNO_CTLPLANE_VLAN
+            # CHANGEME: site4 EDPM computes -- replace CIDRs/gateway/VLAN
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_CTLPLANE_END
+                    start: CHANGEME_EDPM_CTLPLANE_START
+              cidr: CHANGEME_EDPM_CTLPLANE_CIDR
+              gateway: CHANGEME_EDPM_CTLPLANE_GW
+              name: subnet2
+              vlan: CHANGEME_EDPM_CTLPLANE_VLAN
+    datacentre:
+        net-attach-def: |
+            {
+              "cniVersion": "0.4.0",
+              "name": "datacentre",
+              "plugins": [{
+                "type": "host-device",
+                "device": "CHANGEME_SNO_IFACE",
+                "ipam": {}
+              }, {
+                "type": "tuning",
+                "sysctl": {
+                  "net.ipv6.conf.IFNAME.accept_ra": "0"
+                }
+              }]
+            }
+    dns-resolver:
+        config:
+            search: []
+            server:
+                - CHANGEME_SNO_DNS_SERVER
+        options:
+            - key: server
+              values:
+                  - CHANGEME_SNO_DNS_SERVER
+    external:
+        dnsDomain: external.example.com
+        mtu: 1500
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_EXTERNAL_END
+                    start: CHANGEME_SNO_EXTERNAL_START
+              cidr: CHANGEME_SNO_EXTERNAL_CIDR
+              gateway: CHANGEME_SNO_EXTERNAL_GW
+              name: subnet1
+              vlan: CHANGEME_SNO_EXTERNAL_VLAN
+            # CHANGEME: site4 external subnet
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_EXTERNAL_END
+                    start: CHANGEME_EDPM_EXTERNAL_START
+              cidr: CHANGEME_EDPM_EXTERNAL_CIDR
+              gateway: CHANGEME_EDPM_EXTERNAL_GW
+              name: subnet2
+              vlan: CHANGEME_EDPM_EXTERNAL_VLAN
+        vlan: CHANGEME_SNO_EXTERNAL_VLAN
+    internalapi:
+        base_iface: CHANGEME_SNO_IFACE
+        dnsDomain: internalapi.example.com
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: internalapi
+            metallb.universe.tf/allow-shared-ip: internalapi
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_INTAPI_LB_IP
+        iface: internalapi
+        lb_addresses:
+            - CHANGEME_SNO_INTAPI_LB_START-CHANGEME_SNO_INTAPI_LB_END
+        mtu: 1500
+        net-attach-def: |
+            {
+              "cniVersion": "0.4.0",
+              "name": "internalapi",
+              "plugins": [{
+                "type": "macvlan",
+                "master": "internalapi",
+                "ipam": {
+                  "type": "whereabouts",
+                  "range": "CHANGEME_SNO_INTAPI_CIDR",
+                  "range_start": "CHANGEME_SNO_INTAPI_NAD_START",
+                  "range_end": "CHANGEME_SNO_INTAPI_NAD_END"
+                }
+              }, {
+                "type": "tuning",
+                "sysctl": {
+                  "net.ipv6.conf.IFNAME.accept_ra": "0"
+                }
+              }]
+            }
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_INTAPI_END
+                    start: CHANGEME_SNO_INTAPI_START
+              cidr: CHANGEME_SNO_INTAPI_CIDR
+              name: subnet1
+              vlan: CHANGEME_SNO_INTAPI_VLAN
+            # CHANGEME: site4 internalapi subnet
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_INTAPI_END
+                    start: CHANGEME_EDPM_INTAPI_START
+              cidr: CHANGEME_EDPM_INTAPI_CIDR
+              name: subnet2
+              vlan: CHANGEME_EDPM_INTAPI_VLAN
+        vlan: CHANGEME_SNO_INTAPI_VLAN
+    lbServiceType: LoadBalancer
+    # SNO: single OCP node only
+    node_0:
+        ctlplane_ip: CHANGEME_SNO_CTLPLANE_IP
+        internalapi_ip: CHANGEME_SNO_INTAPI_IP
+        name: CHANGEME_SNO_NODE_NAME
+        storage_ip: CHANGEME_SNO_STORAGE_IP
+        # storagemgmt_ip: CHANGEME_SNO_STGMGMT_IP
+        tenant_ip: CHANGEME_SNO_TENANT_IP
+    # SNO: node_1/node_2 are required by lib/nncp replacement sources
+    # even though the NNCP resources are deleted by $patch:delete.
+    node_1:
+        ctlplane_ip: _unused_
+        internalapi_ip: _unused_
+        name: node-1
+        storage_ip: _unused_
+        tenant_ip: _unused_
+    node_2:
+        ctlplane_ip: _unused_
+        internalapi_ip: _unused_
+        name: node-2
+        storage_ip: _unused_
+        tenant_ip: _unused_
+    rabbitmq:
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: internalapi
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_RABBITMQ_IP
+    rabbitmq-cell1:
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: internalapi
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_RABBITMQ_CELL1_IP
+    routes:
+        config: []
+    storage:
+        base_iface: CHANGEME_SNO_IFACE
+        dnsDomain: storage.example.com
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: storage
+            metallb.universe.tf/allow-shared-ip: storage
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_STORAGE_LB_IP
+        iface: storage
+        lb_addresses:
+            - CHANGEME_SNO_STORAGE_LB_START-CHANGEME_SNO_STORAGE_LB_END
+        mtu: 1500
+        net-attach-def: |
+            {
+              "cniVersion": "0.4.0",
+              "name": "storage",
+              "plugins": [{
+                "type": "macvlan",
+                "master": "storage",
+                "ipam": {
+                  "type": "whereabouts",
+                  "range": "CHANGEME_SNO_STORAGE_CIDR",
+                  "range_start": "CHANGEME_SNO_STORAGE_NAD_START",
+                  "range_end": "CHANGEME_SNO_STORAGE_NAD_END"
+                }
+              }, {
+                "type": "tuning",
+                "sysctl": {
+                  "net.ipv6.conf.IFNAME.accept_ra": "0"
+                }
+              }]
+            }
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_STORAGE_END
+                    start: CHANGEME_SNO_STORAGE_START
+              cidr: CHANGEME_SNO_STORAGE_CIDR
+              name: subnet1
+              vlan: CHANGEME_SNO_STORAGE_VLAN
+            # CHANGEME: site4 storage subnet
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_STORAGE_END
+                    start: CHANGEME_EDPM_STORAGE_START
+              cidr: CHANGEME_EDPM_STORAGE_CIDR
+              name: subnet2
+              vlan: CHANGEME_EDPM_STORAGE_VLAN
+        vlan: CHANGEME_SNO_STORAGE_VLAN
+    storageClass: lvms-local-storage
+    storagemgmt:
+        base_iface: CHANGEME_SNO_IFACE
+        dnsDomain: storagemgmt.example.com
+        iface: storagemgmt
+        lb_addresses:
+            - CHANGEME_SNO_STGMGMT_LB_START-CHANGEME_SNO_STGMGMT_LB_END
+        mtu: 1500
+        net-attach-def: |
+            {
+              "cniVersion": "0.4.0",
+              "name": "storagemgmt",
+              "plugins": [{
+                "type": "macvlan",
+                "master": "storagemgmt",
+                "ipam": {
+                  "type": "whereabouts",
+                  "range": "CHANGEME_SNO_STGMGMT_CIDR",
+                  "range_start": "CHANGEME_SNO_STGMGMT_NAD_START",
+                  "range_end": "CHANGEME_SNO_STGMGMT_NAD_END"
+                }
+              }, {
+                "type": "tuning",
+                "sysctl": {
+                  "net.ipv6.conf.IFNAME.accept_ra": "0"
+                }
+              }]
+            }
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_STGMGMT_END
+                    start: CHANGEME_SNO_STGMGMT_START
+              cidr: CHANGEME_SNO_STGMGMT_CIDR
+              name: subnet1
+              vlan: CHANGEME_SNO_STGMGMT_VLAN
+            # CHANGEME: site4 storagemgmt subnet
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_STGMGMT_END
+                    start: CHANGEME_EDPM_STGMGMT_START
+              cidr: CHANGEME_EDPM_STGMGMT_CIDR
+              name: subnet2
+              vlan: CHANGEME_EDPM_STGMGMT_VLAN
+        vlan: CHANGEME_SNO_STGMGMT_VLAN
+    tenant:
+        base_iface: CHANGEME_SNO_IFACE
+        dnsDomain: tenant.example.com
+        endpoint_annotations:
+            metallb.universe.tf/address-pool: tenant
+            metallb.universe.tf/allow-shared-ip: tenant
+            metallb.universe.tf/loadBalancerIPs: CHANGEME_SNO_TENANT_LB_IP
+        iface: tenant
+        lb_addresses:
+            - CHANGEME_SNO_TENANT_LB_START-CHANGEME_SNO_TENANT_LB_END
+        mtu: 1500
+        net-attach-def: |
+            {
+              "cniVersion": "0.4.0",
+              "name": "tenant",
+              "plugins": [{
+                "type": "macvlan",
+                "master": "tenant",
+                "ipam": {
+                  "type": "whereabouts",
+                  "range": "CHANGEME_SNO_TENANT_CIDR",
+                  "range_start": "CHANGEME_SNO_TENANT_NAD_START",
+                  "range_end": "CHANGEME_SNO_TENANT_NAD_END"
+                }
+              }, {
+                "type": "tuning",
+                "sysctl": {
+                  "net.ipv6.conf.IFNAME.accept_ra": "0"
+                }
+              }]
+            }
+        prefix-length: 24
+        subnets:
+            - allocationRanges:
+                  - end: CHANGEME_SNO_TENANT_END
+                    start: CHANGEME_SNO_TENANT_START
+              cidr: CHANGEME_SNO_TENANT_CIDR
+              name: subnet1
+              vlan: CHANGEME_SNO_TENANT_VLAN
+            # CHANGEME: site4 tenant subnet
+            - allocationRanges:
+                  - end: CHANGEME_EDPM_TENANT_END
+                    start: CHANGEME_EDPM_TENANT_START
+              cidr: CHANGEME_EDPM_TENANT_CIDR
+              name: subnet2
+              vlan: CHANGEME_EDPM_TENANT_VLAN
+        vlan: CHANGEME_SNO_TENANT_VLAN
+
+kind: ConfigMap
+metadata:
+    annotations:
+        config.kubernetes.io/local-config: 'true'
+    name: network-values

--- a/examples/dt/nova/nova05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/nova/nova05epsilon/control-plane/service-values.yaml
@@ -1,0 +1,16 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # --- Fields required by lib/control-plane ---
+  # must match ../service-values.yaml
+  preserveJobs: false
+  notificationsBus:
+    cluster: rabbitmq
+  tls:
+    caBundleSecretName: ""

--- a/examples/dt/nova/nova05epsilon/dataplane-post-ceph.md
+++ b/examples/dt/nova/nova05epsilon/dataplane-post-ceph.md
@@ -1,0 +1,107 @@
+# Update the control plane and finish deploying the data plane after Ceph has been installed
+
+## Assumptions
+
+- The [pre-ceph data plane](dataplane-pre-ceph.md) has been deployed
+- Ceph has been installed on the compute nodes
+
+## Initialize
+
+Switch to the "openstack" namespace
+
+```shell
+oc project openstack
+```
+
+Change to the nova05epsilon directory
+
+```shell
+cd architecture/examples/dt/nova/nova05epsilon
+```
+
+Edit the [values.yaml](values.yaml) and [service-values.yaml](service-values.yaml)
+files to suit your environment. In particular, update the Ceph configuration
+placeholders in `values.yaml`:
+
+- **`data.ceph_conf`** (DCN convention): A dict mapping Ceph filenames to
+  base64-encoded content. For a single-site deployment, use plain filenames.
+  For multi-AZ DCN, use az-prefixed filenames (e.g. `az0.conf`, `az1.conf`).
+  - `ceph.client.openstack.keyring`: `base64 -w0 /etc/ceph/ceph.client.openstack.keyring`
+  - `ceph.conf`: `base64 -w0 /etc/ceph/ceph.conf`
+- **`CHANGEME_NOVA_CEPH_CONF`**: Nova compute Ceph configuration in INI
+  format. This configures libvirt RBD for ephemeral disks and Glance
+  copy-on-write. A typical value looks like:
+
+```ini
+[libvirt]
+images_type=rbd
+images_rbd_pool=vms
+images_rbd_ceph_conf=/etc/ceph/ceph.conf
+images_rbd_glance_store_name=default_backend
+images_rbd_glance_copy_poll_interval=15
+images_rbd_glance_copy_timeout=600
+rbd_user=openstack
+rbd_secret_uuid=<ceph-fsid>
+```
+
+Replace `<ceph-fsid>` with the Ceph cluster FSID (from `ceph fsid`).
+
+```shell
+vi values.yaml
+vi service-values.yaml
+```
+
+## Update the control plane and deploy the post-ceph dataplane
+
+Generate the post-ceph CRs (this includes both the updated control plane
+and the post-ceph nodeset):
+
+```shell
+kustomize build > dataplane-nodeset.yaml
+```
+
+Apply the CRs:
+
+```shell
+oc apply -f dataplane-nodeset.yaml
+```
+
+Wait for control plane to be available:
+
+```shell
+oc wait osctlplane controlplane --for condition=Ready --timeout=600s
+```
+
+Wait for the nodeset setup to complete:
+
+```shell
+oc wait osdpns gpu-computes-edpm --for condition=SetupReady --timeout=600s
+```
+
+Generate and apply the post-ceph deployment:
+
+```shell
+kustomize build deployment > dataplane-deployment.yaml
+oc apply -f dataplane-deployment.yaml
+```
+
+Wait for deployment to finish:
+
+```shell
+oc wait osdpd edpm-deployment-post-ceph --for condition=Ready --timeout=40m
+```
+
+## Verify GPU passthrough
+
+After deployment, verify that GPU PCI devices are reported in Placement:
+
+```shell
+oc rsh nova-api-0 nova-manage placement audit
+```
+
+Create a flavor with GPU passthrough:
+
+```shell
+openstack --os-compute-api=2.86 flavor create --ram 8192 --vcpus 4 --disk 40 gpu-passthrough
+openstack --os-compute-api=2.86 flavor set --property "pci_passthrough:alias"="nvidia_a2:1" gpu-passthrough
+```

--- a/examples/dt/nova/nova05epsilon/dataplane-pre-ceph.md
+++ b/examples/dt/nova/nova05epsilon/dataplane-pre-ceph.md
@@ -1,0 +1,103 @@
+# Configure and deploy the initial data plane to prepare for Ceph installation
+
+## Assumptions
+
+- The [control plane](control-plane.md) has been created and successfully deployed
+
+## Initialize
+
+Switch to the "openstack" namespace
+
+```shell
+oc project openstack
+```
+
+Change to the nova05epsilon directory
+
+```shell
+cd architecture/examples/dt/nova/nova05epsilon
+```
+
+Edit the [edpm-pre-ceph/nodeset/values.yaml](edpm-pre-ceph/nodeset/values.yaml)
+file to suit your environment.
+
+```shell
+vi edpm-pre-ceph/nodeset/values.yaml
+```
+
+Pay special attention to:
+- `baremetalhosts` section: BMC addresses, boot MAC addresses, root device hints
+- `edpm_kernel_args`: GPU vendor/product IDs for VFIO passthrough
+- `edpm_tuned_isolated_cores`: CPU cores to isolate for VM pinning
+- `nova.pci.conf`: PCI device_spec entries for each GPU
+- `edpm_ceph_hci_pre_enabled_services`: Ceph services to pre-configure
+- All EDPM nodes use `subnetName: subnet2` (site4 DCN subnet) -- update the
+  CHANGEME CIDRs in both `edpm-pre-ceph/nodeset/values.yaml` and
+  `control-plane/networking/nncp/values.yaml` to match site4's actual network
+
+### Create the BareMetalHost CRs
+
+Create the `bmc-secret` secret with BMC credentials:
+
+```shell
+oc create secret generic bmc-secret --from-literal=username=CHANGEME --from-literal=password=CHANGEME
+```
+
+Generate the BareMetalHost CRs:
+
+```shell
+kustomize build edpm/baremetalhosts > baremetalhosts.yaml
+```
+
+Apply the BareMetalHost CRs:
+
+```shell
+oc apply -f baremetalhosts.yaml
+```
+
+Wait for BareMetalHosts to become available:
+
+```shell
+oc get bmh -w
+```
+
+### Configure and deploy the pre-ceph dataplane
+
+Generate the dataplane nodeset CR:
+
+```shell
+kustomize build edpm-pre-ceph/nodeset > dataplane-nodeset.yaml
+```
+
+Apply the nodeset CR:
+
+```shell
+oc apply -f dataplane-nodeset.yaml
+```
+
+Wait for nodeset setup to finish:
+
+```shell
+oc wait osdpns gpu-computes-edpm --for condition=SetupReady --timeout=600s
+```
+
+Generate and apply the deployment CR:
+
+```shell
+kustomize build edpm-pre-ceph/deployment > dataplane-deployment.yaml
+oc apply -f dataplane-deployment.yaml
+```
+
+Wait for deployment to finish:
+
+```shell
+oc wait osdpd edpm-deployment-pre-ceph --for condition=Ready --timeout=40m
+```
+
+After the NVIDIA drivers have been blacklisted and kernel args updated,
+EDPM hosts will be automatically rebooted.
+
+## Install Ceph
+
+At this point, install Ceph on the compute nodes. The Ceph installation
+is not managed by OpenStack K8S operators.

--- a/examples/dt/nova/nova05epsilon/deployment/kustomization.yaml
+++ b/examples/dt/nova/nova05epsilon/deployment/kustomization.yaml
@@ -1,0 +1,23 @@
+# This is the kustomization for the FINAL step, edpm-post-ceph
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/nova/nova05epsilon/edpm-post-ceph/deployment
+
+resources:
+  - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values-post-ceph
+      fieldPath: data.servicesOverride
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.servicesOverride
+        options:
+          create: true

--- a/examples/dt/nova/nova05epsilon/deployment/values.yaml
+++ b/examples/dt/nova/nova05epsilon/deployment/values.yaml
@@ -1,0 +1,20 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values-post-ceph
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeset_name: gpu-computes-edpm
+  deployment:
+    name: edpm-deployment-post-ceph
+  servicesOverride:
+    - install-certs
+    - ceph-client
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova-custom-gpu-ceph
+    - telemetry

--- a/examples/dt/nova/nova05epsilon/edpm-pre-ceph/.gitignore
+++ b/examples/dt/nova/nova05epsilon/edpm-pre-ceph/.gitignore
@@ -1,0 +1,3 @@
+# Generated files
+dataplane-nodeset.yaml
+dataplane-deployment.yaml

--- a/examples/dt/nova/nova05epsilon/edpm-pre-ceph/deployment/kustomization.yaml
+++ b/examples/dt/nova/nova05epsilon/edpm-pre-ceph/deployment/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/nova/nova05epsilon/edpm-pre-ceph/deployment
+
+resources:
+  - values.yaml

--- a/examples/dt/nova/nova05epsilon/edpm-pre-ceph/deployment/values.yaml
+++ b/examples/dt/nova/nova05epsilon/edpm-pre-ceph/deployment/values.yaml
@@ -1,0 +1,12 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeset_name: gpu-computes-edpm
+  deployment:
+    name: edpm-deployment-pre-ceph

--- a/examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/kustomization.yaml
+++ b/examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/
+
+resources:
+  - values.yaml

--- a/examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/values.yaml
@@ -1,0 +1,199 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+#
+# EDPM compute nodes at site4 use a mandatory LACP bond (both NICs).
+# Native VLAN carries ctlplane; tagged VLANs carry isolated networks.
+# Site4 computes use subnet2 (different CIDRs from site2 subnet1).
+# All subnets in 10.0.0.0/8, routable between sites via L3.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeset_name: gpu-computes-edpm
+  root_password: cmVkaGF0Cg==
+  preProvisioned: false
+  baremetalHostsNetworkData:
+    edpm-compute-0:
+      networkData: |
+        CHANGEME
+  baremetalSetTemplate:
+    ctlplaneInterface: bond0
+    cloudUserName: cloud-admin
+    bmhNamespace: openstack
+    bmhLabelSelector:
+      app: openstack  # CHANGEME
+    passwordSecret:
+      name: baremetalset-password-secret
+      namespace: openstack
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # CHANGEME -- see https://access.redhat.com/solutions/253273
+        edpm_bootstrap_command: |
+          echo CHANGEME
+        rhc_release: 9.4
+        rhc_repositories:
+          - {name: "*", state: disabled}
+          - {name: "CHANGEME"}
+        edpm_bootstrap_release_version_package: []
+        # GPU passthrough: IOMMU + vfio-pci for NVIDIA GPUs
+        edpm_kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=16 intel_iommu=on iommu=pt vfio-pci.ids=10de:20f1 rd.driver.pre=vfio-pci"
+        edpm_reboot_strategy: force
+        edpm_tuned_profile: "cpu-partitioning-powersave"
+        edpm_tuned_isolated_cores: "4-23,28-47"
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_ovn_bridge_mappings:
+          - datacentre:br-ex
+        edpm_network_config_os_net_config_mappings:
+          edpm-compute-0:
+            nic1: CHANGEME
+            nic2: CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            mtu: {{ min_viable_mtu }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            members:
+            - type: linux_bond
+              name: bond0
+              mtu: {{ min_viable_mtu }}
+              bonding_options: "mode=802.3ad lacp_rate=fast"
+              members:
+              - type: interface
+                name: nic1
+                mtu: {{ min_viable_mtu }}
+                primary: true
+              - type: interface
+                name: nic2
+                mtu: {{ min_viable_mtu }}
+          {% for network in nodeset_networks %}
+            - type: vlan
+              mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+              vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+              addresses:
+              - ip_netmask:
+                  {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+              routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth0
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_network_config_nmstate: false
+        edpm_network_config_update: false
+        dns_search_domains: []
+        gather_facts: false
+        edpm_sshd_configure_firewall: true
+        edpm_sshd_allowed_ranges:
+          - CHANGEME_SNO_CTLPLANE_CIDR
+          - CHANGEME_SITE4_CTLPLANE_CIDR
+        # Ceph HCI pre-config
+        edpm_enable_chassis_gw: false
+        edpm_ovn_availability_zones: []
+        edpm_ceph_hci_pre_enabled_services:
+          - ceph_mon
+          - ceph_mgr
+          - ceph_osd
+          - ceph_rgw
+          - ceph_nfs
+          - ceph_rgw_frontend
+          - ceph_nfs_frontend
+        storage_mtu: 9000
+        storage_mgmt_mtu: 9000
+        storage_mgmt_vlan_id: CHANGEME_STGMGMT_VLAN
+        storage_mgmt_cidr: CHANGEME_STGMGMT_PREFIX_LEN
+        storage_mgmt_host_routes: []
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet2
+      - name: internalapi
+        subnetName: subnet2
+      - name: storage
+        subnetName: subnet2
+      - name: tenant
+        subnetName: subnet2
+    nodes:
+      edpm-compute-0:
+        hostName: edpm-compute-0
+        bmhLabelSelector:
+          nodeName: edpm-compute-0
+        networkData:
+          name: edpm-compute-0-network-data
+          namespace: openstack
+        networks:
+          - name: ctlplane
+            subnetName: subnet2
+            defaultRoute: true
+            fixedIP: CHANGEME_SITE4_CTLPLANE_IP
+          - name: internalapi
+            subnetName: subnet2
+          - name: storage
+            subnetName: subnet2
+          - name: storagemgmt
+            subnetName: subnet2
+          - name: tenant
+            subnetName: subnet2
+    services:
+      - vfio-pci-bind
+      - bootstrap
+      - download-cache
+      - configure-network
+      - validate-network
+      - install-os
+      - ceph-hci-pre
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+  nova:
+    compute:
+      conf: |
+        # CHANGEME
+        [DEFAULT]
+        reserved_host_memory_mb = 4096
+        reserved_huge_pages = node:0,size:4,count:524160
+        reserved_huge_pages = node:1,size:4,count:524160
+        [compute]
+        cpu_shared_set = 0-3,24-27
+        cpu_dedicated_set = 8-23,32-47
+    migration:
+      ssh_keys:
+        private: CHANGEME
+        public: CHANGEME
+    pci:
+      conf: |
+        # CHANGEME
+        [pci]
+        device_spec = {"vendor_id":"10de", "product_id":"20f1", "address": "CHANGEME" }
+        alias = { "vendor_id":"10de", "product_id":"20f1", "device_type":"type-PF", "name":"nvidia_a2" }
+        report_in_placement = True

--- a/examples/dt/nova/nova05epsilon/edpm/baremetalhosts/kustomization.yaml
+++ b/examples/dt/nova/nova05epsilon/edpm/baremetalhosts/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/nova/nova05epsilon/edpm/baremetalhosts
+
+resources:
+  - values.yaml

--- a/examples/dt/nova/nova05epsilon/edpm/baremetalhosts/values.yaml
+++ b/examples/dt/nova/nova05epsilon/edpm/baremetalhosts/values.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: baremetalhost-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  metal3_inspection: disabled
+  edpm-compute-0:
+    online: true
+    externallyProvisioned: false
+    labels:
+      app: openstack
+      nodeset: edpm
+      nodeName: edpm-compute-0
+    bmc:
+      address: CHANGEME
+      # NOTE: in CI systems, we use credentials_file from cifmw_baremetal_hosts.
+      # credentialsName: bmc-secret
+      disableCertificateVerification: true
+    bootMACAddress: CHANGEME
+    rootDeviceHints:
+      deviceName: /dev/vda
+    preprovisioningNetworkDataName: edpm-compute-0-nmstate-secret
+    preprovisioningNetworkData:
+      nmstate: |
+        CHANGEME

--- a/examples/dt/nova/nova05epsilon/edpm/baremetalhosts/values.yaml
+++ b/examples/dt/nova/nova05epsilon/edpm/baremetalhosts/values.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: baremetalhost-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  metal3_inspection: disabled
+  edpm-compute-0:
+    online: true
+    externallyProvisioned: false
+    labels:
+      app: openstack
+      nodeset: edpm
+      nodeName: edpm-compute-0
+    bmc:
+      address: CHANGEME
+      # NOTE: in CI systems, we use credentials_file from cifmw_baremetal_hosts.
+      # credentialsName: bmc-secret
+      disableCertificateVerification: true
+    bootMACAddress: CHANGEME
+    rootDeviceHints:
+      deviceName: /dev/vda
+    preprovisioningNetworkDataName: OPTIONAL
+    automatedCleaningMode: metadata
+    preprovisioningNetworkData:
+      networkData: |
+        CHANGEME

--- a/examples/dt/nova/nova05epsilon/kustomization.yaml
+++ b/examples/dt/nova/nova05epsilon/kustomization.yaml
@@ -1,0 +1,13 @@
+# This is the kustomization for the FINAL step, edpm-post-ceph
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/nova/nova05epsilon/edpm-post-ceph/nodeset
+
+resources:
+  - control-plane/networking/nncp/values.yaml
+  - edpm-pre-ceph/nodeset/values.yaml
+  - service-values.yaml
+  - values.yaml

--- a/examples/dt/nova/nova05epsilon/service-values.yaml
+++ b/examples/dt/nova/nova05epsilon/service-values.yaml
@@ -1,0 +1,102 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # --- Fields required by lib/control-plane ---
+  # must match ./control-plane/service-values.yaml
+  preserveJobs: false
+  notificationsBus:
+    cluster: rabbitmq
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
+  neutron:
+    customServiceConfig: |
+      [ml2]
+      mechanism_drivers = ovn
+  ovn:
+    ovnController:
+      nicMappings:
+        datacentre: ospbr
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:rbd
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      rbd_store_ceph_conf = /etc/ceph/ceph.conf
+      store_description = "Ceph RBD backend"
+      rbd_store_pool = images
+      rbd_store_user = openstack
+      rbd_thin_provisioning = True
+    default:
+      replicas: 1
+  swift:
+    enabled: false
+  telemetry:
+    enabled: true
+    template:
+      ceilometer:
+        enabled: true
+      logging:
+        enabled: false
+      metricStorage:
+        dashboardsEnabled: true
+        enabled: true
+        dataplaneNetwork: ctlplane
+        networkAttachments:
+          - ctlplane
+        monitoringStack:
+          alertingEnabled: true
+          scrapeInterval: 30s
+          storage:
+            persistent:
+              pvcStorageClass: local-storage
+              pvcStorageRequest: 20G
+              pvcStorageSelector: {}
+            retention: 24h
+            strategy: persistent
+  # Nova GPU PCI passthrough configuration
+  nova:
+    apiServiceTemplate:
+      customServiceConfig: |
+        [pci]
+        alias = { "vendor_id":"10de", "product_id":"20f1", "device_type":"type-PF", "name":"nvidia_a2" }
+        [filter_scheduler]
+        pci_in_placement = True
+    cell0:
+      conductorServiceTemplate:
+        customServiceConfig: |
+          [filter_scheduler]
+          pci_in_placement = True
+    cell1:
+      conductorServiceTemplate:
+        customServiceConfig: |
+          [filter_scheduler]
+          pci_in_placement = True
+    schedulerServiceTemplate:
+      customServiceConfig: |
+        [filter_scheduler]
+        pci_in_placement = True
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+            - GlanceAPI
+          extraVolType: Ceph
+          volumes:
+            - name: ceph
+              secret:
+                secretName: ceph-conf-files
+          mounts:
+            - name: ceph
+              mountPath: /etc/ceph
+              readOnly: true

--- a/examples/dt/nova/nova05epsilon/values.yaml
+++ b/examples/dt/nova/nova05epsilon/values.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+data:
+    nodeset_name: gpu-computes-edpm
+    ceph_conf:
+        # Ceph config files as base64-encoded content.
+        # For multi-AZ, use az-prefixed filenames (e.g. az0.conf, az1.conf).
+        # Single-site uses plain filenames.
+        #
+        # CHANGEME_CEPH_KEYRING: base64-encoded Ceph client keyring.
+        #   Obtain with: base64 -w0 /etc/ceph/ceph.client.openstack.keyring
+        # CHANGEME_CEPH_CONF: base64-encoded Ceph configuration.
+        #   Obtain with: base64 -w0 /etc/ceph/ceph.conf
+        ceph.client.openstack.keyring: CHANGEME_CEPH_KEYRING
+        ceph.conf: CHANGEME_CEPH_CONF
+    nodeset:
+        services:
+            - bootstrap
+            - configure-network
+            - validate-network
+            - install-os
+            - ceph-hci-pre
+            - configure-os
+            - ssh-known-hosts
+            - run-os
+            - reboot-os
+            - install-certs
+            - ceph-client
+            - ovn
+            - neutron-metadata
+            - libvirt
+            - nova-custom-gpu-ceph
+            - telemetry
+    nova:
+        customDataplaneService:
+            name: nova-custom-gpu-ceph
+        ceph:
+            # CHANGEME_NOVA_CEPH_CONF: Nova compute Ceph config (INI format).
+            # Replace CHANGEME_CEPH_FSID below with the Ceph cluster FSID
+            # obtained with: ceph fsid
+            # Example:
+            #   [libvirt]
+            #   images_type=rbd
+            #   images_rbd_pool=vms
+            #   images_rbd_ceph_conf=/etc/ceph/ceph.conf
+            #   images_rbd_glance_store_name=default_backend
+            #   images_rbd_glance_copy_poll_interval=15
+            #   images_rbd_glance_copy_timeout=600
+            #   rbd_user=openstack
+            #   rbd_secret_uuid=CHANGEME_CEPH_FSID
+            conf: CHANGEME_NOVA_CEPH_CONF
+        name: ceph-nova
+        dataSources:
+            - configMapRef:
+              name: ceph-nova
+            - configMapRef:
+              name: cpu-pinning-nova
+            - configMapRef:
+              name: gpu-nova
+            - secretRef:
+              name: nova-cell1-compute-config
+            - secretRef:
+              name: nova-migration-ssh-key
+    neutron-metadata:
+        customDataplaneService:
+            name: neutron-metadata
+        dataSources:
+            - secretRef:
+              name: neutron-ovn-metadata-agent-neutron-config
+            - secretRef:
+              name: nova-cell1-metadata-neutron-config
+kind: ConfigMap
+metadata:
+    annotations:
+        config.kubernetes.io/local-config: 'true'
+    name: edpm-nodeset-values-post-ceph

--- a/examples/dt/nova/nova05epsilon/values.yaml
+++ b/examples/dt/nova/nova05epsilon/values.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+data:
+    nodeset_name: gpu-computes-edpm
+    ceph_conf:
+        # Ceph config files as base64-encoded content.
+        # For multi-AZ, use az-prefixed filenames (e.g. az0.conf, az1.conf).
+        # Single-site uses plain filenames.
+        #
+        # CHANGEME_CEPH_KEYRING: base64-encoded Ceph client keyring.
+        #   Obtain with: base64 -w0 /etc/ceph/ceph.client.openstack.keyring
+        # CHANGEME_CEPH_CONF: base64-encoded Ceph configuration.
+        #   Obtain with: base64 -w0 /etc/ceph/ceph.conf
+        ceph.client.openstack.keyring: CHANGEME_CEPH_KEYRING
+        ceph.conf: CHANGEME_CEPH_CONF
+    nodeset:
+        services:
+            - bootstrap
+            - configure-network
+            - validate-network
+            - install-os
+            - ceph-hci-pre
+            - configure-os
+            - ssh-known-hosts
+            - run-os
+            - reboot-os
+            - install-certs
+            - ceph-client
+            - ovn
+            - neutron-metadata
+            - libvirt
+            - nova-custom-gpu-ceph
+            - telemetry
+    nova:
+        customDataplaneService:
+            name: nova-custom-gpu-ceph
+        ceph:
+            # CHANGEME_NOVA_CEPH_CONF: Nova compute Ceph config (INI format).
+            # Replace CHANGEME_CEPH_FSID below with the Ceph cluster FSID
+            # obtained with: ceph fsid
+            # Example:
+            #   [libvirt]
+            #   images_type=rbd
+            #   images_rbd_pool=vms
+            #   images_rbd_ceph_conf=/etc/ceph/ceph.conf
+            #   images_rbd_glance_store_name=default_backend
+            #   images_rbd_glance_copy_poll_interval=15
+            #   images_rbd_glance_copy_timeout=600
+            #   rbd_user=openstack
+            #   rbd_secret_uuid=CHANGEME_CEPH_FSID
+            conf: CHANGEME_NOVA_CEPH_CONF
+        name: ceph-nova
+        dataSources:
+            - configMapRef:
+                  name: ceph-nova
+            - configMapRef:
+                  name: cpu-pinning-nova
+            - configMapRef:
+                  name: gpu-nova
+            - secretRef:
+                  name: nova-cell1-compute-config
+            - secretRef:
+                  name: nova-migration-ssh-key
+    neutron-metadata:
+        customDataplaneService:
+            name: neutron-metadata
+        dataSources:
+            - secretRef:
+                  name: neutron-ovn-metadata-agent-neutron-config
+            - secretRef:
+                  name: nova-cell1-metadata-neutron-config
+kind: ConfigMap
+metadata:
+    annotations:
+        config.kubernetes.io/local-config: 'true'
+    name: edpm-nodeset-values-post-ceph

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -21,6 +21,7 @@
       - rhoso-architecture-validate-nova03gamma
       - rhoso-architecture-validate-nova04delta
       - rhoso-architecture-validate-nova04delta-adoption
+      - rhoso-architecture-validate-nova05epsilon
       - rhoso-architecture-validate-nvidia-mdev
       - rhoso-architecture-validate-nvidia-vfio-passthrough
       - rhoso-architecture-validate-nvidia-vfio-passthrough-adoption

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -23,6 +23,7 @@
       - rhoso-architecture-validate-nova03gamma
       - rhoso-architecture-validate-nova04delta
       - rhoso-architecture-validate-nova04delta-adoption
+      - rhoso-architecture-validate-nova05epsilon
       - rhoso-architecture-validate-nvidia-mdev
       - rhoso-architecture-validate-nvidia-vfio-passthrough
       - rhoso-architecture-validate-nvidia-vfio-passthrough-adoption

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -278,6 +278,22 @@
       cifmw_architecture_scenario: nova04delta-adoption
 - job:
     files:
+    - examples/dt/nova/nova05epsilon
+    - examples/dt/nova/nova05epsilon/control-plane
+    - examples/dt/nova/nova05epsilon/control-plane/networking
+    - examples/dt/nova/nova05epsilon/control-plane/networking/dns
+    - examples/dt/nova/nova05epsilon/control-plane/networking/nncp
+    - examples/dt/nova/nova05epsilon/deployment
+    - examples/dt/nova/nova05epsilon/edpm-pre-ceph/deployment
+    - examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset
+    - examples/dt/nova/nova05epsilon/edpm/baremetalhosts
+    - lib
+    name: rhoso-architecture-validate-nova05epsilon
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: nova05epsilon
+- job:
+    files:
     - examples/va/nvidia-mdev/control-plane
     - examples/va/nvidia-mdev/control-plane/nncp
     - examples/va/nvidia-mdev/edpm-post-driver/deployment

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -307,6 +307,22 @@
       cifmw_architecture_scenario: nova04delta-adoption
 - job:
     files:
+    - examples/dt/nova/nova05epsilon
+    - examples/dt/nova/nova05epsilon/control-plane
+    - examples/dt/nova/nova05epsilon/control-plane/networking
+    - examples/dt/nova/nova05epsilon/control-plane/networking/dns
+    - examples/dt/nova/nova05epsilon/control-plane/networking/nncp
+    - examples/dt/nova/nova05epsilon/deployment
+    - examples/dt/nova/nova05epsilon/edpm-pre-ceph/deployment
+    - examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset
+    - examples/dt/nova/nova05epsilon/edpm/baremetalhosts
+    - lib
+    name: rhoso-architecture-validate-nova05epsilon
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: nova05epsilon
+- job:
+    files:
     - examples/va/nvidia-mdev/control-plane
     - examples/va/nvidia-mdev/control-plane/nncp
     - examples/va/nvidia-mdev/edpm-post-driver/deployment


### PR DESCRIPTION
Based on hci, dcn and nova04delta DTs, but
adapted for SNO. Octavia is removed.

Jira: [OSPRH-27841](https://redhat.atlassian.net/browse/OSPRH-27841)
Generated-by: claude-4.6-opus-high