### PR TITLE
Enable segment_bridge extension for uni07eta

### DIFF
--- a/examples/dt/uni07eta/control-plane/neutron-ovn-extra-config.yaml
+++ b/examples/dt/uni07eta/control-plane/neutron-ovn-extra-config.yaml
@@ -7,4 +7,4 @@ metadata:
 data:
   99-neutron-ovn.conf: |
     [agent]
-    extensions = metadata
+    extensions = metadata,segment_bridge


### PR DESCRIPTION
Add segment_bridge to enable multi-segment per host featuer for routed provider networks.

Related-to: [OSPRH-31633](https://redhat.atlassian.net/browse/OSPRH-31633)