### PR TITLE
Remove ovn-egress-iface workaround from br-ex members

### DIFF
--- a/examples/dt/uni01alpha/edpm/values.yaml
+++ b/examples/dt/uni01alpha/edpm/values.yaml
@@ -49,10 +49,6 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni01alpha/networker/nodeset/values.yaml
+++ b/examples/dt/uni01alpha/networker/nodeset/values.yaml
@@ -65,10 +65,6 @@ data:
                   mtu: {{ min_viable_mtu }}
                   # force the MAC address of the bridge to this interface
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni02beta/values.yaml
+++ b/examples/dt/uni02beta/values.yaml
@@ -49,10 +49,6 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni04delta-ipv6/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni04delta-ipv6/edpm-pre-ceph/nodeset/values.yaml
@@ -51,10 +51,6 @@ data:
               mtu: {{ min_viable_mtu }}
               # force the MAC address of the bridge to this interface
               primary: true
-              # this ovs_extra configuration fixes OSPRH-17551, but it will
-              # be not needed when FDP-1472 is resolved
-              ovs_extra:
-                - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
             - type: vlan
               mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni04delta-ipv6/values.yaml
+++ b/examples/dt/uni04delta-ipv6/values.yaml
@@ -59,10 +59,6 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni04delta/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni04delta/edpm-pre-ceph/nodeset/values.yaml
@@ -51,10 +51,6 @@ data:
               mtu: {{ min_viable_mtu }}
               # force the MAC address of the bridge to this interface
               primary: true
-              # this ovs_extra configuration fixes OSPRH-17551, but it will
-              # be not needed when FDP-1472 is resolved
-              ovs_extra:
-                - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
             - type: vlan
               mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni04delta/values.yaml
+++ b/examples/dt/uni04delta/values.yaml
@@ -59,10 +59,6 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni05epsilon/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni05epsilon/edpm-pre-ceph/nodeset/values.yaml
@@ -50,10 +50,6 @@ data:
                   mtu: {{ min_viable_mtu }}
                   # force the MAC address of the bridge to this interface
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni05epsilon/nodeset2/edpm-pre-ceph/values.yaml
+++ b/examples/dt/uni05epsilon/nodeset2/edpm-pre-ceph/values.yaml
@@ -50,10 +50,6 @@ data:
                   mtu: {{ min_viable_mtu }}
                   # force the MAC address of the bridge to this interface
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni06zeta/values.yaml
+++ b/examples/dt/uni06zeta/values.yaml
@@ -49,10 +49,6 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni07eta/edpm/values.yaml
+++ b/examples/dt/uni07eta/edpm/values.yaml
@@ -52,10 +52,6 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni07eta/networker/nodeset/values.yaml
+++ b/examples/dt/uni07eta/networker/nodeset/values.yaml
@@ -63,10 +63,6 @@ data:
                   mtu: {{ min_viable_mtu }}
                   # force the MAC address of the bridge to this interface
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}

--- a/examples/dt/uni09iota/values.yaml
+++ b/examples/dt/uni09iota/values.yaml
@@ -49,10 +49,6 @@ data:
                   name: nic2
                   mtu: {{ min_viable_mtu }}
                   primary: true
-                  # this ovs_extra configuration fixes OSPRH-17551, but it will
-                  # be not needed when FDP-1472 is resolved
-                  ovs_extra:
-                    - "set interface eth1 external-ids:ovn-egress-iface=true"
           {% for network in nodeset_networks %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}


### PR DESCRIPTION
The ovs_extra setting for ovn-egress-iface=true is no longer needed since the OVN fix is included in ovn24.03-24.03.6-7 and later.

Related-to: [OSPRH-29272](https://redhat.atlassian.net/browse/OSPRH-29272)