### PR TITLE
Revert rabbitmq pods memory limits

### DIFF
--- a/examples/dt/dcn/control-plane/scaledown/service-values.yaml
+++ b/examples/dt/dcn/control-plane/scaledown/service-values.yaml
@@ -327,13 +327,6 @@ data:
             spec:
               type: LoadBalancer
         replicas: 3
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: "1"
-            memory: 4Gi
   extraMounts:
     - name: v1
       region: r1

--- a/examples/dt/dcn/service-values.yaml
+++ b/examples/dt/dcn/service-values.yaml
@@ -408,13 +408,6 @@ data:
             spec:
               type: LoadBalancer
         replicas: 3
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: "1"
-            memory: 4Gi
       rabbitmq-cell3:
         override:
           service:
@@ -425,13 +418,6 @@ data:
             spec:
               type: LoadBalancer
         replicas: 3
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: "1"
-            memory: 4Gi
   extraMounts:
     - name: v1
       region: r1

--- a/examples/dt/nova/nova-three-cells/control-plane/service-values.yaml
+++ b/examples/dt/nova/nova-three-cells/control-plane/service-values.yaml
@@ -65,10 +65,3 @@ data:
     templates:
       rabbitmq-cell2:
         replicas: 3
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: "1"
-            memory: 4Gi

--- a/examples/dt/uni05epsilon/control-plane/service-values.yaml
+++ b/examples/dt/uni05epsilon/control-plane/service-values.yaml
@@ -39,10 +39,3 @@ data:
     templates:
       rabbitmq-cell2:
         replicas: 3
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: "1"
-            memory: 4Gi

--- a/examples/dt/uni05epsilon/service-values.yaml
+++ b/examples/dt/uni05epsilon/service-values.yaml
@@ -152,13 +152,6 @@ data:
     templates:
       rabbitmq-cell2:
         replicas: 3
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: "1"
-            memory: 4Gi
       rabbitmq-notifications:
         override:
           service:
@@ -169,13 +162,6 @@ data:
             spec:
               type: LoadBalancer
         replicas: 3
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: "1"
-            memory: 4Gi
 
   swift:
     enabled: true

--- a/examples/va/hci/service-values.yaml
+++ b/examples/va/hci/service-values.yaml
@@ -141,12 +141,5 @@ data:
             spec:
               type: LoadBalancer
         replicas: 3
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: "1"
-            memory: 4Gi
   watcher:
     enabled: true

--- a/examples/va/multi-namespace-skmo/control-plane/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane/kustomization.yaml
@@ -10,24 +10,6 @@ patches:
       kind: ConfigMap
       name: service-values
     path: service-values.yaml
-  - target:
-      group: core.openstack.org
-      version: v1beta1
-      kind: OpenStackControlPlane
-      name: controlplane
-    patch: |-
-      - op: replace
-        path: /spec/rabbitmq/templates/rabbitmq/resources/requests/memory
-        value: 2Gi
-      - op: replace
-        path: /spec/rabbitmq/templates/rabbitmq/resources/limits/memory
-        value: 2Gi
-      - op: replace
-        path: /spec/rabbitmq/templates/rabbitmq-cell1/resources/requests/memory
-        value: 2Gi
-      - op: replace
-        path: /spec/rabbitmq/templates/rabbitmq-cell1/resources/limits/memory
-        value: 2Gi
 
 replacements:
   - source:

--- a/examples/va/multi-namespace-skmo/control-plane2/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane2/kustomization.yaml
@@ -23,18 +23,6 @@ patches:
         path: /spec/keystone/template/override/service/internal/metadata
       - op: remove
         path: /spec/keystone/template/override/service/internal/spec
-      - op: replace
-        path: /spec/rabbitmq/templates/rabbitmq/resources/requests/memory
-        value: 2Gi
-      - op: replace
-        path: /spec/rabbitmq/templates/rabbitmq/resources/limits/memory
-        value: 2Gi
-      - op: replace
-        path: /spec/rabbitmq/templates/rabbitmq-cell1/resources/requests/memory
-        value: 2Gi
-      - op: replace
-        path: /spec/rabbitmq/templates/rabbitmq-cell1/resources/limits/memory
-        value: 2Gi
 
 replacements:
   - source:

--- a/lib/control-plane/base/openstackcontrolplane.yaml
+++ b/lib/control-plane/base/openstackcontrolplane.yaml
@@ -249,22 +249,8 @@ spec:
     templates:
       rabbitmq:
         replicas: 3
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: "1"
-            memory: 4Gi
       rabbitmq-cell1:
         replicas: 3
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: "1"
-            memory: 4Gi
   notificationsBus:
     cluster: rabbitmq
   secret: osp-secret


### PR DESCRIPTION
- Reverts PR #708 which added explicit CPU/memory resource limits to rabbitmq templates
- Removes rabbitmq memory resource patches from multi-namespace-skmo kustomizations that were referencing the now-removed resource fields (fixes the `test-kustomize` CI failure from #730)

Supersedes #730

Jira: https://redhat.atlassian.net/browse/OSPCIX-1310