### PR TITLE
skmo: use post-deploy federation controlplane hook

### DIFF
--- a/automation/vars/multi-namespace-skmo.yaml
+++ b/automation/vars/multi-namespace-skmo.yaml
@@ -100,11 +100,11 @@ vas:
             src_file: ../../multi-namespace/control-plane/networking/nncp/values.yaml
         build_output: ../control-plane.yaml
         post_stage_run:
-          # Run after the OSCP is deployed so hook_controlplane_config can
-          # directly patch the existing OpenStackControlPlane CR.
+          # Run after the OSCP is deployed to update the CA bundle secret and
+          # patch the existing OpenStackControlPlane CR with caBundleSecretName.
           - name: Configure Keystone control plane for federation
             type: playbook
-            source: "federation-controlplane-config.yml"
+            source: "federation-controlplane-config-postdeploy.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
 
       - pre_stage_run:    # stage 6


### PR DESCRIPTION
Switch the Stage 5 post_stage_run from federation-controlplane-config.yml to federation-controlplane-config-postdeploy.yml.

The post-deploy hook is designed for pipelines where the OpenStackControlPlane CR already exists.  It reads the live OSCP to determine the CA bundle secret name, preserves any existing secret data, and merges in the Keycloak CA cert before patching caBundleSecretName when not already set.

The original federation-controlplane-config.yml (pre-deploy hook) is intended for the component pipeline where the OSCP does not yet exist at hook execution time.

Relates-to: [OSPCIX-1321](https://redhat.atlassian.net/browse/OSPCIX-1321)
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3847