### PR TITLE
[SKMO] Enable Cinder Backup with Swift backend

### DIFF
--- a/examples/va/multi-namespace-skmo/control-plane/service-values.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane/service-values.yaml
@@ -13,6 +13,18 @@ data:
       customServiceConfig: |
         [keystone_notifications]
         pool_name = barbican-listener-regionOne
+  cinderBackup:
+    customServiceConfig: |
+      [DEFAULT]
+      backup_driver = cinder.backup.drivers.swift.SwiftBackupDriver
+      backup_swift_auth = single_user
+      backup_swift_user = service:cinder
+      backup_swift_key = {{ .ServicePassword }}
+      backup_swift_tenant = service
+      backup_swift_auth_version = 3
+      backup_swift_project_domain = Default
+      backup_swift_user_domain = Default
+    replicas: 1
   cinderVolumes:
     lvm-iscsi:
       replicas: 1
@@ -28,3 +40,5 @@ data:
         target_helper = lioadm
         volume_backend_name = lvm_iscsi
         target_ip_address = 172.18.0.10
+  swift:
+    enabled: true

--- a/examples/va/multi-namespace-skmo/control-plane2/service-values.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane2/service-values.yaml
@@ -34,6 +34,18 @@ data:
       swift_store_user = service:glance
       swift_store_key = {{ .ServicePassword }}
       swift_store_region = regionTwo
+  cinderBackup:
+    customServiceConfig: |
+      [DEFAULT]
+      backup_driver = cinder.backup.drivers.swift.SwiftBackupDriver
+      backup_swift_auth = single_user
+      backup_swift_user = service:cinder
+      backup_swift_key = {{ .ServicePassword }}
+      backup_swift_tenant = service
+      backup_swift_auth_version = 3
+      backup_swift_project_domain = Default
+      backup_swift_user_domain = Default
+    replicas: 1
   cinderVolumes:
     lvm-iscsi:
       replicas: 1


### PR DESCRIPTION
Add Cinder Backup service configuration for va-multi-namespace-skmo Swift is deployed in the central region (regionOne) and shared across both regions via Keystone service catalog. Both regions' cinder-backup services use single_user authentication to access Swift

Changes:
- control-plane: Enable Swift service and add cinderBackup config
- control-plane2: Add cinderBackup configuration for leaf region