### PR TITLE
Enable OVN-native EVPN in bgp_dt01

### DIFF
--- a/examples/dt/bgp_dt01/README.md
+++ b/examples/dt/bgp_dt01/README.md
@@ -83,7 +83,7 @@ network).
 | Octavia          | (default)        | Must have          |
 | Heat             | (default)        | Must have          |
 | frr              | dataplane        | Must have          |
-| ovn-bgp-agent    | dataplane        | Must have          |
+| neutron-ovn      | dataplane        | Must have          |
 
 ## Considerations/Constraints
 

--- a/examples/dt/bgp_dt01/control-plane/service-values.yaml
+++ b/examples/dt/bgp_dt01/control-plane/service-values.yaml
@@ -34,7 +34,10 @@ data:
     enabled: true
 
   octavia:
-    enabled: true
+    # octavia is disabled due to limitation with Native OVN BGP:
+    # with this feature, only one provider network can be configured, while
+    # octavia needs its own provider network.
+    enabled: false
     amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image
     apacheContainerImage: registry.redhat.io/ubi9/httpd-24:latest
     octaviaAPI:
@@ -67,32 +70,34 @@ data:
   neutron:
     customServiceConfig: |
       [DEFAULT]
+      service_plugins = qos,ovn-router,trunk,segments,port_forwarding,log,placement,evpn
       vlan_transparent = true
       debug = true
       dns_domain = example.org.
-      external_dns_driver = designate
+      # external_dns_driver = designate
       [ovs]
       igmp_snooping_enable = true
-      [designate]
-      url = https://designate-internal.openstack.svc:9001/v2
-      auth_type = password
-      auth_url = {{ .KeystoneInternalURL }}
-      username = {{ .ServiceUser }}
-      password = {{ .ServicePassword }}
-      project_name = service
-      project_domain_name = Default
-      user_domain_name = Default
-      allow_reverse_dns_lookup = True
-      ipv4_ptr_zone_prefix_size = 24
-      ipv6_ptr_zone_prefix_size = 116
-      ptr_zone_email = admin@example.org
+      # [designate]
+      # url = https://designate-internal.openstack.svc:9001/v2
+      # auth_type = password
+      # auth_url = {{ .KeystoneInternalURL }}
+      # username = {{ .ServiceUser }}
+      # password = {{ .ServicePassword }}
+      # project_name = service
+      # project_domain_name = Default
+      # user_domain_name = Default
+      # allow_reverse_dns_lookup = True
+      # ipv4_ptr_zone_prefix_size = 24
+      # ipv6_ptr_zone_prefix_size = 116
+      # ptr_zone_email = admin@example.org
 
   designate-redis:
-    enabled: true
+    enabled: false
     replicas: 1
 
+  # designate disabled due to OSPRH-26878
   designate:
-    enabled: true
+    enabled: false
     nsRecords:
       - hostname: ns1.example.org.
         priority: 1

--- a/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r0/values.yaml
@@ -24,7 +24,9 @@ data:
         edpm_ovn_bridge_mappings:
           - "datacentre:br-ex"
           - "octavia:br-octavia"
-        edpm_ovn_bgp_agent_expose_tenant_networks: true
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 64999
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
@@ -85,7 +87,6 @@ data:
         edpm_sshd_configure_firewall: true
         gather_facts: false
         neutron_physical_bridge_name: br-ex
-        neutron_public_interface_name: eth1
     networks:
       - defaultRoute: true
         name: CtlPlane
@@ -120,9 +121,6 @@ data:
         ansible:
           ansibleHost: 192.168.122.100
           ansibleVars:
-            edpm_ovn_bgp_agent_local_ovn_peer_ips:
-              - 100.64.0.1
-              - 100.65.0.1
             edpm_frr_bgp_peers:
               - 100.64.0.1
               - 100.65.0.1
@@ -155,8 +153,7 @@ data:
       - reboot-os
       - install-certs
       - ovn
-      - neutron-metadata
-      - ovn-bgp-agent
+      - neutron-ovn
       - libvirt
       - nova
   nova:

--- a/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r1/values.yaml
@@ -24,7 +24,9 @@ data:
         edpm_ovn_bridge_mappings:
           - "datacentre:br-ex"
           - "octavia:br-octavia"
-        edpm_ovn_bgp_agent_expose_tenant_networks: true
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 64999
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
@@ -85,7 +87,6 @@ data:
         edpm_sshd_configure_firewall: true
         gather_facts: false
         neutron_physical_bridge_name: br-ex
-        neutron_public_interface_name: eth1
     networks:
       - defaultRoute: true
         name: CtlPlane
@@ -120,9 +121,6 @@ data:
         ansible:
           ansibleHost: 192.168.123.100
           ansibleVars:
-            edpm_ovn_bgp_agent_local_ovn_peer_ips:
-              - 100.64.1.1
-              - 100.65.1.1
             edpm_frr_bgp_peers:
               - 100.64.1.1
               - 100.65.1.1
@@ -155,8 +153,7 @@ data:
       - reboot-os
       - install-certs
       - ovn
-      - neutron-metadata
-      - ovn-bgp-agent
+      - neutron-ovn
       - libvirt
       - nova
   nova:

--- a/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/computes/r2/values.yaml
@@ -24,7 +24,9 @@ data:
         edpm_ovn_bridge_mappings:
           - "datacentre:br-ex"
           - "octavia:br-octavia"
-        edpm_ovn_bgp_agent_expose_tenant_networks: true
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 64999
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
@@ -85,7 +87,6 @@ data:
         edpm_sshd_configure_firewall: true
         gather_facts: false
         neutron_physical_bridge_name: br-ex
-        neutron_public_interface_name: eth1
     networks:
       - defaultRoute: true
         name: CtlPlane
@@ -120,9 +121,6 @@ data:
         ansible:
           ansibleHost: 192.168.124.100
           ansibleVars:
-            edpm_ovn_bgp_agent_local_ovn_peer_ips:
-              - 100.64.2.1
-              - 100.65.2.1
             edpm_frr_bgp_peers:
               - 100.64.2.1
               - 100.65.2.1
@@ -155,8 +153,7 @@ data:
       - reboot-os
       - install-certs
       - ovn
-      - neutron-metadata
-      - ovn-bgp-agent
+      - neutron-ovn
       - libvirt
       - nova
   nova:

--- a/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r0/values.yaml
@@ -24,7 +24,9 @@ data:
         edpm_ovn_bridge_mappings:
           - "datacentre:br-ex"
           - "octavia:br-octavia"
-        edpm_ovn_bgp_agent_expose_tenant_networks: true
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 64999
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
@@ -86,7 +88,6 @@ data:
         edpm_sshd_configure_firewall: true
         gather_facts: false
         neutron_physical_bridge_name: br-ex
-        neutron_public_interface_name: eth1
     networks:
       - defaultRoute: true
         name: CtlPlane
@@ -121,9 +122,6 @@ data:
         ansible:
           ansibleHost: 192.168.122.200
           ansibleVars:
-            edpm_ovn_bgp_agent_local_ovn_peer_ips:
-              - 100.64.0.5
-              - 100.65.0.5
             edpm_frr_bgp_peers:
               - 100.64.0.5
               - 100.65.0.5
@@ -157,8 +155,7 @@ data:
       - reboot-os
       - install-certs
       - ovn
-      - neutron-metadata
-      - ovn-bgp-agent
+      - neutron-ovn
   nova:
     migration:
       ssh_keys:

--- a/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r1/values.yaml
@@ -24,7 +24,9 @@ data:
         edpm_ovn_bridge_mappings:
           - "datacentre:br-ex"
           - "octavia:br-octavia"
-        edpm_ovn_bgp_agent_expose_tenant_networks: true
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 64999
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
@@ -86,7 +88,6 @@ data:
         edpm_sshd_configure_firewall: true
         gather_facts: false
         neutron_physical_bridge_name: br-ex
-        neutron_public_interface_name: eth1
     networks:
       - defaultRoute: true
         name: CtlPlane
@@ -121,9 +122,6 @@ data:
         ansible:
           ansibleHost: 192.168.123.200
           ansibleVars:
-            edpm_ovn_bgp_agent_local_ovn_peer_ips:
-              - 100.64.1.5
-              - 100.65.1.5
             edpm_frr_bgp_peers:
               - 100.64.1.5
               - 100.65.1.5
@@ -157,8 +155,7 @@ data:
       - reboot-os
       - install-certs
       - ovn
-      - neutron-metadata
-      - ovn-bgp-agent
+      - neutron-ovn
   nova:
     migration:
       ssh_keys:

--- a/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt01/edpm/networkers/r2/values.yaml
@@ -24,7 +24,9 @@ data:
         edpm_ovn_bridge_mappings:
           - "datacentre:br-ex"
           - "octavia:br-octavia"
-        edpm_ovn_bgp_agent_expose_tenant_networks: true
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 64999
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
         edpm_frr_bgp_ipv4_src_network: bgpmainnet
         edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
         edpm_frr_bgp_neighbor_password: f00barZ
@@ -86,7 +88,6 @@ data:
         edpm_sshd_configure_firewall: true
         gather_facts: false
         neutron_physical_bridge_name: br-ex
-        neutron_public_interface_name: eth1
     networks:
       - defaultRoute: true
         name: CtlPlane
@@ -121,9 +122,6 @@ data:
         ansible:
           ansibleHost: 192.168.124.200
           ansibleVars:
-            edpm_ovn_bgp_agent_local_ovn_peer_ips:
-              - 100.64.2.5
-              - 100.65.2.5
             edpm_frr_bgp_peers:
               - 100.64.2.5
               - 100.65.2.5
@@ -157,8 +155,7 @@ data:
       - reboot-os
       - install-certs
       - ovn
-      - neutron-metadata
-      - ovn-bgp-agent
+      - neutron-ovn
   nova:
     migration:
       ssh_keys:


### PR DESCRIPTION
Adapt bgp_dt01 deployment topology for EVPN Type-5 testing:

Control plane:
- Add evpn to neutron service_plugins
- Disable octavia (incompatible with single provider network)
- Disable designate due to [OSPRH-26878](https://redhat.atlassian.net/browse/OSPRH-26878)

EDPM nodes:
- Replace neutron-metadata and ovn-bgp-agent services with neutron-ovn
- Remove edpm_ovn_bgp_agent_* variables (no longer needed)
- Configure edpm_neutron_ovn_agent_agent_extensions with metadata,ovn-evpn
- Configure edpm_neutron_ovn_agent_ovn_evpn_bgp_as and edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface
- Remove edpm_ovn_bgp_agent_local_ovn_peer_ips (EVPN does not use this parameter)


Assisted-By: Claude Opus 4.6