### PR TITLE
feat(nfv): add metricStorage replacement 

### DIFF
--- a/examples/va/nfv/ovs-dpdk-sriov-ipv6/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov-ipv6/service-values.yaml
@@ -63,6 +63,8 @@ data:
     template:
       ceilometer:
         enabled: true
+      metricStorage:
+        enabled: true
   extraMounts:
     - name: v1
       region: r1

--- a/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
@@ -63,6 +63,8 @@ data:
     template:
       ceilometer:
         enabled: true
+      metricStorage:
+        enabled: true
   extraMounts:
     - name: v1
       region: r1

--- a/va/nfv/ovs-dpdk-sriov/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-sriov/kustomization.yaml
@@ -128,3 +128,15 @@ replacements:
           - spec.nova.template.schedulerServiceTemplate.customServiceConfig
         options:
           create: true
+  # Telemetry metric storage toggle for NFV deployments
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.enabled
+        options:
+          create: true


### PR DESCRIPTION
The NFV OVS-DPDK-SRIOV validated architecture enables telemetry and ceilometer via service-values replacements, but metricStorage (Prometheus monitoring stack) has no replacement - it stays at the base default of enabled: false regardless of what the deployer sets in service-values.

This adds a kustomize replacement for telemetry.template.metricStorage.enabled so NFV deployments can toggle Prometheus metric collection through service-values.yaml, consistent with how telemetry.enabled and ceilometer.enabled are already handled.

Also adds the metricStorage.enabled field to example service-values for both ovs-dpdk-sriov and ovs-dpdk-sriov-ipv6 to satisfy the kustomize replacement source requirement and provide a working default.