### PR TITLE
fix(nfv): correct enabled_filters typo in nova scheduler config

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov-ipv6/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov-ipv6/service-values.yaml
@@ -82,4 +82,4 @@ data:
     schedulerServiceTemplate:
       customServiceConfig: |
         [filter_scheduler]
-        enabled_filtes = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter
+        enabled_filters = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter

--- a/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
@@ -82,4 +82,4 @@ data:
     schedulerServiceTemplate:
       customServiceConfig: |
         [filter_scheduler]
-        enabled_filtes = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter
+        enabled_filters = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter

--- a/examples/va/nfv/ovs-dpdk/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk/service-values.yaml
@@ -64,4 +64,4 @@ data:
     schedulerServiceTemplate:
       customServiceConfig: |
         [filter_scheduler]
-        enabled_filtes = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter
+        enabled_filters = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter

--- a/examples/va/nfv/sriov/service-values.yaml
+++ b/examples/va/nfv/sriov/service-values.yaml
@@ -46,4 +46,4 @@ data:
     schedulerServiceTemplate:
       customServiceConfig: |
         [filter_scheduler]
-        enabled_filtes = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter
+        enabled_filters = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter


### PR DESCRIPTION
Misspelled as 'enabled_filtes' across all NFV VA examples (ovs-dpdk, ovs-dpdk-sriov, ovs-dpdk-sriov-ipv6, sriov). OpenStack silently ignores unknown keys, so PciPassthroughFilter and NUMATopologyFilter were never active — breaking SR-IOV and NUMA-aware scheduling.