### PR TITLE
Add ospbr-218 to NetConfig for uni07eta

### DIFF
--- a/dt/uni07eta/networking/kustomization.yaml
+++ b/dt/uni07eta/networking/kustomization.yaml
@@ -28,7 +28,51 @@ resources:
   - ocp-networks-ospbr-101-netattach.yaml
 
 
+patches:
+  - target:
+      kind: NetConfig
+      name: netconfig
+    patch: |-
+      - op: add
+        path: /spec/networks/-
+        value:
+          dnsDomain: _replaced_
+          name: ospbr-218
+          subnets:
+            - _replaced_
+          mtu: 9000
+
 replacements:
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ospbr-218.dnsDomain
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=ospbr-218].dnsDomain
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ospbr-218.mtu
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=ospbr-218].mtu
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ospbr-218.subnets
+    targets:
+      - select:
+          kind: NetConfig
+        fieldPaths:
+          - spec.networks.[name=ospbr-218].subnets
+
   - source:
       kind: ConfigMap
       name: network-values

--- a/examples/dt/uni07eta/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/uni07eta/control-plane/networking/nncp/values.yaml
@@ -184,6 +184,13 @@ data:
 
   ospbr-218:
     dnsDomain: ospbr-218.openstack.lab
+    subnets:
+      - allocationRanges:
+          - end: 172.38.0.250
+            start: 172.38.0.100
+        cidr: 172.38.0.0/24
+        name: subnet1
+        vlan: 218
     mtu: 9000
     vlan: 218
     base_iface: ospbr


### PR DESCRIPTION
Add [ospbr-218](https://redhat.atlassian.net/browse/ospbr-218) network to the uni07eta networking kustomization so dataplane nodesets can reference it. Add subnets definition to values.yaml for the kustomize replacements.

Related-to: [OSPRH-28563](https://redhat.atlassian.net/browse/OSPRH-28563)
Assisted-by: Claude Code Opus 4.6