### PR TITLE
Add octavia service to SKMO central and leaf regions

### DIFF
--- a/automation/vars/multi-namespace-skmo.yaml
+++ b/automation/vars/multi-namespace-skmo.yaml
@@ -15,7 +15,7 @@ vas:
         build_output: namespace.yaml
 
       - name: nncp-configuration    # stage 1
-        path: examples/va/multi-namespace/control-plane/networking/nncp
+        path: examples/va/multi-namespace-skmo/control-plane/networking/nncp
         wait_conditions:
           # We don't wait for these NNCPs at this stage, because we'll wait for
           # both namespaces in the next stage so that they can deploy in parallel
@@ -26,24 +26,24 @@ vas:
             --timeout=5m
         values:
           - name: network-values
-            src_file: values.yaml
+            src_file: ../../../../multi-namespace/control-plane/networking/nncp/values.yaml
         build_output: nncp.yaml
 
       - name: nncp-configuration2    # stage 2
-        path: examples/va/multi-namespace/control-plane2/networking/nncp
+        path: examples/va/multi-namespace-skmo/control-plane2/networking/nncp
         wait_conditions:
           - >-
-            oc -n openstack wait nncp
+            oc -n openstack2 wait nncp
             -l osp/nncm-config-type=standard
             --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
             --timeout=5m
         values:
           - name: network-values2
-            src_file: values.yaml
+            src_file: ../../../../multi-namespace/control-plane2/networking/nncp/values.yaml
         build_output: nncp2.yaml
 
       - name: network-configuration    # stage 3
-        path: examples/va/multi-namespace/control-plane/networking
+        path: examples/va/multi-namespace-skmo/control-plane/networking
         wait_conditions:
           - >-
             oc -n metallb-system wait pod
@@ -52,11 +52,11 @@ vas:
             --timeout=5m
         values:
           - name: network-values
-            src_file: nncp/values.yaml
+            src_file: ../../../multi-namespace/control-plane/networking/nncp/values.yaml
         build_output: network.yaml
 
       - name: network-configuration2    # stage 4
-        path: examples/va/multi-namespace/control-plane2/networking
+        path: examples/va/multi-namespace-skmo/control-plane2/networking
         wait_conditions:
           - >-
             oc -n metallb-system wait pod
@@ -65,7 +65,7 @@ vas:
             --timeout=5m
         values:
           - name: network-values2
-            src_file: nncp/values.yaml
+            src_file: ../../../multi-namespace/control-plane2/networking/nncp/values.yaml
         build_output: network2.yaml
 
       - pre_stage_run:    # stage 5
@@ -222,7 +222,7 @@ vas:
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
 
       - name: edpm-nodeset    # stage 7
-        path: examples/va/multi-namespace/edpm/nodeset
+        path: examples/va/multi-namespace-skmo/edpm/nodeset
         wait_conditions:
           # We don't wait for this namespace's OpenStackDataPlaneNodeSet at
           # this stage, because we'll wait for both namespaces in the next
@@ -233,7 +233,7 @@ vas:
             --timeout=5m
         values:
           - name: edpm-nodeset-values
-            src_file: values.yaml
+            src_file: ../../../multi-namespace/edpm/nodeset/values.yaml
         build_output: nodeset.yaml
 
       - pre_stage_run:    # stage 8
@@ -242,7 +242,7 @@ vas:
             source: "../../playbooks/multi-namespace/ns2_osdp_services.yaml"
             inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
         name: edpm-nodeset2
-        path: examples/va/multi-namespace/edpm2/nodeset
+        path: examples/va/multi-namespace-skmo/edpm2/nodeset
         wait_conditions:
           - >-
             oc -n openstack wait
@@ -254,10 +254,15 @@ vas:
             --timeout=10m
         values:
           - name: edpm-nodeset2-values
-            src_file: values.yaml
+            src_file: ../../../multi-namespace/edpm2/nodeset/values.yaml
         build_output: nodeset2.yaml
 
-      - name: edpm-deployment    # stage 9
+      - pre_stage_run:    # stage 9
+          - name: Recreate EDPM deployments when NodeSet config hash drifted
+            type: playbook
+            source: "skmo/recreate-edpm-deployment-if-stale.yaml"
+            inventory: "${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
+        name: edpm-deployment
         path: examples/va/multi-namespace/edpm
         wait_conditions:
           # We don't wait for this namespace's OpenStackDataPlaneDeployment at

--- a/examples/va/multi-namespace-skmo/application-credentials.md
+++ b/examples/va/multi-namespace-skmo/application-credentials.md
@@ -107,11 +107,10 @@ coordination to automate this redeployment.
 
 ## Enabling Application Credentials
 
-AC is **enabled by default** — `control-plane2/application-credentials.yaml`
-is included in `kustomization.yaml` so it is applied on the very first OSCP
-deploy. Services start with `v3applicationcredential` auth from day one.
+AC is **enabled** in `control-plane2/application-credentials.yaml`
+is included in `kustomization.yaml`.
 
-Because the OSCP is created with AC already active, the OSCP `Ready` condition
+The OSCP `Ready` condition
 implicitly gates on all `KeystoneApplicationCredential` CRs being Ready (the
 service operators finish reconciling only once they have an
 `ApplicationCredentialSecret` set). EDPM compute nodes therefore receive AC

--- a/examples/va/multi-namespace-skmo/components/octavia-edpm-bridge/edpm-octavia-ansible-vars.yaml
+++ b/examples/va/multi-namespace-skmo/components/octavia-edpm-bridge/edpm-octavia-ansible-vars.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+data:
+  nodeset:
+    ansible:
+      ansibleVars:
+        edpm_ovn_bridge_mappings:
+          - "datacentre:br-ex"
+          - "octavia:octbr"
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            mtu: {{ min_viable_mtu }}
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            mtu: {{ min_viable_mtu }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            members:
+            - type: interface
+              name: nic2
+              mtu: {{ min_viable_mtu }}
+              # force the MAC address of the bridge to this interface
+              primary: true
+          {% for network in nodeset_networks %}
+            - type: vlan
+              mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+              vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+              addresses:
+              - ip_netmask:
+                  {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+              routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+          - type: ovs_bridge
+            name: octbr
+            mtu: {{ min_viable_mtu }}
+            use_dhcp: false
+            members:
+            - type: vlan
+              mtu: {{ min_viable_mtu }}
+              vlan_id: 23
+              device: nic2

--- a/examples/va/multi-namespace-skmo/components/octavia-edpm-bridge/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/components/octavia-edpm-bridge/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# OVN Octavia compute bridge overlay for EDPM nodesets.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      kind: ConfigMap
+      name: edpm-nodeset-values
+    path: edpm-octavia-ansible-vars.yaml

--- a/examples/va/multi-namespace-skmo/components/octavia-network-values/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/components/octavia-network-values/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# Provide octavia-network-values ConfigMap for use by replacements.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - octavia-network-values.yaml

--- a/examples/va/multi-namespace-skmo/components/octavia-network-values/octavia-network-values.yaml
+++ b/examples/va/multi-namespace-skmo/components/octavia-network-values/octavia-network-values.yaml
@@ -1,0 +1,40 @@
+# local-config: octavia keys for replacements (static oc kustomize; ci-gen also adds octavia at deploy)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: octavia-network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  octavia:
+    dnsDomain: octavia.example.com
+    mtu: 1500
+    vlan: 23
+    base_iface: enp7s0
+    subnets:
+      - allocationRanges:
+          - end: 172.23.0.250
+            start: 172.23.0.100
+        cidr: 172.23.0.0/24
+        name: subnet1
+        vlan: 23
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "octavia",
+        "type": "bridge",
+        "bridge": "octbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.23.0.0/24",
+          "range_start": "172.23.0.30",
+          "range_end": "172.23.0.70",
+          "routes": [
+            {
+              "dst": "172.24.0.0/16",
+              "gw": "172.23.0.150"
+            }
+          ]
+        }
+      }

--- a/examples/va/multi-namespace-skmo/components/octavia-service-values/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/components/octavia-service-values/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# Patch service-values ConfigMap with Octavia service parameters.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      kind: ConfigMap
+      name: service-values
+    path: octavia-service-values.yaml

--- a/examples/va/multi-namespace-skmo/components/octavia-service-values/octavia-service-values.yaml
+++ b/examples/va/multi-namespace-skmo/components/octavia-service-values/octavia-service-values.yaml
@@ -1,0 +1,29 @@
+# Octavia keys for service-values ConfigMap (shared by central and leaf control planes)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ovn:
+    ovnController:
+      nicMappings:
+        octavia: octbr
+  octavia:
+    enabled: true
+    amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image
+    apacheContainerImage: registry.redhat.io/ubi9/httpd-24:latest
+    octaviaAPI:
+      networkAttachments:
+        - internalapi
+    octaviaHousekeeping:
+      networkAttachments:
+        - octavia
+    octaviaHealthManager:
+      networkAttachments:
+        - octavia
+    octaviaWorker:
+      networkAttachments:
+        - octavia

--- a/examples/va/multi-namespace-skmo/control-plane/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane/kustomization.yaml
@@ -4,6 +4,11 @@ kind: Component
 
 components:
   - ../../multi-namespace/control-plane
+  - ../../../../va/multi-namespace-skmo/octavia-controlplane
+
+resources:
+  - networking/octavia-netattach.yaml
+  - octavia-ca-passphrase.yaml
 
 patches:
   - target:

--- a/examples/va/multi-namespace-skmo/control-plane/networking/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane/networking/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../multi-namespace/control-plane/networking
+  - octavia-netattach.yaml
+
+components:
+  - ../../../../../va/multi-namespace-skmo/networking-octavia

--- a/examples/va/multi-namespace-skmo/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane/networking/nncp/kustomization.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# ci_gen_kustomize_values writes env-specific network-values to the base
+# values.yaml before build (see automation vars src_file).
+resources:
+  - ../../../../multi-namespace/control-plane/networking/nncp
+
+components:
+  - ../../../components/octavia-network-values
+
+patches:
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia vlan host interface
+          name: octavia
+          state: up
+          type: vlan
+          vlan:
+            base-iface: _replaced_
+            id: _replaced_
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia bridge
+          mtu: 1500
+          name: octbr
+          type: linux-bridge
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+              - name: octavia
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: octavia-network-values
+      fieldPath: data.octavia.base_iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.base-iface
+  - source:
+      kind: ConfigMap
+      name: octavia-network-values
+      fieldPath: data.octavia.vlan
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=octavia].vlan.id

--- a/examples/va/multi-namespace-skmo/control-plane/networking/octavia-netattach.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane/networking/octavia-netattach.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: octavia
+  namespace: openstack
+  labels:
+    osp/net: octavia
+    osp/net-attach-def-type: standard
+spec:
+  config: |
+    _replaced_

--- a/examples/va/multi-namespace-skmo/control-plane/octavia-ca-passphrase.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane/octavia-ca-passphrase.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: octavia-ca-passphrase
+type: Opaque
+stringData:
+  server-ca-passphrase: "12345678"

--- a/examples/va/multi-namespace-skmo/control-plane/service-values.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane/service-values.yaml
@@ -36,3 +36,17 @@ data:
         target_ip_address = 172.18.0.10
   swift:
     enabled: true
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:swift
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+      swift_store_region = regionOne

--- a/examples/va/multi-namespace-skmo/control-plane2/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane2/kustomization.yaml
@@ -4,9 +4,12 @@ kind: Component
 
 components:
   - ../../multi-namespace/control-plane2
+  - ../../../../va/multi-namespace-skmo/octavia-controlplane
 
 resources:
   - skmo-values.yaml
+  - networking/octavia-netattach.yaml
+  - octavia-ca-passphrase.yaml
 
 patches:
   - target:

--- a/examples/va/multi-namespace-skmo/control-plane2/networking/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane2/networking/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../multi-namespace/control-plane2/networking
+  - octavia-netattach.yaml
+
+components:
+  - ../../../../../va/multi-namespace-skmo/networking-octavia

--- a/examples/va/multi-namespace-skmo/control-plane2/networking/nncp/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane2/networking/nncp/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Octavia bridge on OCP masters is configured by central region NNCP only.
+resources:
+  - ../../../../multi-namespace/control-plane2/networking/nncp

--- a/examples/va/multi-namespace-skmo/control-plane2/networking/octavia-netattach.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane2/networking/octavia-netattach.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: octavia
+  namespace: openstack2
+  labels:
+    osp/net: octavia
+    osp/net-attach-def-type: standard
+spec:
+  config: |
+    _replaced_

--- a/examples/va/multi-namespace-skmo/control-plane2/octavia-ca-passphrase.yaml
+++ b/examples/va/multi-namespace-skmo/control-plane2/octavia-ca-passphrase.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: octavia-ca-passphrase
+type: Opaque
+stringData:
+  server-ca-passphrase: "12345678"

--- a/examples/va/multi-namespace-skmo/edpm/nodeset/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/edpm/nodeset/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../multi-namespace/edpm/nodeset
+  - skmo-edpm-overrides.yaml
+
+components:
+  - ../../components/octavia-edpm-bridge
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: skmo-edpm-overrides
+      fieldPath: data.edpm_nodes_validation_check_for_fqdn
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.edpm_nodes_validation_check_for_fqdn
+        options:
+          create: true

--- a/examples/va/multi-namespace-skmo/edpm/nodeset/skmo-edpm-overrides.yaml
+++ b/examples/va/multi-namespace-skmo/edpm/nodeset/skmo-edpm-overrides.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skmo-edpm-overrides
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  edpm_nodes_validation_check_for_fqdn: "false"

--- a/examples/va/multi-namespace-skmo/edpm2/nodeset/kustomization.yaml
+++ b/examples/va/multi-namespace-skmo/edpm2/nodeset/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../multi-namespace/edpm2/nodeset
+  - skmo-edpm-overrides.yaml
+
+components:
+  - ../../components/octavia-edpm-bridge
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: skmo-edpm-overrides
+      fieldPath: data.edpm_nodes_validation_check_for_fqdn
+    targets:
+      - select:
+          kind: OpenStackDataPlaneNodeSet
+        fieldPaths:
+          - spec.nodeTemplate.ansible.ansibleVars.edpm_nodes_validation_check_for_fqdn
+        options:
+          create: true

--- a/examples/va/multi-namespace-skmo/edpm2/nodeset/skmo-edpm-overrides.yaml
+++ b/examples/va/multi-namespace-skmo/edpm2/nodeset/skmo-edpm-overrides.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skmo-edpm-overrides
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  edpm_nodes_validation_check_for_fqdn: "false"

--- a/examples/va/multi-namespace/control-plane/networking/kustomization.yaml
+++ b/examples/va/multi-namespace/control-plane/networking/kustomization.yaml
@@ -2,28 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-transformers:
-  # Set namespace to OpenStack on all namespaced objects without a namespace
-  - |-
-    apiVersion: builtin
-    kind: NamespaceTransformer
-    metadata:
-      name: _ignored_
-      namespace: openstack
-    setRoleBindingSubjects: none
-    unsetOnly: true
-    fieldSpecs:
-      - path: metadata/name
-        kind: Namespace
-        create: true
-
-
 components:
-  - ../../../../../lib/networking/metallb/base
-  - ../../../../../lib/networking/metallb/ip-addresses
-  - ../../../../../lib/networking/metallb/l2-single-nic
-  - ../../../../../lib/networking/netconfig
-  - ../../../../../lib/networking/nad
+  - ../../../../../va/multi-namespace/control-plane/networking
 
 resources:
   - nncp/values.yaml

--- a/va/multi-namespace-skmo/networking-octavia/kustomization.yaml
+++ b/va/multi-namespace-skmo/networking-octavia/kustomization.yaml
@@ -1,0 +1,61 @@
+---
+# Octavia NetConfig and NAD wiring for SKMO network-configuration stages.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+components:
+  - ../../../examples/va/multi-namespace-skmo/components/octavia-network-values
+
+patches:
+  - target:
+      version: v1beta1
+      kind: NetConfig
+      name: netconfig
+    patch: |-
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: octavia
+          subnets:
+            - _replaced_
+          mtu: 1500
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: octavia-network-values
+      fieldPath: data.octavia.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=octavia].dnsDomain
+  - source:
+      kind: ConfigMap
+      name: octavia-network-values
+      fieldPath: data.octavia.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=octavia].mtu
+  - source:
+      kind: ConfigMap
+      name: octavia-network-values
+      fieldPath: data.octavia.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=octavia].subnets
+  - source:
+      kind: ConfigMap
+      name: octavia-network-values
+      fieldPath: data.octavia.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: octavia
+        fieldPaths:
+          - spec.config

--- a/va/multi-namespace-skmo/octavia-controlplane/kustomization.yaml
+++ b/va/multi-namespace-skmo/octavia-controlplane/kustomization.yaml
@@ -1,0 +1,113 @@
+---
+# Octavia control-plane replacements shared by central and leaf OSCP stages.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+components:
+  - ../../../examples/va/multi-namespace-skmo/components/octavia-network-values
+  - ../../../examples/va/multi-namespace-skmo/components/octavia-service-values
+
+replacements:
+  # Octavia service configuration
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.amphoraImageContainerImage
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.amphoraImageContainerImage
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.apacheContainerImage
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.apacheContainerImage
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaAPI.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaAPI.networkAttachments
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaHousekeeping.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaHousekeeping.networkAttachments
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaHealthManager.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaHealthManager.networkAttachments
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.octaviaWorker.networkAttachments
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.octaviaWorker.networkAttachments
+        options:
+          create: true
+
+  # Octavia network configuration
+  - source:
+      kind: ConfigMap
+      name: octavia-network-values
+      fieldPath: data.octavia.net-attach-def
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: octavia
+        fieldPaths:
+          - spec.config
+
+  # OVN nicMappings configuration
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.ovn.ovnController.nicMappings.octavia
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.ovn.template.ovnController.nicMappings.octavia
+        options:
+          create: true

--- a/va/multi-namespace/control-plane/networking/kustomization.yaml
+++ b/va/multi-namespace/control-plane/networking/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+components:
+  - ../../../../lib/networking/metallb/base
+  - ../../../../lib/networking/metallb/ip-addresses
+  - ../../../../lib/networking/metallb/l2-single-nic
+  - ../../../../lib/networking/netconfig
+  - ../../../../lib/networking/nad

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -189,17 +189,18 @@
     files:
     - automation/net-env/multi-namespace-skmo.yaml
     - examples/va/multi-namespace-skmo/control-plane
+    - examples/va/multi-namespace-skmo/control-plane/networking
+    - examples/va/multi-namespace-skmo/control-plane/networking/nncp
     - examples/va/multi-namespace-skmo/control-plane2
-    - examples/va/multi-namespace/control-plane/networking
-    - examples/va/multi-namespace/control-plane/networking/nncp
-    - examples/va/multi-namespace/control-plane2/networking
-    - examples/va/multi-namespace/control-plane2/networking/nncp
+    - examples/va/multi-namespace-skmo/control-plane2/networking
+    - examples/va/multi-namespace-skmo/control-plane2/networking/nncp
+    - examples/va/multi-namespace-skmo/edpm/nodeset
+    - examples/va/multi-namespace-skmo/edpm2/nodeset
     - examples/va/multi-namespace/edpm
-    - examples/va/multi-namespace/edpm/nodeset
     - examples/va/multi-namespace/edpm2
-    - examples/va/multi-namespace/edpm2/nodeset
     - examples/va/multi-namespace/namespace
     - lib
+    - va/multi-namespace-skmo
     name: rhoso-architecture-validate-multi-namespace-skmo
     parent: rhoso-architecture-base-job
     vars:


### PR DESCRIPTION
Add OVN Octavia networking for SKMO multi-region deployment
Compose SKMO overlays on multi-namespace bases with small components for
Octavia NNCP, EDPM octbr bridge mappings, and network-values patches.
NNCP stages reuse base values.yaml templates; octavia-network-values
component keeps kustomize load-restrictor-safe paths for CI kustomize_deploy.

Signed-off-by: Ade Lee <alee@redhat.com>
Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>