### PR TITLE
Add hci-ironic VA variant for Ironic-provisioned HCI deployments

### DIFF
--- a/automation/vars/hci-ironic.yaml
+++ b/automation/vars/hci-ironic.yaml
@@ -1,0 +1,103 @@
+---
+vas:
+  hci-ironic:
+    stages:
+      - name: nncp-configuration
+        path: examples/va/hci/control-plane/networking/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - name: network-configuration
+        path: examples/va/hci/control-plane/networking
+        wait_conditions:
+          - >-
+            oc -n metallb-system wait pod
+            -l app=metallb -l component=speaker
+            --for condition=Ready
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: network.yaml
+
+      - name: control-plane
+        path: examples/va/hci/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait osctlplane controlplane --for condition=Ready
+            --timeout=60m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: network-values
+            src_file: networking/nncp/values.yaml
+        build_output: ../control-plane.yaml
+
+      - name: edpm-pre-ceph-nodeset
+        path: examples/va/hci-ironic/edpm-pre-ceph/nodeset
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=30m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: nodeset-pre-ceph.yaml
+
+      - name: edpm-pre-ceph-deployment
+        path: examples/va/hci/edpm-pre-ceph/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=30m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: deployment-pre-ceph.yaml
+        post_stage_run:
+          - name: Deploy Ceph
+            type: playbook
+            source: "../../hooks/playbooks/ceph.yml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+
+      - name: edpm-post-ceph-nodeset
+        path: examples/va/hci
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=SetupReady
+            --timeout=10m
+        values:
+          - name: service-values
+            src_file: service-values.yaml
+          - name: edpm-nodeset-values
+            src_file: edpm-pre-ceph/nodeset/values.yaml
+          - name: edpm-nodeset-values-post-ceph
+            src_file: values.yaml
+        build_output: nodeset-post-ceph.yaml
+
+      - name: edpm-post-ceph-deployment
+        path: examples/va/hci/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait
+            osdpns openstack-edpm --for condition=Ready
+            --timeout=80m
+        values:
+          - name: edpm-deployment-values-post-ceph
+            src_file: values.yaml
+        build_output: deployment-post-ceph.yaml
+        post_stage_run:
+          - name: Deploy Loki
+            type: playbook
+            source: "../../hooks/playbooks/deploy-loki-for-ck.yaml"

--- a/examples/va/hci-ironic/README.md
+++ b/examples/va/hci-ironic/README.md
@@ -1,0 +1,67 @@
+# Hyperconverged OpenStack and Ceph with Ironic-Provisioned Compute Nodes
+
+This is a variant of the [HCI validated architecture](../hci/README.md)
+where all compute nodes are provisioned via Ironic rather than being
+pre-provisioned.  It is intended for validating `edpm-hardened-uefi` qcow2
+images through a complete deployment cycle using virtual baremetal
+(Sushy-emulated BareMetalHost resources).
+
+## Differences from the standard HCI VA
+
+| Aspect | Standard HCI | HCI-Ironic |
+|--------|-------------|------------|
+| Compute provisioning | Pre-provisioned (`preProvisioned: true`) | Ironic-provisioned (`preProvisioned: false`) |
+| NodeSet | Uses `lib/dataplane/nodeset` | Uses `lib/dataplane/nodeset` + `lib/dataplane/nodeset-baremetal` |
+| OS image | Host OS from reproducer VM image | Configurable `baremetalSetTemplate.osImage` (e.g. `edpm-hardened-uefi.qcow2`) |
+| BareMetalHost CRs | Not required | Required (created by `deploy_bmh` role with `cifmw_config_bmh: true`) |
+| Values | `examples/va/hci/edpm-pre-ceph/nodeset/values.yaml` | `examples/va/hci-ironic/edpm-pre-ceph/nodeset/values.yaml` |
+
+All other stages (NNCP, networking, control plane, pre-ceph deployment,
+Ceph bootstrap, post-ceph nodeset/deployment) are identical to the
+standard HCI VA and reuse the same paths under `examples/va/hci/`.
+
+## Stages
+
+All stages must be executed in the order listed below.
+
+1. [Install the OpenStack K8S operators and their dependencies](../../common/)
+2. [Configuring networking and deploy the OpenStack control plane](../hci/control-plane.md)
+3. [Configure and deploy the pre-Ceph data plane with Ironic provisioning](dataplane-pre-ceph.md)
+4. [Update the control plane and finish deploying the data plane after Ceph has been installed](../hci/dataplane-post-ceph.md)
+
+## Pre-Ceph Data Plane (Ironic variant)
+
+Stage 3 differs from the standard HCI flow.  The `edpm-pre-ceph/nodeset`
+values include:
+
+- `preProvisioned: false` -- tells the dataplane operator to provision
+  nodes via Ironic instead of assuming they are already running.
+- `baremetalSetTemplate` -- configures the Ironic provisioning parameters:
+  - `osImage`: the qcow2 image name from the `edpm-hardened-uefi` container
+    (e.g. `edpm-hardened-uefi.qcow2` for RHEL 9.4 or
+    `edpm-hardened-uefi-9.6.qcow2` for RHEL 9.6).
+  - `bmhLabelSelector`: selects which BareMetalHost CRs to claim.
+  - `bmhNamespace`: namespace where BareMetalHost CRs reside.
+
+BareMetalHost CRs must exist before the NodeSet is applied.  In CI this
+is handled by the `deploy_bmh` role (enabled via `cifmw_config_bmh: true`).
+
+### Build the pre-Ceph NodeSet CR
+
+```bash
+kustomize build examples/va/hci-ironic/edpm-pre-ceph/nodeset > nodeset-pre-ceph.yaml
+```
+
+Review and apply:
+
+```bash
+oc apply -f nodeset-pre-ceph.yaml
+oc -n openstack wait osdpns openstack-edpm --for condition=SetupReady --timeout=30m
+```
+
+The longer timeout (30m vs 10m for pre-provisioned) accounts for Ironic
+node provisioning time.
+
+After the NodeSet is ready, continue with the standard HCI pre-Ceph
+deployment and subsequent stages as documented in the
+[HCI dataplane-pre-ceph guide](../hci/dataplane-pre-ceph.md#deploy-the-pre-ceph-data-plane).

--- a/examples/va/hci-ironic/dataplane-pre-ceph.md
+++ b/examples/va/hci-ironic/dataplane-pre-ceph.md
@@ -1,0 +1,49 @@
+# Configure and deploy the pre-Ceph data plane (Ironic-provisioned)
+
+## Prerequisites
+
+- BareMetalHost CRs must exist in `openshift-machine-api` namespace
+  for each compute node.
+- The Bare Metal Operator webhook must be healthy
+  (`oc get endpoints baremetal-operator-webhook-service -n openshift-machine-api`
+  should show at least one address).
+
+## Procedure
+
+### 1. Customize the pre-Ceph nodeset values
+
+Edit
+[`edpm-pre-ceph/nodeset/values.yaml`](edpm-pre-ceph/nodeset/values.yaml)
+to match your environment.  Key fields:
+
+- `data.preProvisioned`: must be `false`.
+- `data.baremetalSetTemplate.osImage`: qcow2 image to provision
+  (e.g. `edpm-hardened-uefi.qcow2`).
+- `data.baremetalSetTemplate.bmhLabelSelector`: labels to select the
+  BareMetalHost CRs for this NodeSet.
+- `data.nodeset.nodes`: IP addresses and hostnames for each compute.
+- `data.nodeset.ansible.ansibleVars.edpm_bootstrap_command`: commands
+  to run on nodes after provisioning (repo setup, user creation, etc.).
+
+### 2. Build and apply the NodeSet
+
+```bash
+kustomize build examples/va/hci-ironic/edpm-pre-ceph/nodeset > nodeset-pre-ceph.yaml
+oc apply -f nodeset-pre-ceph.yaml
+```
+
+### 3. Wait for Ironic provisioning to complete
+
+```bash
+oc -n openstack wait osdpns openstack-edpm \
+  --for condition=SetupReady --timeout=30m
+```
+
+This takes longer than the pre-provisioned variant because Ironic must
+boot each node from the qcow2 image via virtual media.
+
+### 4. Continue with the standard HCI pre-Ceph deployment
+
+Once the NodeSet is `SetupReady`, follow the deployment steps from the
+standard HCI guide starting at
+[Deploy the pre-Ceph data plane](../hci/dataplane-pre-ceph.md).

--- a/examples/va/hci-ironic/edpm-pre-ceph/nodeset/kustomization.yaml
+++ b/examples/va/hci-ironic/edpm-pre-ceph/nodeset/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../va/hci-ironic/edpm-pre-ceph/nodeset
+
+resources:
+  - values.yaml

--- a/examples/va/hci-ironic/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/va/hci-ironic/edpm-pre-ceph/nodeset/values.yaml
@@ -1,0 +1,192 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+#
+# Ironic-provisioned variant: includes preProvisioned and
+# baremetalSetTemplate for Ironic provisioning via Metal3.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  preProvisioned: false
+  baremetalSetTemplate:
+    # CHANGEME - qcow2 image name from the edpm-hardened-uefi container
+    osImage: edpm-hardened-uefi.qcow2
+    # set to 'metadata' if redeploying Ceph to ensure clean disks for OSDs
+    automatedCleaningMode: metadata
+    cloudUserName: cloud-admin
+    bmhLabelSelector:
+      app: openstack
+    bmhNamespace: openshift-machine-api
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # CHANGEME -- see https://access.redhat.com/solutions/253273
+        # edpm_bootstrap_command: |
+        #       subscription-manager register --username <subscription_manager_username> \
+        #         --password <subscription_manager_password>
+        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME - should connect to same network as control plane enp6s0
+          edpm-compute-1:
+            nic2: 6b:fe:54:3f:8a:02  # CHANGEME - should connect to same network as control plane enp6s0
+          edpm-compute-2:
+            nic2: 6c:fe:54:3f:8a:02  # CHANGEME - should connect to same network as control plane enp6s0
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            mtu: {{ min_viable_mtu }}
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            mtu: {{ min_viable_mtu }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            members:
+            - type: interface
+              name: nic2
+              mtu: {{ min_viable_mtu }}
+              # force the MAC address of the bridge to this interface
+              primary: true
+          {% for network in nodeset_networks %}
+            - type: vlan
+              mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+              vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+              addresses:
+              - ip_netmask:
+                  {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+              routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth0
+        edpm_ceph_hci_pre_enabled_services:
+          - ceph_mon
+          - ceph_mgr
+          - ceph_osd
+          - ceph_rgw
+          - ceph_nfs
+          - ceph_rgw_frontend
+          - ceph_nfs_frontend
+        storage_mtu: 9000
+        storage_mgmt_mtu: 9000
+        storage_mgmt_vlan_id: 23
+        storage_mgmt_cidr: "24"
+        storage_mgmt_host_routes: []
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
+    nodes:
+      edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.122.100
+        hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: storagemgmt
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+      edpm-compute-1:
+        ansible:
+          ansibleHost: 192.168.122.101
+        hostName: edpm-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: storagemgmt
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+      edpm-compute-2:
+        ansible:
+          ansibleHost: 192.168.122.102
+        hostName: edpm-compute-2
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.102
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: storagemgmt
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+    # The nova-custom-ceph service is omitted since it is not yet
+    # defined. It will be defined and set after Ceph is deployed.
+    # See deployment servicesOverride for effective services list.
+    services:
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - ceph-hci-pre
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ceph-client
+      - ovn
+      - neutron-metadata
+      - libvirt
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/va/hci/README.md
+++ b/examples/va/hci/README.md
@@ -29,6 +29,13 @@ This is a collection of CR templates that represent a validated Red Hat OpenStac
 
 5. Between stages 3 and 4, _it is assumed that the user installs Ceph on the 3 OSP compute nodes._  OpenStack K8S CRDs do not provide a way to install Ceph via any sort of combination of CRs.
 
+## Variants
+
+The steps in [Configuring and deploying the pre-Ceph dataplane](dataplane-pre-ceph.md)
+assume that the compute nodes have been pre-provisioned.  If you wish to
+provision these nodes with Ironic using a custom `edpm-hardened-uefi` qcow2
+image, see the [HCI-Ironic variant](../hci-ironic/README.md).
+
 ## Stages
 
 All stages must be executed in the order listed below. Everything is required unless otherwise indicated.

--- a/lib/dataplane/nodeset-baremetal/kustomization.yaml
+++ b/lib/dataplane/nodeset-baremetal/kustomization.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Optional baremetal provisioning support for OpenStackDataPlaneNodeSet.
+#
+# Include this component alongside lib/dataplane/nodeset when the NodeSet
+# should use Ironic (preProvisioned: false) with a baremetalSetTemplate.
+#
+# The consuming values ConfigMap must provide:
+#   data.preProvisioned:      false
+#   data.baremetalSetTemplate: { osImage, bmhLabelSelector, ... }
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.preProvisioned
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - spec.preProvisioned
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+      fieldPath: data.baremetalSetTemplate
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - spec.baremetalSetTemplate
+        options:
+          create: true

--- a/va/hci-ironic/edpm-pre-ceph/nodeset/kustomization.yaml
+++ b/va/hci-ironic/edpm-pre-ceph/nodeset/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/dataplane/nodeset
+  - ../../../../lib/dataplane/nodeset-baremetal

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -11,6 +11,7 @@
       - rhoso-architecture-validate-dz-storage
       - rhoso-architecture-validate-hci
       - rhoso-architecture-validate-hci-adoption
+      - rhoso-architecture-validate-hci-ironic
       - rhoso-architecture-validate-multi-namespace
       - rhoso-architecture-validate-multi-namespace-skmo
       - rhoso-architecture-validate-nfv-ovs-dpdk-sriov-adoption

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -137,6 +137,21 @@
       cifmw_architecture_scenario: hci-adoption
 - job:
     files:
+    - examples/va/hci
+    - examples/va/hci-ironic/edpm-pre-ceph/nodeset
+    - examples/va/hci/control-plane
+    - examples/va/hci/control-plane/networking
+    - examples/va/hci/control-plane/networking/nncp
+    - examples/va/hci/deployment
+    - examples/va/hci/edpm-pre-ceph/deployment
+    - lib
+    - va/hci-ironic
+    name: rhoso-architecture-validate-hci-ironic
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: hci-ironic
+- job:
+    files:
     - automation/net-env/multi-namespace.yaml
     - examples/va/multi-namespace/control-plane
     - examples/va/multi-namespace/control-plane/networking


### PR DESCRIPTION
Add a new validated architecture variant (hci-ironic) that deploys
the VA-HCI scenario with all compute nodes provisioned via Ironic
using a configurable baremetalSetTemplate.osImage, enabling validation
of edpm-hardened-uefi qcow2 images through a complete deployment cycle.

New reusable component:
- lib/dataplane/nodeset-baremetal -- kustomize Component that maps
  preProvisioned and baremetalSetTemplate from the values ConfigMap
  into the OpenStackDataPlaneNodeSet spec.

New VA variant (va/hci-ironic):
- Identical to va/hci except the edpm-pre-ceph nodeset stage includes
  nodeset-baremetal alongside the standard nodeset component.
- All other stages (NNCP, networking, control-plane, deployments,
  post-ceph, Ceph bootstrap hook) reuse the existing va/hci paths.
- SetupReady timeout increased to 30m to account for Ironic
  provisioning time.

Documentation:
- Added README and dataplane-pre-ceph guide for the hci-ironic variant.
- Updated the standard va/hci README with a Variants section pointing
  to hci-ironic for Ironic-provisioned deployments.

The standard va/hci is untouched -- existing pre-provisioned
deployments are not affected.

Closes: [ANVIL-108](https://redhat.atlassian.net/browse/ANVIL-108)

Co-authored-by: Claude <noreply@anthropic.com>