### PR TITLE
uni04delta-ip6 - ironic enable debug logging

### DIFF
--- a/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
+++ b/examples/dt/uni04delta-ipv6/control-plane/service-values.yaml
@@ -147,8 +147,15 @@ data:
   ironic:
     enabled: true
     rpcTransport: oslo
+    ironicAPI:
+      customServiceConfig: |
+          [DEFAULT]
+          debug = true
     ironicConductors:
       - customServiceConfig: |
+          [DEFAULT]
+          debug = true
+
           [pxe]
           kernel_append_params = console=ttyS0
 
@@ -159,6 +166,9 @@ data:
           inspection_network = provisioning
     ironicInspector:
       customServiceConfig: |
+        [DEFAULT]
+        debug = true
+
         [capabilities]
         boot_mode = true
 


### PR DESCRIPTION
Most other services in the DT enable debug logging, let's enable it for ironic services as well.

Jira: [OSPCIX-1418](https://redhat.atlassian.net/browse/OSPCIX-1418)