### PR TITLE
nova04delta: fix preprovisioning network data for BMO

### DIFF
--- a/dt/nova/nova04delta/edpm/baremetalhosts/baremetalhosts.yaml
+++ b/dt/nova/nova04delta/edpm/baremetalhosts/baremetalhosts.yaml
@@ -25,3 +25,4 @@ spec:
   bootMode: UEFI
   rootDeviceHints: {}
   online: true
+  preprovisioningNetworkDataName: edpm-compute-0-preprovision-network-data

--- a/dt/nova/nova04delta/edpm/baremetalhosts/kustomization.yaml
+++ b/dt/nova/nova04delta/edpm/baremetalhosts/kustomization.yaml
@@ -99,6 +99,21 @@ replacements:
         options:
           create: true
 
+  # preprovisioningNetworkDataName — CI overrides via stage_4 values
+  # to point at the deploy_bmh-created secret instead of the default.
+  - source:
+      kind: ConfigMap
+      name: baremetalhost-values
+      fieldPath: data.edpm-compute-0.preprovisioningNetworkDataName
+    targets:
+      - select:
+          kind: BareMetalHost
+          name: edpm-compute-0
+        fieldPaths:
+          - spec.preprovisioningNetworkDataName
+        options:
+          create: true
+
   # preprovisioningNetworkData
   - source:
       kind: ConfigMap

--- a/examples/dt/nova/nova04delta/edpm/baremetalhosts/values.yaml
+++ b/examples/dt/nova/nova04delta/edpm/baremetalhosts/values.yaml
@@ -21,6 +21,7 @@ data:
     bootMACAddress: CHANGEME
     rootDeviceHints:
       deviceName: /dev/vda
+    preprovisioningNetworkDataName: OPTIONAL
     preprovisioningNetworkData:
-      nmstate: |
+      networkData: |
         CHANGEME


### PR DESCRIPTION
BMO reads preprovisioning network data from
the Secret referenced by BareMetalHost.spec.preprovisioningNetworkDataName and expects the data under the 'networkData' key.

Previously the BMH had no preprovisioningNetworkDataName (the secret was created but orphaned) and the values used 'nmstate' as the key. This did not surface because BMO never attempted to read the unreferenced secret.

- baremetalhosts.yaml: add preprovisioningNetworkDataName pointing to the co-located edpm-compute-0-preprovision-network-data Secret.
- values.yaml: rename the key from 'nmstate' to 'networkData' so the kustomize replacement produces a Secret with the key BMO reads.

Generated-by: claude-4.6-opus-high