### PR TITLE
Add ordering prefixes to BGP pre_stage_run hooks

### DIFF
--- a/automation/vars/bgp-l3-xl.yaml
+++ b/automation/vars/bgp-l3-xl.yaml
@@ -3,7 +3,7 @@ vas:
   bgp-l3-xl:
     stages:
       - pre_stage_run:
-          - name: Apply taint on worker-9
+          - name: 01 Apply taint on worker-9
             type: cr
             definition:
               spec:
@@ -17,7 +17,7 @@ vas:
             kind: Node
             resource_name: worker-9
             state: patched
-          - name: Disable rp_filters on OCP nodes
+          - name: 02 Disable rp_filters on OCP nodes
             type: cr
             definition:
               spec:

--- a/automation/vars/bgp_dt01.yaml
+++ b/automation/vars/bgp_dt01.yaml
@@ -3,7 +3,7 @@ vas:
   bgp_dt01:
     stages:
       - pre_stage_run:
-          - name: Apply taint on worker-3
+          - name: 01 Apply taint on worker-3
             type: cr
             definition:
               spec:
@@ -17,7 +17,7 @@ vas:
             kind: Node
             resource_name: worker-3
             state: patched
-          - name: Disable rp_filters on OCP nodes
+          - name: 02 Disable rp_filters on OCP nodes
             type: cr
             definition:
               spec:


### PR DESCRIPTION
When a stage's pre_stage_run or post_stage_run contains more than one hook, each hook name must include a numeric ordering prefix (e.g. "01", "02") to ensure they execute in a deterministic order.  Even though the hooks are a list, the ordering actually depends on the alphabetical sort of the hooks names, which is fragile and not guaranteed to match the intended sequence.

From ci-framework/roles/run_hook/tasks/main.yml around line 74:                                                                                                                                                                                                          
     
```             
  _hooks: >-                                                                                                                                                                                                                                                                                
    {{            
      (                                                                                                                                                                                                                                                                                     
        _single_hooks +                                                                                                                                                                                                                                                                     
        (hooks | default([], true)) +                                                                                                                                                                                                                                                       
        _list_hooks
      ) | sort(attribute='name')
    }}                                                                                                                                                                                                                                                                                      
```

The `| sort(attribute='name')` Jinja2 filter explicitly reorders all hooks alphabetically before the loop executes them.

Made-with: Cursor