### PR TITLE
[uni04delta-ipv6] set mac binding age threshold to 0

### DIFF
--- a/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
@@ -111,6 +111,7 @@ data:
       [ovn]
       ovn_emit_need_to_frag = false
       ovs_create_tap = true
+      mac_binding_age_threshold = 0
       [ml2]
       type_drivers = geneve,vlan,flat,local
       tenant_network_types = vlan,flat


### PR DESCRIPTION
Due to a regression in OVN, we're observing in this job that the snat ping is failing, this is related to the mac bindings, setting this to 0 as a workarround until issue is fixed either on neutron or OVN.

Related: [OSPCIX-1304](https://redhat.atlassian.net/browse/OSPCIX-1304)