### PR TITLE
Enable Barbican in multi-namespace SKMO control planes

### DIFF
--- a/examples/va/multi-namespace-skmo/control-plane/service-values.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane/service-values.yaml
@@ -9,6 +9,7 @@ data:
   tls:
     caBundleSecretName: custom-ca-certs
   barbican:
+    enabled: true
     barbicanKeystoneListener:
       customServiceConfig: |
         [keystone_notifications]

--- a/examples/va/multi-namespace-skmo/control-plane2/service-values.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane2/service-values.yaml
@@ -12,6 +12,7 @@ data:
 
   # --- SKMO-specific overrides ---
   barbican:
+    enabled: true
     barbicanKeystoneListener:
       customServiceConfig: |
         [keystone_notifications]


### PR DESCRIPTION
Set data.barbican.enabled to true in both central and leaf service-values so the inherited kustomize replacement maps to spec.barbican.template.enabled. The multi-namespace base leaves barbican disabled; SKMO requires Barbican in both regions per the validated scenario README.