### PR TITLE
[skmo] Add Skupper for cross-region RabbitMQ and Keystone

### DIFF
--- a/automation/vars/multi-namespace-skmo.yaml
+++ b/automation/vars/multi-namespace-skmo.yaml
@@ -112,6 +112,7 @@ vas:
             # Run before deploying the leaf control plane so that:
             #  - Fresh deploys start with the correct images (no restart).
             #  - Re-runs wait for the OSCP to settle before continuing.
+            # Numeric prefix required: run_hook sorts hooks alphabetically by name.
             type: playbook
             source: "../../playbooks/multi-namespace/ns2_update_containers.yaml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
@@ -119,7 +120,40 @@ vas:
               cifmw_update_containers_namespace: openstack2
               cifmw_update_containers_metadata: controlplane
               cifmw_update_containers: "true"
-          - name: 02 Prepare SKMO leaf prerequisites in regionZero
+          - name: 02 Install Skupper operator
+            type: playbook
+            source: "skmo/skupper-install.yaml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+          - name: 03 Create and link Skupper Sites
+            type: playbook
+            source: "skmo/skupper-sites.yaml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+          - name: 04 Create Skupper Connector for central Keystone internal endpoint
+            # Must run before the leaf OSCP is applied so that the Skupper
+            # virtual Service (keystone-regionone) exists when OpenStack
+            # services first try to authenticate.  The cert-manager Certificate
+            # is created here too; it will reconcile once the OSCP operator
+            # creates the rootca-internal Issuer during stage 6 deployment.
+            # Set cifmw_skupper_keystone_enabled=false to skip and revert
+            # keystoneInternalURL in skmo-values.yaml to the public URL.
+            type: playbook
+            source: "skmo/skupper-keystone-connector.yaml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+          - name: 05 Create Skupper Listener for Keystone in leaf namespace
+            type: playbook
+            source: "skmo/skupper-listener.yaml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+            extra_vars:
+              cifmw_skupper_listener_enabled: true
+              cifmw_skupper_listener_name: keystone-internal
+              cifmw_skupper_listener_cert_name: skupper-keystone-regionone
+              cifmw_skupper_listener_cert_secret: cert-skupper-keystone-regionone
+              cifmw_skupper_listener_routing_key: keystone-internal
+              cifmw_skupper_listener_host: keystone-regionone
+              cifmw_skupper_listener_port: 5000
+              cifmw_skupper_listener_namespace: openstack2
+              cifmw_skupper_listener_ignore_wait_errors: true
+          - name: 06 Prepare SKMO leaf prerequisites in regionZero
             type: playbook
             source: "skmo/prepare-leaf.yaml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
@@ -140,14 +174,41 @@ vas:
         build_output: ../control-plane2.yaml
         post_stage_run:
           - name: 01 Update central CA bundle with leaf region CAs and wait for reconciliation
+            # Numeric prefix required: run_hook sorts hooks alphabetically by name.
             type: playbook
             source: "skmo/update-central-ca-bundle.yaml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
-          - name: 02 Configure barbican-keystone-listener transport URL for leaf region
+          - name: 02 Create Skupper Connector for central RabbitMQ
+            type: playbook
+            source: "skmo/skupper-connector.yaml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+          - name: 03 Create Skupper Listener for RabbitMQ in leaf namespace
+            type: playbook
+            source: "skmo/skupper-listener.yaml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+            extra_vars:
+              cifmw_skupper_listener_name: rabbitmq-keystone
+              cifmw_skupper_listener_cert_name: skupper-rabbitmq-regionone
+              cifmw_skupper_listener_cert_secret: cert-skupper-rabbitmq-regionone
+              cifmw_skupper_listener_routing_key: rabbit-keystone
+              cifmw_skupper_listener_host: rabbitmq-regionone
+              cifmw_skupper_listener_port: 5671
+              cifmw_skupper_listener_namespace: openstack2
+              cifmw_skupper_listener_ignore_wait_errors: false
+          - name: 04 Configure barbican-keystone-listener to use Skupper
             type: playbook
             source: "skmo/configure-leaf-listener.yaml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
-          - name: 03 Configure Keycloak realms and Keystone federation IdP
+          - name: 05 Patch leaf OSCP internal Keystone endpoint and expose to EDPM
+            # Rewrites the leaf OSCP internal Keystone override to the Skupper
+            # virtual service URL and creates a MetalLB LoadBalancer Service +
+            # DNSData CR so EDPM compute nodes can resolve the Skupper Keystone
+            # hostname.  Skipped automatically when cifmw_skupper_keystone_enabled
+            # is false (set in skupper-keystone-connector.yaml pre-stage hook).
+            type: playbook
+            source: "skmo/configure-leaf-keystone-internal.yaml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+          - name: 06 Configure Keycloak realms and Keystone federation IdP
             type: playbook
             source: "federation-post-deploy.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"

--- a/examples/va/multi-namespace-skmo/control-plane2/skmo-values.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane2/skmo-values.yaml
@@ -12,7 +12,11 @@ data:
   leafAdminUser: admin-two
   leafAdminProject: admin
   leafAdminPasswordKey: AdminPassword
-  # Central Keystone endpoints (use public endpoint for both)
+  # Central Keystone endpoints.
+  # keystoneInternalURL is rewritten at CI time by skupper-keystone-connector.yaml
+  # based on cifmw_skupper_keystone_enabled:
+  #   true  → https://keystone-regionone.openstack2.svc.cluster.local:5000 (Skupper tunnel)
+  #   false → same as keystonePublicURL (standard public routing)
   keystoneInternalURL: https://keystone-public-openstack.apps.ocp.openstack.lab
   keystonePublicURL: https://keystone-public-openstack.apps.ocp.openstack.lab
   # CA bundle secrets

--- a/examples/va/multi-namespace-skmo/skupper-keystone-internal.md
+++ b/examples/va/multi-namespace-skmo/skupper-keystone-internal.md
@@ -1,0 +1,413 @@
+# Routing SKMO Keystone traffic through Skupper
+
+## Overview
+
+In a standard Single Keystone Multiple OpenStacks (SKMO) deployment the
+workload regions authenticate service-to-service traffic using the **public**
+endpoint of the central region's Keystone service.  The current Red Hat
+documentation states explicitly:
+
+> *"Even though the internal service-to-service communication traffic of the
+> workload regions is encrypted it is more vulnerable to DDOS attacks because
+> it is not isolated on a separate internal network making it easier for
+> external attackers to intercept these messages."*
+
+By using Red Hat Service Interconnect (Skupper), the *internal* Keystone
+endpoint of the central region can be exposed as a private virtual service
+inside each workload namespace.  All service-to-service authentication traffic
+then travels over the Skupper mTLS application-network tunnel and never leaves
+the cluster network.
+
+### What changes
+
+| Concern | Current approach | With Skupper |
+|---|---|---|
+| Internal service → Keystone path | Public load-balancer route | Skupper mTLS tunnel (in-cluster) |
+| Keystone endpoint used by leaf services | `https://<external-route>/v3` | `https://keystone-regionone.<leaf-ns>.svc.cluster.local:5000` |
+| Traffic exposure | Public network | Internal cluster network only |
+| End-user / catalog endpoint | Public route | Public route (unchanged) |
+| EDPM compute node auth_url | Public route | MetalLB LoadBalancer IP on internalapi network |
+
+---
+
+## Prerequisites
+
+* Skupper is installed and Sites are linked between the central and workload
+  namespaces.  If you are also routing RabbitMQ traffic through Skupper (for
+  `barbican-keystone-listener`), the Site link is already in place.  See the
+  [Skupper installation and site-link guide](../skupper-install.md) if you are
+  starting from scratch.
+* The central region `OpenStackControlPlane` (`controlplane` in namespace
+  `openstack`) is deployed and `Ready`.
+* The workload region `OpenStackControlPlane` has **not yet been applied**, or
+  you are deploying it fresh.  Steps 1–3 below must complete before the
+  workload OSCP is first created, so that `keystoneInternalURL` is correct from
+  day one and no rolling restart is required.  If the workload OSCP already
+  exists, see the note at the end of Step 4.  Step 5 (EDPM DNS) can be
+  performed at any time after Step 3.
+* `cert-manager` is running in the cluster.  The `rootca-internal` `Issuer` in
+  the workload namespace is created by the OSCP operator during deployment;
+  cert-manager will reconcile the Listener certificate automatically once it
+  appears.
+* If the workload region includes EDPM compute nodes, MetalLB must be
+  configured with an address pool for the workload region's internalapi network
+  (e.g. `internalapi2`), and a `DNSMasq` LoadBalancer Service must be serving
+  DNS to those nodes.  Step 5 relies on both.
+
+---
+
+## Procedure
+
+### Step 1 — Create a Skupper Connector for Keystone in the central namespace
+
+The Connector tells Skupper to expose the Keystone internal service from the
+central namespace onto the application network.
+
+First obtain the TLS Secret name that Keystone uses for its internal endpoint:
+
+```bash
+KEYSTONE_TLS_SECRET=$(oc -n openstack get keystoneapi keystone \
+  -o jsonpath='{.spec.tls.api.internal.secretName}')
+echo "Keystone internal TLS secret: ${KEYSTONE_TLS_SECRET}"
+```
+
+Apply the Connector CR:
+
+```yaml
+apiVersion: skupper.io/v2alpha1
+kind: Connector
+metadata:
+  name: keystone-internal
+  namespace: openstack        # central namespace
+spec:
+  routingKey: keystone-internal
+  host: keystone-internal.openstack.svc.cluster.local
+  port: 5000
+  type: tcp
+  tlsCredentials: <keystone-tls-secret>   # value from the command above
+  # verifyHostname is false because the Skupper router connects using the
+  # cluster-internal service name which may differ from the cert SANs.
+  verifyHostname: false
+```
+
+Wait for the Connector to report `Configured: True`:
+
+```bash
+oc -n openstack wait connector keystone-internal \
+  --for=jsonpath='{.status.conditions[?(@.type=="Configured")].status}'=True \
+  --timeout=5m
+```
+
+> **Note:** The Connector will not reach `Ready: True` until the matching
+> Listener is also created (step 3 below).  `Configured: True` is sufficient
+> to proceed.
+
+---
+
+### Step 2 — Create a TLS certificate for the Listener in the workload namespace
+
+The Skupper Listener presents its own TLS certificate to workload-region
+services.  Create a `cert-manager` Certificate issued by the workload
+namespace's `rootca-internal` Issuer so that workload services trust it.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: skupper-keystone-regionone
+  namespace: openstack2       # workload namespace
+spec:
+  secretName: cert-skupper-keystone-regionone
+  issuerRef:
+    name: rootca-internal
+    kind: Issuer
+  dnsNames:
+    - keystone-regionone
+    - keystone-regionone.openstack2.svc
+    - keystone-regionone.openstack2.svc.cluster.local
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+```
+
+Wait for cert-manager to issue the certificate:
+
+```bash
+oc -n openstack2 wait certificate skupper-keystone-regionone \
+  --for=condition=Ready --timeout=2m
+```
+
+> **Note:** If the workload OSCP has not yet been deployed, `rootca-internal`
+> will not exist yet and cert-manager cannot issue the certificate immediately.
+> Apply the `Certificate` CR anyway — cert-manager will reconcile it
+> automatically once the Issuer is created during OSCP deployment.  Continue
+> to Step 3 without waiting.
+
+---
+
+### Step 3 — Create a Skupper Listener in the workload namespace
+
+The Listener creates a virtual `Service` named `keystone-regionone` in the
+workload namespace backed by the Skupper tunnel to the central Keystone
+Connector.
+
+```yaml
+apiVersion: skupper.io/v2alpha1
+kind: Listener
+metadata:
+  name: keystone-internal
+  namespace: openstack2       # workload namespace
+spec:
+  routingKey: keystone-internal
+  host: keystone-regionone
+  port: 5000
+  type: tcp
+  tlsCredentials: cert-skupper-keystone-regionone
+```
+
+The Skupper controller creates the virtual `Service` immediately regardless of
+whether the TLS certificate has been issued yet.  The Listener will transition
+to `Configured: True` once the matching Connector is active and the TLS
+credentials are available.
+
+---
+
+### Step 4 — Set keystoneInternalURL before deploying the workload OSCP
+
+The recommended approach is to set `keystoneInternalURL` to the Skupper virtual
+Service endpoint in your kustomize values **before** applying the workload
+`OpenStackControlPlane`.  This ensures the OSCP is created with the correct
+endpoint from the first apply and no rolling restart is required.
+
+In your workload region kustomize overlay (e.g.
+`control-plane2/skmo-values.yaml` or equivalent), set:
+
+```yaml
+keystoneInternalURL: https://keystone-regionone.openstack2.svc.cluster.local:5000
+keystonePublicURL: https://keystone-public-openstack.apps.ocp.openstack.lab   # unchanged
+```
+
+The virtual Service `keystone-regionone.openstack2.svc.cluster.local` was
+created in Step 3 and will be reachable from within the workload namespace as
+soon as the Skupper mTLS link is established.
+
+Now apply the workload OSCP as normal:
+
+```bash
+oc apply -k examples/va/multi-namespace-skmo/control-plane2/
+```
+
+Wait for the workload control plane to reach `Ready`:
+
+```bash
+oc -n openstack2 wait osctlplane controlplane \
+  --for condition=Ready --timeout=60m
+```
+
+> **If the workload OSCP already exists** (i.e. it was previously deployed
+> pointing at the public Keystone URL), you can patch it after completing
+> Steps 1–3:
+>
+> ```bash
+> INTERNAL_URL="https://keystone-regionone.openstack2.svc.cluster.local:5000"
+>
+> oc -n openstack2 patch osctlplane controlplane --type=merge -p "{
+>   \"spec\": {
+>     \"keystone\": {
+>       \"template\": {
+>         \"override\": {
+>           \"service\": {
+>             \"internal\": {
+>               \"endpointURL\": \"${INTERNAL_URL}\"
+>             }
+>           }
+>         }
+>       }
+>     }
+>   }
+> }"
+> ```
+>
+> The OSCP will perform a rolling restart of the affected services; allow up to
+> 30 minutes for it to return to `Ready`.
+
+---
+
+### Step 5 — Expose the Skupper Keystone endpoint to EDPM compute nodes
+
+> **Skip this step if the workload region has no EDPM compute nodes.**
+
+The Skupper Listener creates `keystone-regionone` as a **ClusterIP** Service.
+ClusterIP addresses are only routable from within the OCP cluster; EDPM
+compute nodes running outside the cluster cannot reach them.  Yet `nova-compute`
+on those nodes is configured with an `auth_url` of
+`https://keystone-regionone.<leaf-ns>.svc.cluster.local:5000`, which it must be
+able to resolve and connect to on startup.
+
+Two resources are required:
+
+1. A **LoadBalancer Service** that selects the same Skupper router pod and
+   obtains a MetalLB IP on the workload region's internalapi network, making
+   port 5000 reachable from EDPM nodes.
+2. A **DNSData CR** that registers both the short (`.svc`) and
+   fully-qualified (`.svc.cluster.local`) names in the dnsmasq instance
+   serving EDPM nodes, resolving to that MetalLB IP.
+
+Create the LoadBalancer Service:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keystone-regionone-lb
+  namespace: openstack2       # workload namespace
+  annotations:
+    # Let MetalLB auto-assign an IP from the workload internalapi pool.
+    metallb.universe.tf/address-pool: internalapi2
+spec:
+  type: LoadBalancer
+  selector:
+    application: skupper-router
+    skupper.io/component: router
+  ports:
+    - name: keystone-internal
+      port: 5000
+      protocol: TCP
+      targetPort: 1024        # Skupper router application port
+```
+
+Wait for MetalLB to assign an external IP:
+
+```bash
+oc -n openstack2 get svc keystone-regionone-lb \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+Once the IP is shown (e.g. `172.17.10.87`), create the `DNSData` CR:
+
+```yaml
+apiVersion: network.openstack.org/v1beta1
+kind: DNSData
+metadata:
+  name: keystone-skupper
+  namespace: openstack2       # workload namespace
+spec:
+  dnsDataLabelSelectorValue: dnsdata
+  hosts:
+    - hostnames:
+        - keystone-regionone.openstack2.svc
+        - keystone-regionone.openstack2.svc.cluster.local
+      ip: <metallb-ip>        # IP from the command above
+```
+
+The `dnsDataLabelSelectorValue: dnsdata` label causes the `DNSMasq` operator
+to pick up this CR automatically and inject the host entries into the running
+dnsmasq pods without a restart.
+
+> **Background — why the Skupper Service alone is not enough:**
+> Skupper manages `keystone-regionone` with the annotation
+> `internal.skupper.io/controlled: "true"`, and its controller enforces the
+> ClusterIP type.  Patching that Service directly to LoadBalancer would be
+> reverted on the next Skupper reconcile.  The separate `keystone-regionone-lb`
+> Service is intentionally unmanaged by Skupper and survives reconciliation.
+
+---
+
+## Verification
+
+After the control plane has reconciled, confirm that the Keystone virtual
+service is reachable from within the workload namespace:
+
+```bash
+# Start a debug pod in the workload namespace
+oc -n openstack2 run skupper-keystone-test --rm -it \
+  --image=registry.access.redhat.com/ubi9/ubi-minimal \
+  --restart=Never -- \
+  curl -ks https://keystone-regionone.openstack2.svc.cluster.local:5000/v3 \
+  | python3 -m json.tool
+```
+
+You should see the Keystone v3 API response from the central region.
+
+Confirm that the OSCP is using the virtual endpoint:
+
+```bash
+oc -n openstack2 get osctlplane controlplane \
+  -o jsonpath='{.spec.keystone.template.override.service.internal.endpointURL}'
+```
+
+Optionally, confirm that Skupper reports both sides `Ready`:
+
+```bash
+oc -n openstack  get connector keystone-internal -o wide
+oc -n openstack2 get listener  keystone-internal -o wide
+```
+
+If Step 5 was performed, verify DNS resolution and connectivity from an EDPM
+compute node:
+
+```bash
+# Confirm the LoadBalancer IP was assigned
+oc -n openstack2 get svc keystone-regionone-lb
+
+# Confirm the DNSData CR is reconciled
+oc -n openstack2 get dnsdata keystone-skupper
+
+# From an EDPM compute node, confirm name resolution
+ssh <edpm-node> getent hosts keystone-regionone.openstack2.svc.cluster.local
+
+# Confirm nova-compute is running and registered
+oc -n openstack2 exec openstackclient -- openstack compute service list \
+  --service nova-compute
+```
+
+---
+
+## Comparison with the current documented approach
+
+The existing RHOSO 18 documentation
+([Chapter 10, section 10.5](https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/18.0/html/configuring_security_services/assembly_single-keystone-multiple-openstacks-deployments#proc_create-public-private-endpoints-workload-region_assembly_single-keystone-multiple-openstacks-deployments))
+instructs operators to set *both* the public and internal endpoint overrides to
+the central region's **public** Keystone URL:
+
+```yaml
+# Current documented approach (both point to the public route)
+override:
+  service:
+    internal:
+      endpointURL: <central-public-url>   # ← public URL for internal traffic
+    public:
+      endpointURL: <central-public-url>
+```
+
+With the Skupper approach only the internal override changes; the public
+override and all Keystone catalog entries are left untouched:
+
+```yaml
+# Skupper approach
+override:
+  service:
+    internal:
+      endpointURL: https://keystone-regionone.openstack2.svc.cluster.local:5000
+    public:
+      endpointURL: <central-public-url>   # unchanged
+```
+
+The `openstack endpoint create` catalog entries created during initial SKMO
+setup do not need to change — they continue to point to the central public URL
+for end-user consumption.
+
+---
+
+## Security considerations
+
+* All traffic between the workload region services and the central Keystone
+  service travels over Skupper's mTLS tunnel.  No authentication tokens or
+  service passwords cross the public network during routine operation.
+* The Skupper Listener certificate is issued by the workload namespace's own
+  `rootca-internal` CA, which is already trusted by all services in that
+  namespace.  No additional CA distribution is required.
+* The public Keystone endpoint (used by end users and the Keystone service
+  catalog) continues to be secured by the central region's external TLS
+  certificate as before.

--- a/examples/va/skupper-install.md
+++ b/examples/va/skupper-install.md
@@ -1,0 +1,202 @@
+# Skupper installation and site-link guide
+
+## Overview
+
+[Red Hat Service Interconnect](https://www.redhat.com/en/technologies/cloud-computing/service-interconnect)
+(upstream: [Skupper](https://skupper.io/)) provides a layer-7 application
+network that connects services running in different Kubernetes namespaces or
+clusters over a mutual-TLS tunnel.  In the SKMO scenario it is used to:
+
+* Expose the **central RabbitMQ** service to the leaf (`openstack2`) namespace
+  so that `barbican-keystone-listener` can reach it without traversing the
+  public network.
+* Expose the **central Keystone internal endpoint** to the leaf namespace so
+  that service-to-service authentication traffic stays on the cluster network.
+
+This guide covers the two steps that must be completed before any
+Skupper Connector or Listener can be created:
+
+1. Install the Skupper operator (cluster-scoped, runs in the `skupper` namespace).
+2. Create Skupper Sites in the central (`openstack`) and leaf (`openstack2`)
+   namespaces and establish the site link between them.
+
+---
+
+## Automated deployment
+
+In the CI pipeline these steps are handled by two hook playbooks that run as
+`pre_stage_run` hooks in Stage 5 of
+`automation/vars/multi-namespace-skmo.yaml`:
+
+| Step | Playbook |
+|------|----------|
+| Install Skupper operator | `skmo/skupper-install.yaml` |
+| Create and link Sites | `skmo/skupper-sites.yaml` |
+
+The playbooks are idempotent: they check whether the Skupper CRD / Sites /
+Links already exist and skip creation if they do.
+
+Relevant variables (all have defaults; set in your automation vars or as
+`extra_vars` to override):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `cifmw_skupper_install_source` | `upstream` | `upstream` fetches from skupper.io; `downstream` applies a locally-downloaded Red Hat Service Interconnect YAML |
+| `cifmw_skupper_upstream_install_url` | `https://skupper.io/v2/install.yaml` | URL for the upstream install YAML |
+| `cifmw_skupper_downstream_install_file` | _(empty)_ | Path to a locally-downloaded downstream install YAML; required when `source=downstream` |
+| `cifmw_skupper_central_namespace` | `openstack` | Central region namespace |
+| `cifmw_skupper_leaf_namespace` | `openstack2` | Leaf region namespace |
+| `cifmw_skupper_central_site_name` | `openstack` | Skupper Site name in the central namespace |
+| `cifmw_skupper_leaf_site_name` | `openstack2` | Skupper Site name in the leaf namespace |
+| `cifmw_skupper_link_access_type` | `route` | How the central Site exposes its link endpoint: `route` (OpenShift Route), `loadbalancer`, or `nodeport` |
+
+---
+
+## Manual procedure
+
+The steps below reproduce what the automation playbooks do.  Follow them if
+you need to set up Skupper outside of the CI pipeline.
+
+### Prerequisites
+
+* An OpenShift cluster with the `openstack` and `openstack2` namespaces already
+  created.
+* `oc` and `kubectl` configured to reach the cluster.
+* Cluster-admin privileges (the Skupper operator is cluster-scoped).
+
+### Step 1 — Install the Skupper operator
+
+**Upstream (community) install:**
+
+```bash
+kubectl apply -f https://skupper.io/v2/install.yaml
+```
+
+**Downstream (Red Hat Service Interconnect) install:**
+
+Download the install YAML from the Red Hat registry or customer portal, then:
+
+```bash
+kubectl apply -f /path/to/rhsi-install.yaml
+```
+
+Wait for the controller to be ready:
+
+```bash
+kubectl -n skupper rollout status deployment --timeout=5m
+```
+
+Verify:
+
+```bash
+kubectl -n skupper get deploy
+# NAME                         READY   UP-TO-DATE   AVAILABLE
+# skupper-controller           1/1     1            1         (upstream)
+# skupper-controller-manager   1/1     1            1         (downstream)
+```
+
+### Step 2 — Create Sites
+
+Create a Site in the central namespace with link access enabled so it can
+issue tokens, and a Site in the leaf namespace that will connect to it:
+
+```bash
+# Central site (link access enabled via OpenShift Route)
+kubectl apply -f - <<EOF
+apiVersion: skupper.io/v2alpha1
+kind: Site
+metadata:
+  name: openstack
+  namespace: openstack
+spec:
+  linkAccess: route
+EOF
+
+# Leaf site
+kubectl apply -f - <<EOF
+apiVersion: skupper.io/v2alpha1
+kind: Site
+metadata:
+  name: openstack2
+  namespace: openstack2
+spec:
+  linkAccess: none
+EOF
+```
+
+Wait for both Sites to be Ready:
+
+```bash
+kubectl -n openstack  wait site/openstack  --for='condition=Ready' --timeout=5m
+kubectl -n openstack2 wait site/openstack2 --for='condition=Ready' --timeout=5m
+```
+
+### Step 3 — Link the Sites
+
+Create an `AccessGrant` in the central namespace (the grant holds a one-time
+token that the leaf will redeem):
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: skupper.io/v2alpha1
+kind: AccessGrant
+metadata:
+  name: link-to-openstack2
+  namespace: openstack
+spec:
+  redemptionsAllowed: 1
+  expirationWindow: 15m
+EOF
+```
+
+Wait for the grant to be ready and extract the credentials:
+
+```bash
+kubectl -n openstack wait accessgrant/link-to-openstack2 \
+  --for='condition=Ready' --timeout=5m
+
+URL=$(kubectl -n openstack get accessgrant/link-to-openstack2 \
+  -o jsonpath='{.status.url}')
+CA=$(kubectl -n openstack get accessgrant/link-to-openstack2 \
+  -o jsonpath='{.status.ca}')
+CODE=$(kubectl -n openstack get accessgrant/link-to-openstack2 \
+  -o jsonpath='{.status.code}')
+```
+
+Redeem the grant from the leaf namespace by creating an `AccessToken`:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: skupper.io/v2alpha1
+kind: AccessToken
+metadata:
+  name: link-to-openstack
+  namespace: openstack2
+spec:
+  url: "$URL"
+  ca: "$CA"
+  code: "$CODE"
+EOF
+```
+
+Wait for the Link to be established:
+
+```bash
+kubectl -n openstack2 wait link --all --for='condition=Ready' --timeout=5m
+```
+
+### Verification
+
+```bash
+# Both Sites should show Ready=True
+kubectl get site -n openstack
+kubectl get site -n openstack2
+
+# A Link should appear in the leaf namespace with Ready=True
+kubectl get link -n openstack2
+```
+
+Once the Link is Ready you can proceed to create Skupper Connectors and
+Listeners for individual services.  See:
+
+* [Routing SKMO Keystone traffic through Skupper](multi-namespace-skmo/skupper-keystone-internal.md)


### PR DESCRIPTION
[skmo]  Add Skupper for cross-region RabbitMQ and Keystone internal routing

Add automation variables and kustomize configuration to establish Skupper
virtual services for RabbitMQ and Keystone internal endpoints, enabling
cross-region connectivity in the multi-namespace SKMO scenario.

The RabbitMQ Skupper connector routes barbican-keystone-listener traffic
from the leaf (openstack2) namespace to the central (openstack) RabbitMQ
over an mTLS tunnel, avoiding exposure on the public network.

The Keystone Skupper connector routes internal service-to-service
authentication traffic from leaf region services to the central Keystone
endpoint, replacing the previous approach of using the public Keystone URL
for internal traffic.

To make the Skupper Keystone virtual service reachable from EDPM compute
nodes (which run outside the OCP cluster and cannot reach ClusterIP
services), a MetalLB LoadBalancer Service and a DNSData CR are created
alongside the Skupper Listener. This ensures nova-compute can resolve
and connect to the Keystone auth_url on startup.

Also adds skupper-keystone-internal.md documenting the full procedure,
including the EDPM DNS workaround and the rationale for each step.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3836