### PR TITLE
Remove neutron-ovn-igmp from HCI post-ceph deployment

### DIFF
--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/deployment/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/deployment/values.yaml
@@ -13,7 +13,6 @@ data:
     - install-certs
     - ceph-client
     - ovn
-    - neutron-ovn-igmp
     - neutron-metadata
     - neutron-sriov
     - libvirt


### PR DESCRIPTION
This service was missed in commit 9ebbdc38 ("Remove neutron-ovn-igmp data plane service") which removed it from all other scenarios but left it in the HCI post-ceph servicesOverride, causing the deployment to fail with "neutron-ovn-igmp not found".