### PR TITLE
[uni04delta-ipv6] Set heat replicas to 3

### DIFF
--- a/dt/uni04delta-ipv6/control-plane/kustomization.yaml
+++ b/dt/uni04delta-ipv6/control-plane/kustomization.yaml
@@ -155,3 +155,16 @@ replacements:
           - spec.heat.enabled
         options:
           create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.heat.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.heat.template.heatAPI.replicas
+          - spec.heat.template.heatEngine.replicas
+        options:
+          create: true

--- a/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
@@ -192,6 +192,7 @@ data:
 
   heat:
     enabled: true
+    replicas: 3
 
   telemetry:
     enabled: true


### PR DESCRIPTION
uni04delta-ipv6 deploys 3 OCP controlplane nodes, but heat only ran on 1 of them. Setting number of heatAPI and heatEngine replicas to 3 could help to prevent some instabilities with heat.

[OSPCIX-1373](https://redhat.atlassian.net/browse/OSPCIX-1373)