### PR TITLE
[DCN] Adding cinderBackups to controlplane

### DIFF
--- a/dt/dcn/control-plane/kustomization.yaml
+++ b/dt/dcn/control-plane/kustomization.yaml
@@ -112,6 +112,17 @@ replacements:
   - source:
       kind: ConfigMap
       name: service-values
+      fieldPath: data.cinderBackups
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.cinder.template.cinderBackups
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
       fieldPath: data.cinderVolumes
     targets:
       - select:

--- a/examples/dt/dcn/control-plane/kustomization.yaml
+++ b/examples/dt/dcn/control-plane/kustomization.yaml
@@ -8,3 +8,11 @@ components:
 resources:
   - networking/nncp/values.yaml
   - service-values.yaml
+
+patches:
+  - target:
+      kind: OpenStackControlPlane
+    patch: |-
+      - op: add
+        path: /spec/cinder/template/cinderBackups
+        value: {}

--- a/examples/dt/dcn/control-plane/scaledown/service-values.yaml
+++ b/examples/dt/dcn/control-plane/scaledown/service-values.yaml
@@ -21,13 +21,44 @@ data:
   cinderAPI:
     replicas: 3
   cinderBackup:
-    replicas: 3
+    replicas: 0
     customServiceConfig: |
       [DEFAULT]
-      backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
-      backup_ceph_conf = /etc/ceph/az0.conf
-      backup_ceph_pool = backups
-      backup_ceph_user = openstack
+      # cinderBackup (singular) is deprecated; use cinderBackups (plural)
+  cinderBackups:
+    az0:
+      customServiceConfig: |
+        [DEFAULT]
+        storage_availability_zone = az0
+        backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
+        backup_ceph_conf = /etc/ceph/az0.conf
+        backup_ceph_pool = backups
+        backup_ceph_user = openstack
+      networkAttachments:
+        - storage
+      replicas: 2
+    az1:
+      customServiceConfig: |
+        [DEFAULT]
+        storage_availability_zone = az1
+        backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
+        backup_ceph_conf = /etc/ceph/az1.conf
+        backup_ceph_pool = backups
+        backup_ceph_user = openstack
+      networkAttachments:
+        - storage
+      replicas: 0
+    az2:
+      customServiceConfig: |
+        [DEFAULT]
+        storage_availability_zone = az2
+        backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
+        backup_ceph_conf = /etc/ceph/az2.conf
+        backup_ceph_pool = backups
+        backup_ceph_user = openstack
+      networkAttachments:
+        - storage
+      replicas: 2
   cinderVolumes:
     az0:
       customServiceConfig: |

--- a/examples/dt/dcn/service-values.yaml
+++ b/examples/dt/dcn/service-values.yaml
@@ -22,13 +22,44 @@ data:
   cinderAPI:
     replicas: 3
   cinderBackup:
-    replicas: 3
+    replicas: 0
     customServiceConfig: |
       [DEFAULT]
-      backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
-      backup_ceph_conf = /etc/ceph/az0.conf
-      backup_ceph_pool = backups
-      backup_ceph_user = openstack
+      # cinderBackup (singular) is deprecated; use cinderBackups (plural)
+  cinderBackups:
+    az0:
+      customServiceConfig: |
+        [DEFAULT]
+        storage_availability_zone = az0
+        backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
+        backup_ceph_conf = /etc/ceph/az0.conf
+        backup_ceph_pool = backups
+        backup_ceph_user = openstack
+      networkAttachments:
+        - storage
+      replicas: 2
+    az1:
+      customServiceConfig: |
+        [DEFAULT]
+        storage_availability_zone = az1
+        backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
+        backup_ceph_conf = /etc/ceph/az1.conf
+        backup_ceph_pool = backups
+        backup_ceph_user = openstack
+      networkAttachments:
+        - storage
+      replicas: 2
+    az2:
+      customServiceConfig: |
+        [DEFAULT]
+        storage_availability_zone = az2
+        backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
+        backup_ceph_conf = /etc/ceph/az2.conf
+        backup_ceph_pool = backups
+        backup_ceph_user = openstack
+      networkAttachments:
+        - storage
+      replicas: 2
   cinderVolumes:
     az0:
       customServiceConfig: |
@@ -439,6 +470,7 @@ data:
         - propagation:
             - CinderVolume
             - CinderBackup
+            - CinderBackups
             - GlanceAPI
             - ManilaShare
           extraVolType: Ceph


### PR DESCRIPTION
To deploy multiple cinder backups distributed across edge sites

Removes the existing spec.cinder.template.cinderBackup (singluar) by setting repliacs to 0 and adds cinderBackups (plural)

Jira: [OSPRH-28343](https://redhat.atlassian.net/browse/OSPRH-28343)
Signed-off-by: Gais Ameer <gameer@redhat.com>