### PR TITLE
Add per-node config (ansibleHost, networks, fixedIP) to all NFV scena…

### DIFF
--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset/values.yaml
@@ -173,7 +173,20 @@ data:
         subnetName: subnet1
     nodes:
       edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.122.100
         hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
     services:
       - bootstrap
       - download-cache

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset2/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset2/values.yaml
@@ -173,7 +173,20 @@ data:
         subnetName: subnet1
     nodes:
       edpm-compute-1:
+        ansible:
+          ansibleHost: 192.168.122.101
         hostName: edpm-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
     services:
       - bootstrap
       - download-cache

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/computes/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/computes/values.yaml
@@ -121,7 +121,20 @@ data:
         subnetName: subnet1
     nodes:
       edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.122.100
         hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
     services:
       - bootstrap
       - download-cache

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/networkers/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/networkers/values.yaml
@@ -107,7 +107,20 @@ data:
         subnetName: subnet1
     nodes:
       edpm-networker-0:
+        ansible:
+          ansibleHost: 192.168.122.101
         hostName: edpm-networker-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
     services:
       - bootstrap
       - download-cache

--- a/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
@@ -173,9 +173,35 @@ data:
         subnetName: subnet1
     nodes:
       edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.122.100
         hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
       edpm-compute-1:
+        ansible:
+          ansibleHost: 192.168.122.101
         hostName: edpm-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
     services:
       - bootstrap
       - download-cache

--- a/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
@@ -141,9 +141,35 @@ data:
         subnetName: subnet1
     nodes:
       edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.122.100
         hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
       edpm-compute-1:
+        ansible:
+          ansibleHost: 192.168.122.101
         hostName: edpm-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
     services:
       - bootstrap
       - download-cache

--- a/examples/va/nfv/sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/sriov/edpm/nodeset/values.yaml
@@ -116,9 +116,35 @@ data:
         subnetName: subnet1
     nodes:
       edpm-compute-0:
+        ansible:
+          ansibleHost: 192.168.122.100
         hostName: edpm-compute-0
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
       edpm-compute-1:
+        ansible:
+          ansibleHost: 192.168.122.101
         hostName: edpm-compute-1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.101
+            name: ctlplane
+            subnetName: subnet1
+          - name: internalapi
+            subnetName: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
     services:
       - bootstrap
       - download-cache


### PR DESCRIPTION
Add per-node config (ansibleHost, networks, fixedIP) to all NFV scenarios
Define per-node networks with fixedIP in all NFV nodeset values so that
each compute node gets a known IP address on the ctlplane network.
Without this, nodes are generated with only hostName and the resulting
IP is unpredictable.

Extends the pattern already present in nfv-ovs-dpdk-sriov-hci to:
ovs-dpdk, ovs-dpdk-sriov, sriov, nfv-ovs-dpdk-sriov-2nodesets,
and nfv-ovs-dpdk-sriov-networker.

Signed-off-by: Miguel Angel Nieto Jimenez <mnietoji@redhat.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>