### PR TITLE
Add worker-0 NNCP networking for uni04delta-adoption

### DIFF
--- a/automation/net-env/uni04delta-adoption.yaml
+++ b/automation/net-env/uni04delta-adoption.yaml
@@ -409,6 +409,52 @@ instances:
         prefix_length_v4: 24
         skip_nm: false
         vlan_id: 122
+  ocp-3:
+    hostname: worker-0
+    name: ocp-3
+    networks:
+      ctlplane:
+        interface_name: enp6s0
+        ip_v4: 192.168.122.20
+        mac_addr: "52:54:02:18:86:bc"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: ctlplane
+        prefix_length_v4: 24
+        skip_nm: false
+      internalapi:
+        interface_name: enp6s0.120
+        ip_v4: 172.17.0.20
+        mac_addr: "52:54:00:04:df:88"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: internalapi
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 120
+      storage:
+        interface_name: enp6s0.121
+        ip_v4: 172.18.0.20
+        mac_addr: "52:54:00:7e:b2:1d"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: storage
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 121
+      tenant:
+        interface_name: enp6s0.122
+        ip_v4: 172.19.0.20
+        mac_addr: "52:54:00:12:d1:e1"
+        mtu: 1500
+        netmask_v4: 255.255.255.0
+        network_name: tenant
+        parent_interface: enp6s0
+        prefix_length_v4: 24
+        skip_nm: false
+        vlan_id: 122
   networker-0:
     hostname: networker-0
     name: networker-0

--- a/automation/vars/uni04delta-adoption.yaml
+++ b/automation/vars/uni04delta-adoption.yaml
@@ -3,7 +3,7 @@ vas:
   uni04delta-adoption:
     stages:
       - name: nncp-configuration
-        path: examples/dt/uni04delta/control-plane/networking/nncp
+        path: examples/dt/uni04delta-adoption/control-plane/networking/nncp
         wait_conditions:
           - >-
             oc -n openstack wait nncp
@@ -16,7 +16,7 @@ vas:
         build_output: nncp.yaml
 
       - name: network-configuration
-        path: examples/dt/uni04delta/control-plane/networking
+        path: examples/dt/uni04delta-adoption/control-plane/networking
         wait_conditions:
           - >-
             oc -n metallb-system wait pod

--- a/examples/dt/uni04delta-adoption/control-plane/networking/kustomization.yaml
+++ b/examples/dt/uni04delta-adoption/control-plane/networking/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/uni04delta/networking
+
+resources:
+  - nncp/values.yaml

--- a/examples/dt/uni04delta-adoption/control-plane/networking/nncp/.gitignore
+++ b/examples/dt/uni04delta-adoption/control-plane/networking/nncp/.gitignore
@@ -1,0 +1,1 @@
+nncp.yaml

--- a/examples/dt/uni04delta-adoption/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/dt/uni04delta-adoption/control-plane/networking/nncp/kustomization.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  - |-
+      apiVersion: builtin
+      kind: NamespaceTransformer
+      metadata:
+        name: _ignored_
+        namespace: openstack
+      setRoleBindingSubjects: none
+      unsetOnly: true
+      fieldSpecs:
+        - path: metadata/name
+          kind: Namespace
+          create: true
+
+components:
+  - ../../../../../../dt/uni04delta/networking/nncp
+
+resources:
+  - values.yaml
+  - ocp_worker_nodes.yaml
+
+replacements:
+  # Static Node IPs: node-3 (worker-0)
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.internalapi_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.tenant_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.storage_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.ip
+
+  # prefix-length: node-3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=linux-bridge].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=internalapi].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.tenant.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=tenant].ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - spec.desiredState.interfaces.[name=storage].ipv4.address.0.prefix-length
+
+  # Node name and hostname selector
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]

--- a/examples/dt/uni04delta-adoption/control-plane/networking/nncp/ocp_worker_nodes.yaml
+++ b/examples/dt/uni04delta-adoption/control-plane/networking/nncp/ocp_worker_nodes.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-3
+  labels:
+    osp/nncm-config-type: standard

--- a/examples/dt/uni04delta-adoption/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/uni04delta-adoption/control-plane/networking/nncp/values.yaml
@@ -1,0 +1,285 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+data:
+  openstack-operator-image:
+    "quay.io/openstack-k8s-operators/openstack-operator-index:latest"
+
+  node_0:
+    name: master-0
+    internalapi_ip: 172.17.0.5
+    tenant_ip: 172.19.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+    designate_ip: 172.26.0.5
+    designateext_ip: 172.34.0.5
+  node_1:
+    name: master-1
+    internalapi_ip: 172.17.0.6
+    tenant_ip: 172.19.0.6
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.6
+    designate_ip: 172.26.0.6
+    designateext_ip: 172.34.0.6
+  node_2:
+    name: master-2
+    internalapi_ip: 172.17.0.7
+    tenant_ip: 172.19.0.7
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.7
+    designate_ip: 172.26.0.7
+    designateext_ip: 172.34.0.7
+  node_3:
+    name: worker-0
+    internalapi_ip: 172.17.0.20
+    tenant_ip: 172.19.0.20
+    ctlplane_ip: 192.168.122.20
+    storage_ip: 172.18.0.20
+
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet1
+    prefix-length: 24
+    iface: enp6s0
+    mtu: 9000
+    lb_addresses:
+      - 192.168.122.80-192.168.122.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "macvlan",
+        "master": "ospbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.122.0/24",
+          "range_start": "192.168.122.30",
+          "range_end": "192.168.122.70"
+        }
+      }
+
+  designate:
+    dnsDomain: designate.example.com
+    mtu: 9000
+    prefix-length: 24
+    iface: designate
+    vlan: 24
+    subnets:
+      - allocationRanges:
+          - end: 172.26.0.250
+            start: 172.26.0.100
+        cidr: 172.26.0.0/24
+        name: subnet1
+    lb_addresses:
+      - 172.26.0.80-172.26.0.120
+    base_iface: enp6s0
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "designate",
+        "type": "macvlan",
+        "master": "designate",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.26.0.0/24",
+          "range_start": "172.26.0.30",
+          "range_end": "172.26.0.70"
+        }
+      }
+
+  designateext:
+    dnsDomain: designateext.example.com
+    mtu: 9000
+    prefix-length: 24
+    iface: designateext
+    vlan: 34
+    base_iface: enp6s0
+    subnets:
+      - allocationRanges:
+          - end: 172.34.0.250
+            start: 172.34.0.100
+        cidr: 172.34.0.0/24
+        name: subnet1
+    lb_addresses:
+      - 172.34.0.80-172.34.0.120
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "designateext",
+        "type": "macvlan",
+        "master": "designateext",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.34.0.0/24",
+          "range_start": "172.34.0.30",
+          "range_end": "172.34.0.70"
+        }
+      }
+
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "macvlan",
+        "master": "internalapi",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 9000
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "macvlan",
+        "master": "storage",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+
+  storagemgmt:
+    dnsDomain: storagemgmt.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.20.0.250
+            start: 172.20.0.100
+        cidr: 172.20.0.0/24
+        name: subnet1
+        vlan: 23
+    mtu: 9000
+
+  tenant:
+    dnsDomain: tenant.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        name: subnet1
+        vlan: 22
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp6s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "macvlan",
+        "master": "tenant",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70"
+        }
+      }
+
+  external:
+    dnsDomain: external.example.com
+    subnets:
+      - allocationRanges:
+          - end: 10.0.0.250
+            start: 10.0.0.100
+        cidr: 10.0.0.0/24
+        gateway: 10.0.0.1
+        name: subnet1
+    mtu: 1500
+  datacentre:
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "datacentre",
+        "type": "bridge",
+        "bridge": "ospbr",
+        "ipam": {}
+      }
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config: []
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -561,8 +561,8 @@
 - job:
     files:
     - automation/net-env/uni04delta-adoption.yaml
-    - examples/dt/uni04delta/control-plane/networking
-    - examples/dt/uni04delta/control-plane/networking/nncp
+    - examples/dt/uni04delta-adoption/control-plane/networking
+    - examples/dt/uni04delta-adoption/control-plane/networking/nncp
     - lib
     name: rhoso-architecture-validate-uni04delta-adoption
     parent: rhoso-architecture-base-job


### PR DESCRIPTION
Following configuration from other adoptions jobs that use worker-0 like uni02beta and uni04delta-ipv6.

Related to [OSPRH-31782](https://redhat.atlassian.net/browse/OSPRH-31782)

Assisted-By: Cursor-composer-2-fast