### PR TITLE
Add numeric prefixes to multi-hook pre/post stage runs

### DIFF
--- a/automation/vars/bgp-l3-xl-adoption.yaml
+++ b/automation/vars/bgp-l3-xl-adoption.yaml
@@ -3,7 +3,7 @@ vas:
   bgp-l3-xl-adoption:
     stages:
       - pre_stage_run:
-          - name: Apply taint on worker-9
+          - name: 01 Apply taint on worker-9
             type: cr
             definition:
               spec:
@@ -17,7 +17,7 @@ vas:
             kind: Node
             resource_name: worker-9
             state: patched
-          - name: Disable rp_filters on OCP nodes
+          - name: 02 Disable rp_filters on OCP nodes
             type: cr
             definition:
               spec:

--- a/automation/vars/bgp_dt04_ipv6.yaml
+++ b/automation/vars/bgp_dt04_ipv6.yaml
@@ -3,7 +3,7 @@ vas:
   bgp_dt04_ipv6:
     stages:
       - pre_stage_run:
-          - name: Apply taint on worker-3
+          - name: 01 Apply taint on worker-3
             type: cr
             definition:
               spec:
@@ -17,7 +17,7 @@ vas:
             kind: Node
             resource_name: worker-3.ocp.openstack.lab
             state: patched
-          - name: Disable rp_filters on OCP nodes
+          - name: 02 Disable rp_filters on OCP nodes
             type: cr
             definition:
               spec:

--- a/automation/vars/dz-storage.yaml
+++ b/automation/vars/dz-storage.yaml
@@ -3,7 +3,7 @@ vas:
   dz-storage:
     stages:
       - pre_stage_run:
-          - name: Apply taint on worker-9
+          - name: 01 Apply taint on worker-9
             type: cr
             definition:
               spec:
@@ -17,7 +17,7 @@ vas:
             kind: Node
             resource_name: worker-9
             state: patched
-          - name: Disable rp_filters on OCP nodes
+          - name: 02 Disable rp_filters on OCP nodes
             type: cr
             definition:
               spec:
@@ -64,7 +64,7 @@ vas:
             namespace: openshift-cluster-node-tuning-operator
             state: present
 
-          - name: Deploy SNR/NHC
+          - name: 03 Deploy SNR/NHC
             type: playbook
             source: "../../playbooks/snr-nhc.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
@@ -223,17 +223,17 @@ vas:
             src_file: values.yaml
         build_output: edpm-deployment.yaml
         post_stage_run:
-          - name: "1 - Wait until computes are ready"
+          - name: "01 Wait until computes are ready"
             type: playbook
             source: "nova_wait_for_compute_service.yml"
             extra_vars:
               _number_of_computes: 6
               _cell_conductor: nova-cell0-conductor-0
-          - name: "2 - Setup Cinder volume types and Nova aggregates for dz-storage"
+          - name: "02 Setup Cinder volume types and Nova aggregates for dz-storage"
             type: playbook
             source: "../../hooks/playbooks/dz_storage_post_deploy_az.yaml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
-          - name: "3 - Create and import cirros image to all Glance stores"
+          - name: "03 Create and import cirros image to all Glance stores"
             type: playbook
             source: "../../hooks/playbooks/dz_storage_pre_test_images.yaml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"

--- a/automation/vars/multi-namespace-skmo.yaml
+++ b/automation/vars/multi-namespace-skmo.yaml
@@ -69,7 +69,7 @@ vas:
         build_output: network2.yaml
 
       - pre_stage_run:    # stage 5
-          - name: Apply cinder-lvm label on master-0
+          - name: 01 Apply cinder-lvm label on master-0
             type: cr
             definition:
               metadata:
@@ -78,7 +78,7 @@ vas:
             kind: Node
             resource_name: master-0
             state: patched
-          - name: Bootstrap Keycloak for Keystone federation
+          - name: 02 Bootstrap Keycloak for Keystone federation
             type: playbook
             source: "federation-pre-deploy.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
@@ -108,7 +108,7 @@ vas:
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
 
       - pre_stage_run:    # stage 6
-          - name: Update container images for openstack2 namespace
+          - name: 01 Update container images for openstack2 namespace
             # Run before deploying the leaf control plane so that:
             #  - Fresh deploys start with the correct images (no restart).
             #  - Re-runs wait for the OSCP to settle before continuing.
@@ -119,7 +119,7 @@ vas:
               cifmw_update_containers_namespace: openstack2
               cifmw_update_containers_metadata: controlplane
               cifmw_update_containers: "true"
-          - name: Prepare SKMO leaf prerequisites in regionZero
+          - name: 02 Prepare SKMO leaf prerequisites in regionZero
             type: playbook
             source: "skmo/prepare-leaf.yaml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
@@ -139,15 +139,15 @@ vas:
             src_file: ../../multi-namespace/control-plane2/networking/nncp/values.yaml
         build_output: ../control-plane2.yaml
         post_stage_run:
-          - name: Update central CA bundle with leaf region CAs and wait for reconciliation
+          - name: 01 Update central CA bundle with leaf region CAs and wait for reconciliation
             type: playbook
             source: "skmo/update-central-ca-bundle.yaml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
-          - name: Configure barbican-keystone-listener transport URL for leaf region
+          - name: 02 Configure barbican-keystone-listener transport URL for leaf region
             type: playbook
             source: "skmo/configure-leaf-listener.yaml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
-          - name: Configure Keycloak realms and Keystone federation IdP
+          - name: 03 Configure Keycloak realms and Keystone federation IdP
             type: playbook
             source: "federation-post-deploy.yml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"


### PR DESCRIPTION
CIFMW's run_hook module sorts hooks alphabetically by name before executing them. Without numeric prefixes, this alphabetical sorting can silently reorder hooks in stages that have two or more entries, potentially breaking deployment sequences.

Add zero-padded numeric prefixes (01, 02, ...) to all multi-hook pre_stage_run and post_stage_run lists in:
- bgp-l3-xl-adoption.yaml
- bgp_dt04_ipv6.yaml
- dz-storage.yaml (pre_stage_run and post_stage_run)
- multi-namespace-skmo.yaml (control-plane and control-plane2 stages)

Co-author: Claude Opus 4.6