### PR TITLE
fix(security): add PSA audit/warn restricted labels to shipped Namesp…

### DIFF
--- a/lib/olm-deps/cert_manager_namespace.yaml
+++ b/lib/olm-deps/cert_manager_namespace.yaml
@@ -5,4 +5,8 @@ metadata:
   name: cert-manager-operator
   labels:
     pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
     security.openshift.io/scc.podSecurityLabelSync: "false"

--- a/lib/olm-deps/metallb_namespace.yaml
+++ b/lib/olm-deps/metallb_namespace.yaml
@@ -5,4 +5,8 @@ metadata:
   name: metallb-system
   labels:
     pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
     security.openshift.io/scc.podSecurityLabelSync: "false"

--- a/lib/olm-deps/nmstate_namespace.yaml
+++ b/lib/olm-deps/nmstate_namespace.yaml
@@ -5,4 +5,8 @@ metadata:
   name: openshift-nmstate
   labels:
     pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
     security.openshift.io/scc.podSecurityLabelSync: "false"

--- a/lib/olm-openstack-subscriptions/base/namespaces.yaml
+++ b/lib/olm-openstack-subscriptions/base/namespaces.yaml
@@ -5,6 +5,10 @@ metadata:
   name: openstack-operators
   labels:
     pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
     security.openshift.io/scc.podSecurityLabelSync: "false"
 ---
 apiVersion: v1
@@ -13,4 +17,8 @@ metadata:
   name: openstack
   labels:
     pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
     security.openshift.io/scc.podSecurityLabelSync: "false"

--- a/lib/olm-openstack/namespaces.yaml
+++ b/lib/olm-openstack/namespaces.yaml
@@ -5,6 +5,10 @@ metadata:
   name: openstack-operators
   labels:
     pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
     security.openshift.io/scc.podSecurityLabelSync: "false"
 ---
 apiVersion: v1
@@ -13,4 +17,8 @@ metadata:
   name: openstack
   labels:
     pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
     security.openshift.io/scc.podSecurityLabelSync: "false"


### PR DESCRIPTION
…aces (OSPRH-32421 / FIND-009)

All namespace manifests used privileged enforce with no audit or warn labels, meaning policy violations were completely silent. Add audit: restricted and warn: restricted to detect pods that could be tightened without blocking deployments (OSPRH-32421 / FIND-009).

enforce: privileged is intentionally kept — metallb-system, openshift-nmstate, cert-manager-operator, openstack, and openstack-operators all run workloads that require privileged SCC (host networking, custom operators). Changing enforce would break deployments. The audit/warn labels surface any violations in the OCP audit log and console without blocking.

Files patched:
- lib/olm-deps/cert_manager_namespace.yaml
- lib/olm-deps/metallb_namespace.yaml
- lib/olm-deps/nmstate_namespace.yaml
- lib/olm-openstack/namespaces.yaml
- lib/olm-openstack-subscriptions/base/namespaces.yaml

Refs: OSPRH-32421