### PR TITLE
[bgp] Add CRC single-node BGP component job example

### DIFF
--- a/examples/dt/bgp_crc/control-plane/kustomization.yaml
+++ b/examples/dt/bgp_crc/control-plane/kustomization.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/bgp/
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+resources:
+  - service-values.yaml
+
+replacements:
+  # configure neutron customServiceConfig
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.neutron.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.neutron.template.customServiceConfig
+        options:
+          create: true

--- a/examples/dt/bgp_crc/control-plane/networking/kustomization.yaml
+++ b/examples/dt/bgp_crc/control-plane/networking/kustomization.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bgp/networking
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+resources:
+  - metallb_bgppeers.yaml
+
+patches:
+  # Add BGPPeer to BGPAdvertisement
+  - target:
+      kind: BGPAdvertisement
+    patch: |-
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-spine

--- a/examples/dt/bgp_crc/control-plane/networking/metallb_bgppeers.yaml
+++ b/examples/dt/bgp_crc/control-plane/networking/metallb_bgppeers.yaml
@@ -1,0 +1,12 @@
+# Single BGPPeer from CRC to FRR router (spine) over link-test network.
+# CRC is the only OCP node (single-node deployment).
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-spine
+  namespace: metallb-system
+spec:
+  myASN: 64998
+  peerASN: 64999
+  peerAddress: 172.30.0.1

--- a/examples/dt/bgp_crc/control-plane/service-values.yaml
+++ b/examples/dt/bgp_crc/control-plane/service-values.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  preserveJobs: false
+  notificationsBus:
+    cluster: rabbitmq
+  tls:
+    caBundleSecretName: ""
+
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:swift
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+    default:
+      replicas: 1
+
+  swift:
+    enabled: true
+
+  neutron:
+    customServiceConfig: |
+      [DEFAULT]
+      vlan_transparent = true
+      debug = true
+      global_physnet_mtu = 1400
+      [ovn]
+      ovn_router_indirect_snat = true
+      ovs_create_tap = true
+      [ml2]
+      path_mtu = 1400
+      [ovs]
+      igmp_snooping_enable = true

--- a/examples/dt/bgp_crc/edpm/computes/kustomization.yaml
+++ b/examples/dt/bgp_crc/edpm/computes/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bgp/edpm/nodeset
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: compute-nodes

--- a/examples/dt/bgp_crc/edpm/computes/values.yaml
+++ b/examples/dt/bgp_crc/edpm/computes/values.yaml
@@ -1,0 +1,111 @@
+# yamllint disable rule:line-length
+# CRC BGP component job - compute nodeset values
+# 2 computes, each on a different leaf (different AS)
+# Single BGP link per compute to spine via ctlplane
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    authorized: CHANGEME
+    private: CHANGEME2
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_bgp_agent_expose_tenant_networks: true
+        edpm_frr_bgp_ipv4_src_network: ctlplane
+        edpm_frr_bgp_peers:
+          - 192.168.122.12
+        edpm_enable_chassis_gw: true
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: StorageMgmt
+        subnetName: subnet1
+    nodes:
+      edpm-compute-0:
+        hostName: edpm-compute-0
+        ansible:
+          ansibleHost: 192.168.122.100
+          ansibleVars:
+            edpm_frr_bgp_asn: 64512
+            edpm_ovn_bgp_agent_bgp_as: 64512
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: StorageMgmt
+            subnetName: subnet1
+      edpm-compute-1:
+        hostName: edpm-compute-1
+        ansible:
+          ansibleHost: 192.168.122.101
+          ansibleVars:
+            edpm_frr_bgp_asn: 64513
+            edpm_ovn_bgp_agent_bgp_as: 64513
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: StorageMgmt
+            subnetName: subnet1
+    services:
+      - bootstrap
+      - configure-network
+      - frr
+      - validate-network
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp_crc/edpm/deployment/kustomization.yaml
+++ b/examples/dt/bgp_crc/edpm/deployment/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bgp/edpm/deployment
+
+resources:
+  - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.nodeSets
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.nodeSets

--- a/examples/dt/bgp_crc/edpm/deployment/values.yaml
+++ b/examples/dt/bgp_crc/edpm/deployment/values.yaml
@@ -1,0 +1,12 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeSets:
+    - networker-nodes
+    - compute-nodes

--- a/examples/dt/bgp_crc/edpm/networker/kustomization.yaml
+++ b/examples/dt/bgp_crc/edpm/networker/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bgp/edpm/nodeset
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: networker-nodes

--- a/examples/dt/bgp_crc/edpm/networker/values.yaml
+++ b/examples/dt/bgp_crc/edpm/networker/values.yaml
@@ -1,0 +1,90 @@
+# yamllint disable rule:line-length
+# CRC BGP component job - networker nodeset values
+# 1 networker on its own leaf (AS 64514)
+# Single BGP link to spine via ctlplane
+# Acts as OVN gateway chassis (edpm_enable_chassis_gw: true)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    authorized: CHANGEME
+    private: CHANGEME2
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_bgp_agent_expose_tenant_networks: true
+        edpm_frr_bgp_ipv4_src_network: ctlplane
+        edpm_frr_bgp_peers:
+          - 192.168.122.12
+        edpm_enable_chassis_gw: true
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth1
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
+      - name: StorageMgmt
+        subnetName: subnet1
+    nodes:
+      edpm-networker-0:
+        hostName: edpm-networker-0
+        ansible:
+          ansibleHost: 192.168.122.102
+          ansibleVars:
+            edpm_frr_bgp_asn: 64514
+            edpm_ovn_bgp_agent_bgp_as: 64514
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.102
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            subnetName: subnet1
+          - name: Storage
+            subnetName: subnet1
+          - name: Tenant
+            subnetName: subnet1
+          - name: StorageMgmt
+            subnetName: subnet1
+    services:
+      - bootstrap
+      - configure-network
+      - frr
+      - validate-network
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - ovn-bgp-agent
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp_crc/metallb/kustomization.yaml
+++ b/examples/dt/bgp_crc/metallb/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../lib/metallb


### PR DESCRIPTION
New architecture example bgp_crc for CRC-based component testing with BGP spine-leaf topology:

- Single BGPPeer (CRC AS 64998 -> spine AS 64999) via link-test
- 2 computes (AS 64512, 64513) with frr + ovn-bgp-agent services
- 1 networker (AS 64514) as OVN gateway chassis
- Single BGP link per node (no HA)
- Simplified control plane (no designate/octavia)