### PR TITLE
Fix/nfv controlplane novnc and metricstorage

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov-ipv6/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov-ipv6/service-values.yaml
@@ -63,6 +63,8 @@ data:
     template:
       ceilometer:
         enabled: true
+      metricStorage:
+        enabled: true
   extraMounts:
     - name: v1
       region: r1

--- a/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
@@ -63,6 +63,8 @@ data:
     template:
       ceilometer:
         enabled: true
+      metricStorage:
+        enabled: true
   extraMounts:
     - name: v1
       region: r1

--- a/lib/control-plane/base/openstackcontrolplane.yaml
+++ b/lib/control-plane/base/openstackcontrolplane.yaml
@@ -204,6 +204,10 @@ spec:
             cluster: rabbitmq-cell1
           conductorServiceTemplate:
             replicas: 1
+          noVNCProxyServiceTemplate:
+            enabled: true
+            networkAttachments:
+              - ctlplane
           hasAPIAccess: true
   octavia:
     enabled: false

--- a/va/nfv/ovs-dpdk-sriov/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-sriov/kustomization.yaml
@@ -128,3 +128,15 @@ replacements:
           - spec.nova.template.schedulerServiceTemplate.customServiceConfig
         options:
           create: true
+  # Telemetry metric storage toggle for NFV deployments
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.enabled
+        options:
+          create: true


### PR DESCRIPTION
Fixes two gaps in the NFV OVS-DPDK-SRIOV controlplane configuration identified by comparing rendered manifests against authoritative RHOSO component specs:

  - **Add noVNCProxyServiceTemplate to nova cell1** (`lib/control-plane/base`): The base OpenStackControlPlane defines cell1 without a noVNCProxyServiceTemplate, meaning VNC console access to VMs on cell1 compute nodes is unavailable out of the box. The authoritative RHOSO docs specify `enabled: true` with a `ctlplane` network attachment. This affects all validated architectures inheriting from `lib/control-plane/base`.

  - **Add metricStorage kustomize replacement** (`va/nfv/ovs-dpdk-sriov`): The NFV VA already exposes `telemetry.enabled` and `ceilometer.enabled` via service-values replacements, but `metricStorage.enabled` has no replacement — it stays `false` regardless of deployer intent. This adds the missing replacement so NFV deployments can toggle Prometheus metric collection through `service-values.yaml`.