### PR TITLE
Add dt-sharded deployment topology with per-service galera, rabbitmq and memcached

### DIFF
--- a/automation/net-env/dt-sharded.yaml
+++ b/automation/net-env/dt-sharded.yaml
@@ -1,0 +1,783 @@
+---
+instances:
+  ceph-0:
+    hostname: ceph-0
+    name: ceph-0
+    networks:
+      ctlplane:
+        interface_name: eth1
+        ip_v4: 192.168.122.111
+        mac_addr: "52:54:00:3a:60:69"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      external:
+        interface_name: eth1
+        ip_v4: 10.46.22.135
+        mac_addr: "52:54:00:3a:60:69"
+        mtu: 1500
+        netmask_v4: 255.255.255.192
+        network_name: external
+        prefix_length_v4: 26
+        skip_nm: false
+      internalapi:
+        interface_name: eth1.120
+        ip_v4: 172.17.0.111
+        mac_addr: "52:54:00:34:8e:48"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 20
+      storage:
+        interface_name: eth1.121
+        ip_v4: 172.18.0.111
+        mac_addr: "52:54:00:10:9b:1d"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 21
+      storagemgmt:
+        interface_name: eth1.23
+        ip_v4: 172.20.0.111
+        mac_addr: "52:54:00:0d:e9:95"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storagemgmt
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 23
+  ceph-1:
+    hostname: ceph-1
+    name: ceph-1
+    networks:
+      ctlplane:
+        interface_name: eth1
+        ip_v4: 192.168.122.112
+        mac_addr: "52:54:00:f0:a5:5f"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      external:
+        interface_name: eth1
+        ip_v4: 10.46.22.136
+        mac_addr: "52:54:00:f0:a5:5f"
+        mtu: 1500
+        netmask_v4: 255.255.255.192
+        network_name: external
+        prefix_length_v4: 26
+        skip_nm: false
+      internalapi:
+        interface_name: eth1.120
+        ip_v4: 172.17.0.112
+        mac_addr: "52:54:00:77:8d:d0"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 20
+      storage:
+        interface_name: eth1.121
+        ip_v4: 172.18.0.112
+        mac_addr: "52:54:00:35:fc:f2"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 21
+      storagemgmt:
+        interface_name: eth1.23
+        ip_v4: 172.20.0.112
+        mac_addr: "52:54:00:01:27:76"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storagemgmt
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 23
+  ceph-2:
+    hostname: ceph-2
+    name: ceph-2
+    networks:
+      ctlplane:
+        interface_name: eth1
+        ip_v4: 192.168.122.113
+        mac_addr: "52:54:00:55:f7:08"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      external:
+        interface_name: eth1
+        ip_v4: 10.46.22.137
+        mac_addr: "52:54:00:55:f7:08"
+        mtu: 1500
+        netmask_v4: 255.255.255.192
+        network_name: external
+        prefix_length_v4: 26
+        skip_nm: false
+      internalapi:
+        interface_name: eth1.120
+        ip_v4: 172.17.0.113
+        mac_addr: "52:54:00:01:23:43"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 20
+      storage:
+        interface_name: eth1.121
+        ip_v4: 172.18.0.113
+        mac_addr: "52:54:00:3a:1f:2f"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 21
+      storagemgmt:
+        interface_name: eth1.23
+        ip_v4: 172.20.0.113
+        mac_addr: "52:54:00:23:96:dc"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storagemgmt
+        parent_interface: eth1
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 23
+  controller-0:
+    hostname: controller-0
+    name: controller-0
+    networks:
+      ctlplane:
+        interface_name: eth1
+        ip_v4: 192.168.122.9
+        mac_addr: "52:54:00:aa:40:6d"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+  ocp-0:
+    hostname: osasinfra-master-0
+    name: ocp-0
+    networks:
+      ctlplane:
+        interface_name: enp6s0
+        ip_v4: 192.168.122.10
+        mac_addr: "52:54:00:28:4f:f0"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      designate:
+        interface_name: enp6s0.24
+        ip_v4: 172.26.0.5
+        mac_addr: '52:54:00:18:b0:f6'
+        mtu: 1500
+        network_name: designate
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 24
+        prefix_length_v4: 24
+      designateext:
+        interface_name: enp6s0.34
+        ip_v4: 172.34.0.5
+        mac_addr: '52:54:00:18:c0:f6'
+        mtu: 1500
+        network_name: designateext
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 34
+        prefix_length_v4: 24
+      internalapi:
+        interface_name: enp6s0.120
+        ip_v4: 172.17.0.5
+        mac_addr: "52:54:00:56:0a:fb"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 20
+      octavia:
+        interface_name: enp6s0.124
+        ip_v4: 172.23.0.5
+        mac_addr: "52:54:00:14:51:28"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: octavia
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
+      storage:
+        interface_name: enp6s0.121
+        ip_v4: 172.18.0.5
+        mac_addr: "52:54:00:62:0d:a2"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 21
+      tenant:
+        interface_name: enp6s0.122
+        ip_v4: 172.19.0.5
+        mac_addr: "52:54:00:09:be:0e"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 22
+  ocp-1:
+    hostname: osasinfra-master-1
+    name: ocp-1
+    networks:
+      ctlplane:
+        interface_name: enp6s0
+        ip_v4: 192.168.122.11
+        mac_addr: "52:54:00:14:39:b5"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      designate:
+        interface_name: enp6s0.24
+        ip_v4: 172.26.0.6
+        mac_addr: '52:54:00:18:b0:f7'
+        mtu: 1500
+        network_name: designate
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 24
+        prefix_length_v4: 24
+      designateext:
+        interface_name: enp6s0.34
+        ip_v4: 172.34.0.6
+        mac_addr: '52:54:00:18:c0:f7'
+        mtu: 1500
+        network_name: designateext
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 34
+        prefix_length_v4: 24
+      internalapi:
+        interface_name: enp6s0.120
+        ip_v4: 172.17.0.6
+        mac_addr: "52:54:00:7a:aa:0e"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 20
+      octavia:
+        interface_name: enp6s0.124
+        ip_v4: 172.23.0.6
+        mac_addr: "52:54:00:26:c9:4c"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: octavia
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
+      storage:
+        interface_name: enp6s0.121
+        ip_v4: 172.18.0.6
+        mac_addr: "52:54:00:19:5b:d2"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 21
+      tenant:
+        interface_name: enp6s0.122
+        ip_v4: 172.19.0.6
+        mac_addr: "52:54:00:1b:3e:25"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 22
+  ocp-2:
+    hostname: osasinfra-master-2
+    name: ocp-2
+    networks:
+      ctlplane:
+        interface_name: enp6s0
+        ip_v4: 192.168.122.12
+        mac_addr: "52:54:00:de:3d:95"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      designate:
+        interface_name: enp6s0.24
+        ip_v4: 172.26.0.7
+        mac_addr: '52:54:00:18:b0:f8'
+        mtu: 1500
+        network_name: designate
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 24
+        prefix_length_v4: 24
+      designateext:
+        interface_name: enp6s0.34
+        ip_v4: 172.34.0.7
+        mac_addr: '52:54:00:18:c0:f8'
+        mtu: 1500
+        network_name: designateext
+        parent_interface: enp6s0
+        skip_nm: false
+        vlan_id: 34
+        prefix_length_v4: 24
+      internalapi:
+        interface_name: enp6s0.120
+        ip_v4: 172.17.0.7
+        mac_addr: "52:54:00:63:20:1c"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 20
+      octavia:
+        interface_name: enp6s0.124
+        ip_v4: 172.23.0.7
+        mac_addr: "52:54:00:1e:24:16"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: octavia
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 124
+      storage:
+        interface_name: enp6s0.121
+        ip_v4: 172.18.0.7
+        mac_addr: "52:54:00:23:e0:ff"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 21
+      tenant:
+        interface_name: enp6s0.122
+        ip_v4: 172.19.0.7
+        mac_addr: "52:54:00:29:56:10"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 22
+  compute-0:
+    hostname: compute-0
+    name: compute-0
+    networks:
+      ctlplane:
+        interface_name: eth1
+        ip_v4: 192.168.122.100
+        mac_addr: "52:54:00:17:05:43"
+        mtu: 1500
+        network_name: ctlplane
+        skip_nm: false
+      internalapi:
+        interface_name: eth1.20
+        ip_v4: 172.17.0.100
+        mac_addr: "52:54:00:05:da:ef"
+        mtu: 1500
+        network_name: internalapi
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 20
+      storage:
+        interface_name: eth1.21
+        ip_v4: 172.18.0.100
+        mac_addr: "52:54:00:59:8a:4c"
+        mtu: 1500
+        network_name: storage
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 21
+      tenant:
+        interface_name: eth1.22
+        ip_v4: 172.19.0.100
+        mac_addr: "52:54:00:0b:1c:d7"
+        mtu: 1500
+        network_name: tenant
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 22
+  compute-1:
+    hostname: compute-1
+    name: compute-1
+    networks:
+      ctlplane:
+        interface_name: eth1
+        ip_v4: 192.168.122.101
+        mac_addr: "52:54:00:17:05:44"
+        mtu: 1500
+        network_name: ctlplane
+        skip_nm: false
+      internalapi:
+        interface_name: eth1.20
+        ip_v4: 172.17.0.101
+        mac_addr: "52:54:00:05:db:00"
+        mtu: 1500
+        network_name: internalapi
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 20
+      storage:
+        interface_name: eth1.21
+        ip_v4: 172.18.0.101
+        mac_addr: "52:54:00:59:8a:4e"
+        mtu: 1500
+        network_name: storage
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 21
+      tenant:
+        interface_name: eth1.22
+        ip_v4: 172.19.0.101
+        mac_addr: "52:54:00:0b:1c:d5"
+        mtu: 1500
+        network_name: tenant
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 22
+  compute-2:
+    hostname: compute-2
+    name: compute-2
+    networks:
+      ctlplane:
+        interface_name: eth1
+        ip_v4: 192.168.122.102
+        mac_addr: "52:54:00:17:05:46"
+        mtu: 1500
+        network_name: ctlplane
+        skip_nm: false
+      internalapi:
+        interface_name: eth1.20
+        ip_v4: 172.17.0.102
+        mac_addr: "52:54:00:05:db:02"
+        mtu: 1500
+        network_name: internalapi
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 20
+      storage:
+        interface_name: eth1.21
+        ip_v4: 172.18.0.102
+        mac_addr: "52:54:00:59:8a:50"
+        mtu: 1500
+        network_name: storage
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 21
+      tenant:
+        interface_name: eth1.22
+        ip_v4: 172.19.0.102
+        mac_addr: "52:54:00:0b:1c:d7"
+        mtu: 1500
+        network_name: tenant
+        parent_interface: eth1
+        skip_nm: false
+        vlan_id: 22
+networks:
+  ctlplane:
+    dns_v4:
+      - 192.168.122.1
+    dns_v6: []
+    gw_v4: 192.168.122.1
+    mtu: 1500
+    network_name: ctlplane
+    network_v4: 192.168.122.0/24
+    search_domain: ctlplane.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 192.168.122.90
+            end_host: 90
+            length: 11
+            start: 192.168.122.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 192.168.122.70
+            end_host: 70
+            length: 41
+            start: 192.168.122.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 192.168.122.120
+            end_host: 120
+            length: 21
+            start: 192.168.122.100
+            start_host: 100
+        ipv6_ranges: []
+  designate:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: designate
+    network_v4: 172.26.0.0/24
+    search_domain: designate.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.26.0.90
+            end_host: 90
+            length: 11
+            start: 172.26.0.80
+            start_host: 80
+            ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.26.0.70
+            end_host: 70
+            length: 41
+            start: 172.26.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.26.0.200
+            end_host: 200
+            length: 101
+            start: 172.26.0.100
+        ipv6_ranges: []
+    vlan_id: 24
+  designateext:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: designateext
+    network_v4: 172.34.0.0/24
+    search_domain: designateext.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.34.0.90
+            end_host: 90
+            length: 11
+            start: 172.34.0.80
+            start_host: 80
+            ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.34.0.70
+            end_host: 70
+            length: 41
+            start: 172.34.0.30
+            start_host: 30
+            ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.34.0.200
+            end_host: 200
+            length: 101
+            start: 172.34.0.100
+        ipv6_ranges: []
+    vlan_id: 34
+  external:
+    dns_v4:
+      - 10.46.22.128
+    dns_v6: []
+    gw_v4: 10.46.22.189
+    mtu: 1500
+    network_name: external
+    network_v4: 10.46.22.128/26
+    search_domain: external.example.com
+    tools:
+      netconfig:
+        ipv4_ranges:
+          - end: 10.46.22.143
+            end_host: 15
+            length: 13
+            start: 10.46.22.131
+            start_host: 3
+        ipv6_ranges: []
+  internalapi:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: internalapi
+    network_v4: 172.17.0.0/24
+    search_domain: internalapi.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.17.0.90
+            end_host: 90
+            length: 11
+            start: 172.17.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.17.0.70
+            end_host: 70
+            length: 41
+            start: 172.17.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.17.0.250
+            end_host: 250
+            length: 151
+            start: 172.17.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 20
+  octavia:
+    dns_v4: []
+    dns_v6: []
+    network_name: octavia
+    network_v4: 172.23.0.0/24
+    search_domain: octavia.example.com
+    tools:
+      multus:
+        ipv4_ranges:
+          - end: 172.23.0.70
+            end_host: 70
+            length: 41
+            start: 172.23.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.23.0.250
+            end_host: 250
+            length: 151
+            start: 172.23.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 124
+  storage:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: storage
+    network_v4: 172.18.0.0/24
+    search_domain: storage.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.18.0.90
+            end_host: 90
+            length: 11
+            start: 172.18.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.18.0.70
+            end_host: 70
+            length: 41
+            start: 172.18.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.18.0.250
+            end_host: 250
+            length: 151
+            start: 172.18.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 21
+  storagemgmt:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: storagemgmt
+    network_v4: 172.20.0.0/24
+    search_domain: storagemgmt.example.com
+    tools:
+      netconfig:
+        ipv4_ranges:
+          - end: 172.20.0.250
+            end_host: 250
+            length: 151
+            start: 172.20.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 23
+  tenant:
+    dns_v4: []
+    dns_v6: []
+    mtu: 1500
+    network_name: tenant
+    network_v4: 172.19.0.0/24
+    search_domain: tenant.example.com
+    tools:
+      metallb:
+        ipv4_ranges:
+          - end: 172.19.0.90
+            end_host: 90
+            length: 11
+            start: 172.19.0.80
+            start_host: 80
+        ipv6_ranges: []
+      multus:
+        ipv4_ranges:
+          - end: 172.19.0.70
+            end_host: 70
+            length: 41
+            start: 172.19.0.30
+            start_host: 30
+        ipv6_ranges: []
+      netconfig:
+        ipv4_ranges:
+          - end: 172.19.0.250
+            end_host: 250
+            length: 151
+            start: 172.19.0.100
+            start_host: 100
+        ipv6_ranges: []
+    vlan_id: 22
+routers: {}

--- a/automation/vars/dt-sharded.yaml
+++ b/automation/vars/dt-sharded.yaml
@@ -1,0 +1,57 @@
+---
+vas:
+  dt-sharded:
+    stages:
+      - name: nncp-configuration
+        path: examples/dt/dt-sharded/control-plane/networking/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - name: network-configuration
+        path: examples/dt/dt-sharded/control-plane/networking
+        wait_conditions:
+          - >-
+            oc -n metallb-system wait pod
+            -l app=metallb -l component=speaker
+            --for condition=Ready
+            --timeout=5m
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: network.yaml
+
+      - name: control-plane
+        path: examples/dt/dt-sharded/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackcontrolplane
+            controlplane
+            --for condition=Ready
+            --timeout=60m
+        values:
+          - name: network-values
+            src_file: networking/nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+
+      - name: edpm-deployment
+        path: examples/dt/dt-sharded
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanedeployment
+            edpm-deployment
+            --for condition=Ready
+            --timeout=40m
+        values:
+          - name: edpm-nodeset-values
+            src_file: values.yaml
+        build_output: edpm.yaml

--- a/dt/dt-sharded/edpm/kustomization.yaml
+++ b/dt/dt-sharded/edpm/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../lib/dataplane

--- a/dt/dt-sharded/kustomization.yaml
+++ b/dt/dt-sharded/kustomization.yaml
@@ -1,0 +1,718 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+secretGenerator:
+  - name: octavia-ca-passphrase
+    literals:
+      - server-ca-passphrase=12345678
+    options:
+      disableNameSuffixHash: true
+
+transformers:
+  - |-
+      apiVersion: builtin
+      kind: NamespaceTransformer
+      metadata:
+        name: _ignored_
+        namespace: openstack
+      setRoleBindingSubjects: none
+      unsetOnly: true
+      fieldSpecs:
+        - path: metadata/name
+          kind: Namespace
+          create: true
+
+components:
+  - ../../lib/control-plane
+
+patches:
+  # Replace galera templates with per-service dedicated databases
+  - target:
+      kind: OpenStackControlPlane
+    patch: |-
+      - op: replace
+        path: /spec/galera/templates
+        value:
+          openstack-barbican:
+            replicas: 1
+            secret: osp-secret
+            storageRequest: 5Gi
+          openstack-cinder:
+            replicas: 1
+            secret: osp-secret
+            storageRequest: 5Gi
+          openstack-designate:
+            replicas: 1
+            secret: osp-secret
+            storageRequest: 5Gi
+          openstack-glance:
+            replicas: 1
+            secret: osp-secret
+            storageRequest: 5Gi
+          openstack-keystone:
+            replicas: 1
+            secret: osp-secret
+            storageRequest: 5Gi
+          openstack-neutron:
+            replicas: 1
+            secret: osp-secret
+            storageRequest: 5Gi
+          openstack-octavia:
+            replicas: 1
+            secret: osp-secret
+            storageRequest: 5Gi
+          openstack-nova:
+            replicas: 1
+            secret: osp-secret
+            storageRequest: 5Gi
+          openstack-nova-cell1:
+            replicas: 1
+            secret: osp-secret
+            storageRequest: 5Gi
+          openstack-placement:
+            replicas: 1
+            secret: osp-secret
+            storageRequest: 5Gi
+
+  # Replace memcached templates with per-service dedicated instances.
+  # Only services that support memcachedInstance are included:
+  # keystone, glance, cinder, neutron, horizon, manila, nova.
+  - target:
+      kind: OpenStackControlPlane
+    patch: |-
+      - op: replace
+        path: /spec/memcached/templates
+        value:
+          memcached-keystone:
+            replicas: 1
+          memcached-glance:
+            replicas: 1
+          memcached-cinder:
+            replicas: 1
+          memcached-neutron:
+            replicas: 1
+          memcached-horizon:
+            replicas: 1
+          memcached-nova:
+            replicas: 1
+
+  # Replace rabbitmq templates with per-service dedicated clusters.
+  # rabbitmq and rabbitmq-cell1 are kept for lib/control-plane compatibility.
+  - target:
+      kind: OpenStackControlPlane
+    patch: |-
+      - op: replace
+        path: /spec/rabbitmq/templates
+        value:
+          rabbitmq:
+            replicas: 1
+          rabbitmq-cell1:
+            replicas: 1
+          rabbitmq-barbican:
+            replicas: 1
+          rabbitmq-cinder:
+            replicas: 1
+          rabbitmq-designate:
+            replicas: 1
+          rabbitmq-glance:
+            replicas: 1
+          rabbitmq-keystone:
+            replicas: 1
+          rabbitmq-neutron:
+            replicas: 1
+          rabbitmq-octavia:
+            replicas: 1
+
+  # Point each service to its dedicated galera database
+  - target:
+      kind: OpenStackControlPlane
+    patch: |-
+      - op: replace
+        path: /spec/barbican/template/databaseInstance
+        value: openstack-barbican
+      - op: replace
+        path: /spec/cinder/template/databaseInstance
+        value: openstack-cinder
+      - op: add
+        path: /spec/designate/template/databaseInstance
+        value: openstack-designate
+      - op: replace
+        path: /spec/glance/template/databaseInstance
+        value: openstack-glance
+      - op: replace
+        path: /spec/keystone/template/databaseInstance
+        value: openstack-keystone
+      - op: replace
+        path: /spec/neutron/template/databaseInstance
+        value: openstack-neutron
+      - op: replace
+        path: /spec/octavia/template/databaseInstance
+        value: openstack-octavia
+      - op: replace
+        path: /spec/placement/template/databaseInstance
+        value: openstack-placement
+      - op: replace
+        path: /spec/nova/template/apiDatabaseInstance
+        value: openstack-nova
+      - op: replace
+        path: /spec/nova/template/cellTemplates/cell0/cellDatabaseInstance
+        value: openstack-nova
+      - op: replace
+        path: /spec/nova/template/cellTemplates/cell1/cellDatabaseInstance
+        value: openstack-nova-cell1
+
+  # Point each service to its dedicated memcached instance
+  - target:
+      kind: OpenStackControlPlane
+    patch: |-
+      - op: replace
+        path: /spec/keystone/template/memcachedInstance
+        value: memcached-keystone
+      - op: replace
+        path: /spec/glance/template/memcachedInstance
+        value: memcached-glance
+      - op: replace
+        path: /spec/cinder/template/memcachedInstance
+        value: memcached-cinder
+      - op: replace
+        path: /spec/neutron/template/memcachedInstance
+        value: memcached-neutron
+      - op: replace
+        path: /spec/horizon/template/memcachedInstance
+        value: memcached-horizon
+      - op: replace
+        path: /spec/nova/template/memcachedInstance
+        value: memcached-nova
+
+  # Point each service to its dedicated rabbitmq cluster
+  - target:
+      kind: OpenStackControlPlane
+    patch: |-
+      - op: add
+        path: /spec/barbican/template/rabbitMqClusterName
+        value: rabbitmq-barbican
+      - op: add
+        path: /spec/cinder/template/rabbitMqClusterName
+        value: rabbitmq-cinder
+      - op: add
+        path: /spec/designate/template/rabbitMqClusterName
+        value: rabbitmq-designate
+      - op: add
+        path: /spec/glance/template/rabbitMqClusterName
+        value: rabbitmq-glance
+      - op: add
+        path: /spec/keystone/template/rabbitMqClusterName
+        value: rabbitmq-keystone
+      - op: add
+        path: /spec/neutron/template/rabbitMqClusterName
+        value: rabbitmq-neutron
+      - op: add
+        path: /spec/octavia/template/rabbitMqClusterName
+        value: rabbitmq-octavia
+      - op: replace
+        path: /spec/nova/template/cellTemplates/cell0/messagingBus/cluster
+        value: rabbitmq
+      - op: replace
+        path: /spec/nova/template/cellTemplates/cell1/messagingBus/cluster
+        value: rabbitmq-cell1
+
+  # Add storagemgmt, designate, designateext networks to NetConfig
+  - target:
+      kind: NetConfig
+      name: netconfig
+    patch: |-
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: storagemgmt
+          subnets:
+            - _replaced_
+          mtu: 1500
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: designate
+          subnets:
+            - _replaced_
+          mtu: 1500
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: designateext
+          subnets:
+            - _replaced_
+          mtu: 1500
+
+  # Enable services that are disabled by default
+  - target:
+      kind: OpenStackControlPlane
+    patch: |-
+      - op: replace
+        path: /spec/designate/enabled
+        value: true
+      - op: replace
+        path: /spec/octavia/enabled
+        value: true
+
+  # Reduce replicas to 1 for test DT
+  - target:
+      kind: OpenStackControlPlane
+    patch: |-
+      - op: replace
+        path: /spec/barbican/template/barbicanAPI/replicas
+        value: 1
+      - op: replace
+        path: /spec/barbican/template/barbicanWorker/replicas
+        value: 1
+      - op: replace
+        path: /spec/cinder/template/cinderAPI/replicas
+        value: 1
+      - op: replace
+        path: /spec/designate/template/designateAPI/replicas
+        value: 1
+      - op: replace
+        path: /spec/designate/template/designateBackendbind9/replicas
+        value: 1
+      - op: replace
+        path: /spec/designate/template/designateMdns/replicas
+        value: 1
+      - op: replace
+        path: /spec/designate/template/designateProducer/replicas
+        value: 1
+      - op: replace
+        path: /spec/designate/template/designateWorker/replicas
+        value: 1
+      - op: replace
+        path: /spec/dns/template/replicas
+        value: 1
+      - op: replace
+        path: /spec/keystone/template/replicas
+        value: 1
+      - op: replace
+        path: /spec/neutron/template/replicas
+        value: 1
+      - op: replace
+        path: /spec/nova/template/apiServiceTemplate/replicas
+        value: 1
+      - op: replace
+        path: /spec/nova/template/metadataServiceTemplate/replicas
+        value: 1
+      - op: replace
+        path: /spec/nova/template/schedulerServiceTemplate/replicas
+        value: 1
+      - op: replace
+        path: /spec/placement/template/replicas
+        value: 1
+      - op: replace
+        path: /spec/ovn/template/ovnDBCluster/ovndbcluster-nb/replicas
+        value: 1
+      - op: replace
+        path: /spec/ovn/template/ovnDBCluster/ovndbcluster-sb/replicas
+        value: 1
+
+replacements:
+  # Glance
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.customServiceConfig
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.glanceAPIs.default.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.glance.glanceAPIs.default.type
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.glance.template.glanceAPIs.default.type
+        options:
+          create: true
+
+  # Cinder
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.cinderBackup.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackup.replicas
+        options:
+          create: true
+
+  # Base rabbitmq endpoint annotations (re-applied after templates replace)
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq.override.service.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-cell1.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-cell1.override.service.metadata.annotations
+        options:
+          create: true
+
+  # Per-service rabbitmq endpoint annotations
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-barbican.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-barbican.override.service.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-cinder.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-cinder.override.service.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-designate.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-designate.override.service.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-glance.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-glance.override.service.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-keystone.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-keystone.override.service.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-neutron.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-neutron.override.service.metadata.annotations
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.rabbitmq-octavia.endpoint_annotations
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq-octavia.override.service.metadata.annotations
+        options:
+          create: true
+  # Rabbitmq service types (base + per-service)
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.lbServiceType
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.rabbitmq.templates.rabbitmq.override.service.spec.type
+          - spec.rabbitmq.templates.rabbitmq-cell1.override.service.spec.type
+          - spec.rabbitmq.templates.rabbitmq-barbican.override.service.spec.type
+          - spec.rabbitmq.templates.rabbitmq-cinder.override.service.spec.type
+          - spec.rabbitmq.templates.rabbitmq-designate.override.service.spec.type
+          - spec.rabbitmq.templates.rabbitmq-glance.override.service.spec.type
+          - spec.rabbitmq.templates.rabbitmq-keystone.override.service.spec.type
+          - spec.rabbitmq.templates.rabbitmq-neutron.override.service.spec.type
+          - spec.rabbitmq.templates.rabbitmq-octavia.override.service.spec.type
+        options:
+          create: true
+
+  # Designate NAD config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: designate
+        fieldPaths:
+          - spec.config
+
+  # Designate bind9Services
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate.bind9Services
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.designate.template.designateBackendbind9.bind9Services
+        options:
+          create: true
+
+  # Designate Redis
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate-redis.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.redis.templates.designate-redis.replicas
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate-redis.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.redis.enabled
+        options:
+          create: true
+
+  # Octavia NAD config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: octavia
+        fieldPaths:
+          - spec.config
+
+  # Octavia container images
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.amphoraImageContainerImage
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.amphoraImageContainerImage
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.apacheContainerImage
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.apacheContainerImage
+        options:
+          create: true
+
+  # Octavia networkAttachments
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaAPI.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaAPI.networkAttachments
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaHousekeeping.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaHousekeeping.networkAttachments
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaHealthManager.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaHealthManager.networkAttachments
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaWorker.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaWorker.networkAttachments
+        options:
+          create: true
+
+  # OVN controller nicMappings (for octavia bridge)
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.ovn.ovnController.nicMappings
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ovn.template.ovnController.nicMappings
+        options:
+          create: true
+
+  # storagemgmt NetConfig
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].subnets
+
+  # designate NetConfig
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designate].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designate].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designate].subnets
+
+  # designateext NetConfig
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designateext].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designateext].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designateext].subnets

--- a/dt/dt-sharded/networking/kustomization.yaml
+++ b/dt/dt-sharded/networking/kustomization.yaml
@@ -1,0 +1,169 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+components:
+  - ../../../lib/networking/metallb
+  - ../../../lib/networking/netconfig
+  - ../../../lib/networking/nad
+
+resources:
+  - nad.yaml
+  - metallb-designateext.yaml
+
+patches:
+  # Add storagemgmt network to NetConfig
+  - target:
+      kind: NetConfig
+      name: netconfig
+    patch: |-
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: storagemgmt
+          subnets:
+            - _replaced_
+          mtu: 1500
+  # Add designateext network to NetConfig
+  - target:
+      kind: NetConfig
+      name: netconfig
+    patch: |-
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: designateext
+          subnets:
+            - _replaced_
+          mtu: 1500
+
+replacements:
+  # storagemgmt NetConfig
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storagemgmt.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=storagemgmt].subnets
+  # designateext MetalLB
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.lb_addresses
+    targets:
+      - select:
+          kind: IPAddressPool
+          name: designateext
+        fieldPaths:
+          - spec.addresses
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.iface
+    targets:
+      - select:
+          kind: L2Advertisement
+          name: designateext
+        fieldPaths:
+          - spec.interfaces.0
+
+  # designateext NetConfig
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designateext].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designateext].mtu
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=designateext].subnets
+
+  # designateext NAD config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: designateext
+        fieldPaths:
+          - spec.config
+
+  # designate NAD config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: designate
+        fieldPaths:
+          - spec.config
+
+  # octavia NAD config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: octavia
+        fieldPaths:
+          - spec.config

--- a/dt/dt-sharded/networking/metallb-designateext.yaml
+++ b/dt/dt-sharded/networking/metallb-designateext.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: designateext
+  labels:
+    osp/lb-addresses-type: standard
+spec:
+  addresses: []
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: designateext
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - designateext
+  interfaces:
+    - _replaced_

--- a/dt/dt-sharded/networking/nad.yaml
+++ b/dt/dt-sharded/networking/nad.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: designate
+  labels:
+    osp/net: designate
+    osp/net-attach-def-type: standard
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: designateext
+  labels:
+    osp/net: designateext
+    osp/net-attach-def-type: standard
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: octavia
+  labels:
+    osp/net: octavia
+    osp/net-attach-def-type: standard

--- a/examples/dt/dt-sharded/README.md
+++ b/examples/dt/dt-sharded/README.md
@@ -1,0 +1,131 @@
+# DT-Sharded: Per-Service Galera, RabbitMQ, and Memcached Isolation
+
+This is a collection of CR templates that represent a validated Red Hat OpenStack Services on OpenShift deployment that has the following characteristics:
+
+- 3 master+worker combo OpenShift nodes
+- Per-service dedicated Galera databases (replicas: 1)
+- Per-service dedicated RabbitMQ clusters (replicas: 1)
+- Per-service dedicated Memcached instances (replicas: 1)
+- OVN networking
+- Network isolation over a single NIC
+- 2 compute nodes
+- Glance with file backend (no Ceph)
+
+## Sharding Architecture
+
+This DT tests full infrastructure sharding where each OpenStack service gets its own dedicated database, message bus, and cache instance.
+
+### Galera Databases
+
+Each service gets a dedicated Galera cluster:
+
+openstack-barbican, openstack-cinder, openstack-designate, openstack-glance, openstack-keystone, openstack-neutron, openstack-octavia, openstack-nova, openstack-nova-cell1, openstack-placement
+
+### RabbitMQ Clusters
+
+Per-service dedicated RabbitMQ clusters:
+
+rabbitmq-barbican, rabbitmq-cinder, rabbitmq-designate, rabbitmq-glance, rabbitmq-keystone, rabbitmq-neutron, rabbitmq-octavia
+
+Nova cells use the standard `rabbitmq` (cell0/notifications) and `rabbitmq-cell1` (cell1).
+
+### Memcached Instances
+
+Per-service dedicated Memcached instances for services that support `memcachedInstance`:
+
+memcached-keystone, memcached-glance, memcached-cinder, memcached-neutron, memcached-horizon, memcached-nova
+
+Services without `memcachedInstance` support (barbican, designate, octavia, placement) or disabled services (manila) are not included.
+
+### Services Enabled
+
+barbican, cinder, designate, glance, horizon, keystone, neutron, nova, octavia
+
+## Assumptions
+
+- A storage class called `local-storage` should already exist.
+
+## Prerequisites
+
+[Install the OpenStack K8S operators and their dependencies](https://github.com/openstack-k8s-operators/architecture/blob/main/examples/common)
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the dt-sharded directory
+```
+cd architecture/examples/dt/dt-sharded
+```
+Edit the [control-plane/networking/nncp/values.yaml](control-plane/networking/nncp/values.yaml) and
+[control-plane/service-values.yaml](control-plane/service-values.yaml) files to suit
+your environment.
+```
+vi control-plane/networking/nncp/values.yaml
+vi control-plane/service-values.yaml
+```
+
+## Apply node network configuration
+
+Generate the node network configuration
+```
+kustomize build control-plane/networking/nncp > nncp.yaml
+```
+Apply the NNCP CRs
+```
+oc apply -f nncp.yaml
+```
+Wait for NNCPs to be available
+```
+oc wait nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=300s
+```
+
+## Apply networking configuration
+
+Generate the networking CRs.
+```
+kustomize build control-plane/networking > network.yaml
+```
+Apply the CRs
+```
+oc apply -f network.yaml
+```
+
+Wait for MetalLB speaker pods to be ready
+```
+oc -n metallb-system wait pod -l app=metallb -l component=speaker --for condition=Ready --timeout=300s
+```
+
+## Apply control-plane configuration
+
+Generate the control-plane CRs.
+```
+kustomize build control-plane > control-plane.yaml
+```
+Apply the CRs
+```
+oc apply -f control-plane.yaml
+```
+
+Wait for control plane to be available
+```
+oc wait osctlplane controlplane --for condition=Ready --timeout=60m
+```
+
+## Apply dataplane configuration
+
+Generate the dataplane CRs.
+```
+kustomize build > edpm.yaml
+```
+Apply the CRs
+```
+oc apply -f edpm.yaml
+```
+
+Wait for the dataplanedeployment to reach the "Ready" condition
+```
+oc -n openstack wait openstackdataplanedeployment edpm-deployment --for condition=Ready --timeout=40m
+```

--- a/examples/dt/dt-sharded/control-plane/kustomization.yaml
+++ b/examples/dt/dt-sharded/control-plane/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../lib/networking/metallb
+  - ../../../../lib/networking/netconfig
+  - ../../../../lib/networking/nad
+  - ../../../../dt/dt-sharded
+
+resources:
+  - networking/nncp/values.yaml
+  - service-values.yaml

--- a/examples/dt/dt-sharded/control-plane/networking/kustomization.yaml
+++ b/examples/dt/dt-sharded/control-plane/networking/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/dt-sharded/networking/
+
+resources:
+  - nncp/values.yaml

--- a/examples/dt/dt-sharded/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/dt/dt-sharded/control-plane/networking/nncp/kustomization.yaml
@@ -1,0 +1,237 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../../../lib/nncp
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-0
+    patch: |-
+      - op: add
+        path: /spec/nodeSelector/node-role.kubernetes.io~1master
+        value: ""
+      - op: remove
+        path: /spec/nodeSelector/node-role.kubernetes.io~1worker
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-1
+    patch: |-
+      - op: add
+        path: /spec/nodeSelector/node-role.kubernetes.io~1master
+        value: ""
+      - op: remove
+        path: /spec/nodeSelector/node-role.kubernetes.io~1worker
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: master-2
+    patch: |-
+      - op: add
+        path: /spec/nodeSelector/node-role.kubernetes.io~1master
+        value: ""
+      - op: remove
+        path: /spec/nodeSelector/node-role.kubernetes.io~1worker
+  # Add designate VLAN interface to each node
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: designate vlan interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          name: designate
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+  # Add designateext VLAN interface to each node
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: designateext vlan interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          name: designateext
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+
+replacements:
+  # designate VLAN config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].vlan.base-iface
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].vlan.id
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.mtu
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].mtu
+        options:
+          create: true
+  # Per-node designate IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.designate_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.designate_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.designate_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designate].ipv4.address.0.ip
+  # designateext VLAN config
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].vlan.base-iface
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].vlan.id
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designateext.mtu
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].mtu
+        options:
+          create: true
+  # Per-node designateext IPs (target post-replacement names, since lib/nncp
+  # renames node-X to the actual hostname before parent replacements run)
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_0.designateext_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-0
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_1.designateext_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-1
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_2.designateext_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: master-2
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=designateext].ipv4.address.0.ip

--- a/examples/dt/dt-sharded/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/dt-sharded/control-plane/networking/nncp/values.yaml
@@ -1,0 +1,324 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  node_0:
+    name: master-0
+    internalapi_ip: 172.17.0.5
+    tenant_ip: 172.19.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+    designate_ip: 172.26.0.5
+    designateext_ip: 172.34.0.5
+  node_1:
+    name: master-1
+    internalapi_ip: 172.17.0.6
+    tenant_ip: 172.19.0.6
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.6
+    designate_ip: 172.26.0.6
+    designateext_ip: 172.34.0.6
+  node_2:
+    name: master-2
+    internalapi_ip: 172.17.0.7
+    tenant_ip: 172.19.0.7
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.7
+    designate_ip: 172.26.0.7
+    designateext_ip: 172.34.0.7
+
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet1
+    prefix-length: 24
+    iface: enp6s0
+    mtu: 1500
+    lb_addresses:
+      - 192.168.122.80-192.168.122.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "macvlan",
+        "master": "ospbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.122.0/24",
+          "range_start": "192.168.122.30",
+          "range_end": "192.168.122.70"
+        }
+      }
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.99
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "macvlan",
+        "master": "internalapi",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 1500
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "macvlan",
+        "master": "storage",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+  tenant:
+    dnsDomain: tenant.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        name: subnet1
+        vlan: 22
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "macvlan",
+        "master": "tenant",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70"
+        }
+      }
+  external:
+    dnsDomain: external.example.com
+    subnets:
+      - allocationRanges:
+          - end: 10.0.0.250
+            start: 10.0.0.100
+        cidr: 10.0.0.0/24
+        gateway: 10.0.0.1
+        name: subnet1
+    mtu: 1500
+
+  storagemgmt:
+    dnsDomain: storagemgmt.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.20.0.250
+            start: 172.20.0.100
+        cidr: 172.20.0.0/24
+        name: subnet1
+        vlan: 23
+    mtu: 1500
+
+  designate:
+    dnsDomain: designate.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.26.0.250
+            start: 172.26.0.100
+        cidr: 172.26.0.0/24
+        name: subnet1
+        vlan: 24
+    mtu: 1500
+    prefix-length: 24
+    iface: designate
+    vlan: 24
+    base_iface: enp6s0
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "designate",
+        "type": "macvlan",
+        "master": "internalapi",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.200",
+          "range_end": "172.17.0.210"
+        }
+      }
+
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config:
+      - destination: 0.0.0.0/0
+        next-hop-address: 192.168.122.1
+        next-hop-interface: enp6s0
+
+  # Base rabbitmq endpoints (required by lib/control-plane/service-endpoints)
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  # Per-service rabbitmq endpoints
+  rabbitmq-barbican:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.87
+  rabbitmq-cinder:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.88
+  rabbitmq-designate:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.89
+  rabbitmq-glance:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.90
+  rabbitmq-keystone:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.91
+  rabbitmq-neutron:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.93
+  rabbitmq-octavia:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.94
+  designateext:
+    dnsDomain: designateext.example.com
+    mtu: 1500
+    prefix-length: 24
+    iface: designateext
+    vlan: 34
+    base_iface: enp6s0
+    subnets:
+      - allocationRanges:
+          - end: 172.34.0.250
+            start: 172.34.0.100
+        cidr: 172.34.0.0/24
+        name: subnet1
+    lb_addresses:
+      - 172.34.0.80-172.34.0.120
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "designateext",
+        "type": "macvlan",
+        "master": "designateext",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.34.0.0/24",
+          "range_start": "172.34.0.30",
+          "range_end": "172.34.0.70"
+        }
+      }
+
+  octavia:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "octavia",
+        "type": "bridge",
+        "bridge": "octbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.23.0.0/24",
+          "range_start": "172.23.0.30",
+          "range_end": "172.23.0.70",
+          "routes": [
+            {
+              "dst": "172.24.0.0/16",
+              "gw": "172.23.0.150"
+            }
+          ]
+        }
+      }
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr

--- a/examples/dt/dt-sharded/control-plane/service-values.yaml
+++ b/examples/dt/dt-sharded/control-plane/service-values.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  preserveJobs: false
+  notificationsBus:
+    cluster: rabbitmq
+  tls:
+    caBundleSecretName: ""
+
+  cinderBackup:
+    replicas: 0
+
+  designate:
+    bind9Services:
+      services:
+        - metadata:
+            annotations:
+              metallb.universe.tf/address-pool: designateext
+              metallb.universe.tf/allow-shared-ip: designateext
+              metallb.universe.tf/LoadBalancerIPs: 172.34.0.80
+          spec:
+            type: LoadBalancer
+
+  designate-redis:
+    enabled: true
+    replicas: 1
+
+  octavia:
+    amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image
+    apacheContainerImage: registry.redhat.io/ubi9/httpd-24:latest
+    octaviaAPI:
+      networkAttachments:
+        - internalapi
+    octaviaHousekeeping:
+      networkAttachments:
+        - octavia
+    octaviaHealthManager:
+      networkAttachments:
+        - octavia
+    octaviaWorker:
+      networkAttachments:
+        - octavia
+
+  ovn:
+    ovnController:
+      nicMappings:
+        datacentre: ospbr
+        octavia: octbr
+
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      debug = True
+      enabled_backends = default_backend:file
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      filesystem_store_datadir = /var/lib/glance/images/
+    glanceAPIs:
+      default:
+        replicas: 1
+        type: single

--- a/examples/dt/dt-sharded/kustomization.yaml
+++ b/examples/dt/dt-sharded/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../dt/dt-sharded/edpm
+
+resources:
+  - values.yaml

--- a/examples/dt/dt-sharded/values.yaml
+++ b/examples/dt/dt-sharded/values.yaml
@@ -1,0 +1,138 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  ssh_keys:
+    authorized: _replaced_
+    private: _replaced_
+    public: _replaced_
+
+  nova:
+    migration:
+      ssh_keys:
+        private: _replaced_
+        public: _replaced_
+
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+            - type: ovs_bridge
+              name: {{ neutron_physical_bridge_name }}
+              mtu: {{ min_viable_mtu }}
+              use_dhcp: false
+              dns_servers: {{ ctlplane_dns_nameservers }}
+              domain: {{ dns_search_domains }}
+              addresses:
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+              routes: {{ ctlplane_host_routes }}
+              members:
+                - type: interface
+                  name: nic2
+                  mtu: {{ min_viable_mtu }}
+                  primary: true
+          {% for network in nodeset_networks %}
+                - type: vlan
+                  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+                  vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+                  addresses:
+                    - ip_netmask: >-
+                        {{
+                          lookup('vars', networks_lower[network] ~ '_ip')
+                        }}/{{
+                          lookup('vars', networks_lower[network] ~ '_cidr')
+                        }}
+                  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+        neutron_physical_bridge_name: br-ex
+        neutron_public_interface_name: eth0
+
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+
+        edpm_sshd_configure_firewall: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+
+        gather_facts: false
+
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
+
+    nodes:
+      edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.122.100
+        hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+
+      edpm-compute-1:
+        ansible:
+          ansibleHost: 192.168.122.101
+        hostName: edpm-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+
+    services:
+      - bootstrap
+      - download-cache
+      - configure-network
+      - validate-network
+      - install-os
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-metadata
+      - libvirt
+      - nova

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,6 +8,7 @@
       - rhoso-architecture-validate-bgp_dt04_ipv6
       - rhoso-architecture-validate-bmo01
       - rhoso-architecture-validate-dcn
+      - rhoso-architecture-validate-dt-sharded
       - rhoso-architecture-validate-dz-storage
       - rhoso-architecture-validate-hci
       - rhoso-architecture-validate-hci-adoption

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -94,6 +94,20 @@
       cifmw_networking_env_def_file: automation/net-env/dcn.yaml
 - job:
     files:
+    - automation/net-env/dt-sharded.yaml
+    - dt/dt-sharded
+    - examples/dt/dt-sharded
+    - examples/dt/dt-sharded/control-plane
+    - examples/dt/dt-sharded/control-plane/networking
+    - examples/dt/dt-sharded/control-plane/networking/nncp
+    - lib
+    name: rhoso-architecture-validate-dt-sharded
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: dt-sharded
+      cifmw_networking_env_def_file: automation/net-env/dt-sharded.yaml
+- job:
+    files:
     - automation/mocks/dz-storage.yaml
     - examples/dt/dz-storage/control-plane
     - examples/dt/dz-storage/control-plane/networking


### PR DESCRIPTION
New deployment topology for testing per-service database, message bus,
and cache sharding. Each OpenStack service gets a dedicated galera
cluster, a dedicated rabbitmq cluster, and a dedicated memcached
instance, all with replicas:1.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Depends-on: https://github.com/openstack-k8s-operators/ci-framework/pull/3907