### PR TITLE
Fix uni07eta networker to use neutron-ovn agent

### DIFF
--- a/examples/dt/uni07eta/control-plane/neutron-ovn-extra-config.yaml
+++ b/examples/dt/uni07eta/control-plane/neutron-ovn-extra-config.yaml
@@ -7,4 +7,4 @@ metadata:
 data:
   99-neutron-ovn.conf: |
     [agent]
-    extensions = metadata,segment_bridge
+    extensions = metadata

--- a/examples/dt/uni07eta/networker/nodeset/values.yaml
+++ b/examples/dt/uni07eta/networker/nodeset/values.yaml
@@ -141,4 +141,4 @@ data:
       - reboot-os
       - install-certs
       - ovn
-      - neutron-metadata
+      - neutron-ovn


### PR DESCRIPTION
Switch networker to use neutron-ovn agent and remove segment_bridge extension from neutron-ovn-extra-config.

Related-to: [OSPCIX-1424](https://redhat.atlassian.net/browse/OSPCIX-1424)