### PR TITLE
bgp_dt05 , iBGP for EDPM nodes

### DIFF
--- a/automation/mocks/bgp_dt05.yaml
+++ b/automation/mocks/bgp_dt05.yaml
@@ -1,0 +1,1047 @@
+---
+cifmw_networking_env_definition:
+  instances:
+    r0-compute-0:
+      hostname: r0-compute-0
+      name: r0-compute-0
+      networks:
+        ctlplaner0:
+          interface_name: eth1
+          ip_v4: 192.168.122.100
+          mac_addr: 52:54:00:6a:4a:25
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.100
+          mac_addr: 52:54:00:14:8c:e5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.100
+          mac_addr: 52:54:00:0d:c3:a1
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.100
+          mac_addr: '52:54:00:16:41:11'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r1-compute-0:
+      hostname: r1-compute-0
+      name: r1-compute-0
+      networks:
+        ctlplaner1:
+          interface_name: eth1
+          ip_v4: 192.168.123.101
+          mac_addr: 52:54:00:9b:e6:98
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.101
+          mac_addr: 52:54:00:38:f8:36
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.101
+          mac_addr: 52:54:00:4d:c4:0b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.101
+          mac_addr: 52:54:00:14:06:e3
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r2-compute-0:
+      hostname: r2-compute-0
+      name: r2-compute-0
+      networks:
+        ctlplaner2:
+          interface_name: eth1
+          ip_v4: 192.168.124.102
+          mac_addr: 52:54:00:98:a6:ae
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.102
+          mac_addr: 52:54:00:6a:da:29
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        storage:
+          interface_name: eth1.21
+          ip_v4: 172.18.0.102
+          mac_addr: 52:54:00:03:0a:e8
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.102
+          mac_addr: 52:54:00:78:92:ee
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    controller-0:
+      hostname: controller-0
+      name: controller-0
+      networks:
+        ctlplane:
+          interface_name: eth1
+          ip_v4: 192.168.122.9
+          mac_addr: 52:54:00:b2:7c:cb
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+    r0-networker-0:
+      hostname: r0-networker-0
+      name: r0-networker-0
+      networks:
+        ctlplaner0:
+          interface_name: eth1
+          ip_v4: 192.168.122.106
+          mac_addr: 52:54:00:15:d3:88
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.106
+          mac_addr: 52:54:00:10:fd:f9
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.106
+          mac_addr: '52:54:00:42:16:57'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r1-networker-0:
+      hostname: r1-networker-0
+      name: r1-networker-0
+      networks:
+        ctlplaner1:
+          interface_name: eth1
+          ip_v4: 192.168.122.107
+          mac_addr: 52:54:00:de:46:aa
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.107
+          mac_addr: 52:54:00:3c:46:9b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.107
+          mac_addr: 52:54:00:6c:66:38
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    r2-networker-0:
+      hostname: r2-networker-0
+      name: r2-networker-0
+      networks:
+        ctlplaner2:
+          interface_name: eth1
+          ip_v4: 192.168.122.108
+          mac_addr: 52:54:00:3f:b8:15
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: eth1.20
+          ip_v4: 172.17.0.108
+          mac_addr: 52:54:00:7c:e7:5f
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        tenant:
+          interface_name: eth1.22
+          ip_v4: 172.19.0.108
+          mac_addr: 52:54:00:12:ef:f8
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: eth1
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-0:
+      hostname: master-0
+      name: ocp-0
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.10
+          mac_addr: 52:54:00:a6:a2:28
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.10
+          mac_addr: 52:54:00:4d:b7:40
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.10
+          mac_addr: 52:54:00:01:fb:71
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.10
+          mac_addr: 52:54:00:1d:70:f5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.10
+          mac_addr: 52:54:00:19:a0:48
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-1:
+      hostname: master-1
+      name: ocp-1
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.11
+          mac_addr: 52:54:00:5d:5c:75
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.11
+          mac_addr: 52:54:00:43:51:94
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.11
+          mac_addr: 52:54:00:4c:f6:5b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.11
+          mac_addr: 52:54:00:4e:3f:30
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.11
+          mac_addr: '52:54:00:52:32:54'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-2:
+      hostname: master-2
+      name: ocp-2
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.12
+          mac_addr: 52:54:00:51:83:2d
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.12
+          mac_addr: 52:54:00:5c:31:ac
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.12
+          mac_addr: 52:54:00:64:39:96
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.12
+          mac_addr: 52:54:00:2e:71:ce
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.12
+          mac_addr: 52:54:00:2f:c7:35
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-worker-0:
+      hostname: worker-0
+      name: ocp-worker-0
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.13
+          mac_addr: 52:54:00:89:69:43
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.13
+          mac_addr: 52:54:00:35:4f:c2
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.13
+          mac_addr: 52:54:00:13:5a:96
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.13
+          mac_addr: '52:54:00:36:09:28'
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.13
+          mac_addr: 52:54:00:5c:09:09
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-worker-1:
+      hostname: worker-1
+      name: ocp-worker-1
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.14
+          mac_addr: 52:54:00:4b:f9:06
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.14
+          mac_addr: 52:54:00:4d:35:b4
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.14
+          mac_addr: 52:54:00:06:6b:f0
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.14
+          mac_addr: 52:54:00:2c:69:fe
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.14
+          mac_addr: 52:54:00:47:50:3b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-worker-2:
+      hostname: worker-2
+      name: ocp-worker-2
+      networks:
+        ctlplane:
+          interface_name: enp8s0
+          ip_v4: 192.168.122.15
+          mac_addr: 52:54:00:a3:32:7a
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp8s0.20
+          ip_v4: 172.17.0.15
+          mac_addr: 52:54:00:2a:55:0f
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp8s0.23
+          ip_v4: 172.23.0.15
+          mac_addr: 52:54:00:13:4e:27
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp8s0.21
+          ip_v4: 172.18.0.15
+          mac_addr: 52:54:00:12:6e:dc
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp8s0.22
+          ip_v4: 172.19.0.15
+          mac_addr: 52:54:00:18:2f:ac
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp8s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+    ocp-worker-3:
+      hostname: worker-3
+      name: ocp-worker-3
+      networks:
+        ctlplane:
+          interface_name: enp7s0
+          ip_v4: 192.168.122.16
+          mac_addr: 52:54:00:67:1b:c5
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: ctlplane
+          prefix_length_v4: 24
+          skip_nm: false
+        internalapi:
+          interface_name: enp7s0.20
+          ip_v4: 172.17.0.16
+          mac_addr: 52:54:00:65:17:db
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: internalapi
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 20
+        octavia:
+          interface_name: enp7s0.23
+          ip_v4: 172.23.0.16
+          mac_addr: 52:54:00:2f:28:7e
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: octavia
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 23
+        storage:
+          interface_name: enp7s0.21
+          ip_v4: 172.18.0.16
+          mac_addr: 52:54:00:46:68:6b
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: storage
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 21
+        tenant:
+          interface_name: enp7s0.22
+          ip_v4: 172.19.0.16
+          mac_addr: 52:54:00:31:3b:02
+          mtu: 1500
+          netmask_v4: 255.255.255.0
+          network_name: tenant
+          parent_interface: enp7s0
+          prefix_length_v4: 24
+          skip_nm: false
+          vlan_id: 22
+  networks:
+    ctlplane:
+      dns_v4:
+        - 192.168.125.1
+      dns_v6: []
+      gw_v4: 192.168.125.1
+      mtu: 1500
+      network_name: ctlplane
+      network_v4: 192.168.125.0/24
+      search_domain: ctlplane.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.125.90
+              end_host: 90
+              length: 11
+              start: 192.168.125.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.125.70
+              end_host: 70
+              length: 41
+              start: 192.168.125.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.125.120
+              end_host: 120
+              length: 21
+              start: 192.168.125.100
+              start_host: 100
+            - end: 192.168.125.200
+              end_host: 200
+              length: 51
+              start: 192.168.125.150
+              start_host: 150
+          ipv6_ranges: []
+    ctlplane_ocp_nad:
+      gw_v4: 192.168.126.1
+      mtu: 1500
+      network_name: ctlplane_ocp_nad
+      network_v4: 192.168.126.0/24
+      tools:
+        multus:
+          ipv4_ranges:
+            - end: 192.168.126.70
+              end_host: 70
+              length: 41
+              start: 192.168.126.30
+              start_host: 30
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.126.90
+              end_host: 90
+              length: 11
+              start: 192.168.126.80
+              start_host: 80
+    ctlplaner0:
+      dns_v4:
+        - 192.168.122.1
+      dns_v6: []
+      gw_v4: 192.168.122.1
+      mtu: 1500
+      network_name: ctlplaner0
+      network_v4: 192.168.122.0/24
+      search_domain: ctlplaner0.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.122.90
+              end_host: 90
+              length: 11
+              start: 192.168.122.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.122.70
+              end_host: 70
+              length: 41
+              start: 192.168.122.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.122.120
+              end_host: 120
+              length: 21
+              start: 192.168.122.100
+              start_host: 100
+            - end: 192.168.122.200
+              end_host: 200
+              length: 51
+              start: 192.168.122.150
+              start_host: 150
+          ipv6_ranges: []
+    ctlplaner1:
+      dns_v4:
+        - 192.168.123.1
+      dns_v6: []
+      gw_v4: 192.168.123.1
+      mtu: 1500
+      network_name: ctlplaner1
+      network_v4: 192.168.123.0/24
+      search_domain: ctlplaner1.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.123.90
+              end_host: 90
+              length: 11
+              start: 192.168.123.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.123.70
+              end_host: 70
+              length: 41
+              start: 192.168.123.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.123.120
+              end_host: 120
+              length: 21
+              start: 192.168.123.100
+              start_host: 100
+            - end: 192.168.123.200
+              end_host: 200
+              length: 51
+              start: 192.168.123.150
+              start_host: 150
+          ipv6_ranges: []
+    ctlplaner2:
+      dns_v4:
+        - 192.168.124.1
+      dns_v6: []
+      gw_v4: 192.168.124.1
+      mtu: 1500
+      network_name: ctlplaner2
+      network_v4: 192.168.124.0/24
+      search_domain: ctlplaner2.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 192.168.124.90
+              end_host: 90
+              length: 11
+              start: 192.168.124.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 192.168.124.70
+              end_host: 70
+              length: 41
+              start: 192.168.124.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.124.120
+              end_host: 120
+              length: 21
+              start: 192.168.124.100
+              start_host: 100
+            - end: 192.168.124.200
+              end_host: 200
+              length: 51
+              start: 192.168.124.150
+              start_host: 150
+          ipv6_ranges: []
+    external:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: external
+      network_v4: 192.168.32.0/20
+      search_domain: external.example.com
+      tools:
+        netconfig:
+          ipv4_ranges:
+            - end: 192.168.32.250
+              end_host: 250
+              length: 121
+              start: 192.168.32.130
+              start_host: 130
+          ipv6_ranges: []
+      vlan_id: 99
+    internalapi:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: internalapi
+      network_v4: 172.17.0.0/24
+      search_domain: internalapi.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 172.17.0.90
+              end_host: 90
+              length: 11
+              start: 172.17.0.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 172.17.0.70
+              end_host: 70
+              length: 41
+              start: 172.17.0.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 172.17.0.250
+              end_host: 250
+              length: 151
+              start: 172.17.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 20
+    octavia:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: octavia
+      network_v4: 172.23.0.0/24
+      search_domain: octavia.example.com
+      tools:
+        multus:
+          ipv4_ranges:
+            - end: 172.23.0.70
+              end_host: 70
+              length: 41
+              start: 172.23.0.30
+              start_host: 30
+          ipv6_ranges: []
+          ipv4_routes:
+            - destination: "172.24.0.0/16"
+              gateway: "172.23.0.150"
+        netconfig:
+          ipv4_ranges:
+            - end: 172.23.0.250
+              end_host: 250
+              length: 151
+              start: 172.23.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 23
+    storage:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: storage
+      network_v4: 172.18.0.0/24
+      search_domain: storage.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 172.18.0.90
+              end_host: 90
+              length: 11
+              start: 172.18.0.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 172.18.0.70
+              end_host: 70
+              length: 41
+              start: 172.18.0.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 172.18.0.250
+              end_host: 250
+              length: 151
+              start: 172.18.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 21
+    tenant:
+      dns_v4: []
+      dns_v6: []
+      mtu: 1500
+      network_name: tenant
+      network_v4: 172.19.0.0/24
+      search_domain: tenant.example.com
+      tools:
+        metallb:
+          ipv4_ranges:
+            - end: 172.19.0.90
+              end_host: 90
+              length: 11
+              start: 172.19.0.80
+              start_host: 80
+          ipv6_ranges: []
+        multus:
+          ipv4_ranges:
+            - end: 172.19.0.70
+              end_host: 70
+              length: 41
+              start: 172.19.0.30
+              start_host: 30
+          ipv6_ranges: []
+        netconfig:
+          ipv4_ranges:
+            - end: 172.19.0.250
+              end_host: 250
+              length: 151
+              start: 172.19.0.100
+              start_host: 100
+          ipv6_ranges: []
+      vlan_id: 22
+  routers: {}
+
+test_groups:
+  all:
+    - controller-0
+    - r0-compute-0
+    - r1-compute-0
+    - r2-compute-0
+    - r0-networker-0
+    - r1-networker-0
+    - r2-networker-0
+    - ocp-master-0
+    - ocp-master-1
+    - ocp-master-2
+    - ocp-worker-0
+    - ocp-worker-1
+    - ocp-worker-2
+    - ocp-worker-3
+    - router-0
+    - spine-0
+    - spine-1
+    - leaf-0
+    - leaf-1
+    - leaf-2
+    - leaf-3
+    - leaf-4
+    - leaf-5
+    - hypervisor
+    - localhost
+  controllers:
+    - controller-0
+  hypervisors:
+    - hypervisor
+  leafs:
+    - leaf-0
+    - leaf-1
+    - leaf-2
+    - leaf-3
+    - leaf-4
+    - leaf-5
+  localhosts:
+    - localhost
+  ocp_workers:
+    - ocp-worker-0
+    - ocp-worker-1
+    - ocp-worker-2
+    - ocp-worker-3
+  ocps:
+    - ocp-master-0
+    - ocp-master-1
+    - ocp-master-2
+  r0-computes:
+    - r0-compute-0
+  r0-networkers:
+    - r0-networker-0
+  r1-computes:
+    - r1-compute-0
+  r1-networkers:
+    - r1-networker-0
+  r2-computes:
+    - r2-compute-0
+  r2-networkers:
+    - r2-networker-0
+  routers:
+    - router-0
+  spines:
+    - spine-0
+    - spine-1

--- a/automation/vars/bgp_dt05.yaml
+++ b/automation/vars/bgp_dt05.yaml
@@ -1,0 +1,200 @@
+---
+vas:
+  bgp_dt05:
+    stages:
+      - pre_stage_run:
+          - name: 01 Apply taint on worker-3
+            type: cr
+            definition:
+              spec:
+                taints:
+                  - effect: NoSchedule
+                    key: testOperator
+                    value: 'true'
+                  - effect: NoExecute
+                    key: testOperator
+                    value: 'true'
+            kind: Node
+            resource_name: worker-3
+            state: patched
+          - name: 02 Disable rp_filters on OCP nodes
+            type: cr
+            definition:
+              spec:
+                profile:
+                  - data: |
+                      [main]
+                      summary=Optimize systems running OpenShift (provider specific parent profile)
+                      include=-provider-${f:exec:cat:/var/lib/ocp-tuned/provider},openshift
+
+                      [sysctl]
+                      net.ipv4.conf.enp7s0.rp_filter=0
+                      net.ipv4.conf.enp8s0.rp_filter=0
+                    name: openshift-no-reapply-sysctl
+                recommend:
+                  - match:
+                      # applied to all nodes except worker-3, because worker-3 has no enp8s0
+                      - label: kubernetes.io/hostname
+                        value: worker-0
+                      - label: kubernetes.io/hostname
+                        value: worker-1
+                      - label: kubernetes.io/hostname
+                        value: worker-2
+                      - label: node-role.kubernetes.io/master
+                    operand:
+                      tunedConfig:
+                        reapply_sysctl: false
+                    priority: 15
+                    profile: openshift-no-reapply-sysctl
+            api_version: tuned.openshift.io/v1
+            kind: Tuned
+            resource_name: openshift-no-reapply-sysctl
+            namespace: openshift-cluster-node-tuning-operator
+            state: present
+        name: nncp-configuration
+        path: examples/dt/bgp_dt05/control-plane/networking/nncp
+        wait_conditions:
+          - >-
+            oc -n openstack wait nncp
+            -l osp/nncm-config-type=standard
+            --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+            --timeout=300s
+        values:
+          - name: network-values
+            src_file: values.yaml
+        build_output: nncp.yaml
+
+      - name: networking
+        path: examples/dt/bgp_dt05/control-plane/networking
+        wait_conditions:
+          - >-
+            oc -n metallb-system wait pod
+            -l app=metallb -l component=speaker
+            --for condition=Ready
+        values:
+          - name: network-values
+            src_file: nncp/values.yaml
+        build_output: networking.yaml
+
+      - name: control-plane
+        path: examples/dt/bgp_dt05/control-plane
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackcontrolplane
+            controlplane
+            --for condition=Ready
+            --timeout=30m
+        values:
+          - name: network-values
+            src_file: networking/nncp/values.yaml
+          - name: service-values
+            src_file: service-values.yaml
+        build_output: control-plane.yaml
+        post_stage_run:
+          - name: Create BGPConfiguration after controlplane is deployed
+            type: cr
+            definition:
+              spec: {}
+            api_version: network.openstack.org/v1beta1
+            kind: BGPConfiguration
+            resource_name: bgpconfiguration
+            namespace: openstack
+            state: present
+
+      - name: edpm-computes-r0-nodeset
+        path: examples/dt/bgp_dt05/edpm/computes/r0
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r0-compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r0-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r0-compute-nodeset.yaml
+
+      - name: edpm-computes-r1-nodeset
+        path: examples/dt/bgp_dt05/edpm/computes/r1
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r1-compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r1-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r1-compute-nodeset.yaml
+
+      - name: edpm-computes-r2-nodeset
+        path: examples/dt/bgp_dt05/edpm/computes/r2
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r2-compute-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r2-compute-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r2-compute-nodeset.yaml
+
+      - name: edpm-networkers-r0-nodeset
+        path: examples/dt/bgp_dt05/edpm/networkers/r0
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r0-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r0-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r0-networker-nodeset.yaml
+
+      - name: edpm-networkers-r1-nodeset
+        path: examples/dt/bgp_dt05/edpm/networkers/r1
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r1-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r1-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r1-networker-nodeset.yaml
+
+      - name: edpm-networkers-r2-nodeset
+        path: examples/dt/bgp_dt05/edpm/networkers/r2
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanenodeset
+            r2-networker-nodes
+            --for condition=SetupReady
+            --timeout=600s
+        values:
+          - name: edpm-r2-networker-nodeset-values
+            src_file: values.yaml
+        build_output: edpm-r2-networker-nodeset.yaml
+
+      - name: edpm-deployment
+        path: examples/dt/bgp_dt05/edpm/deployment
+        wait_conditions:
+          - >-
+            oc -n openstack wait openstackdataplanedeployment
+            edpm-deployment
+            --for condition=Ready
+            --timeout=120m
+        values:
+          - name: edpm-deployment-values
+            src_file: values.yaml
+        build_output: edpm-deployment.yaml
+        post_stage_run:
+          - name: Wait until computes are ready
+            type: playbook
+            source: "nova_wait_for_compute_service.yml"
+            extra_vars:
+              _number_of_computes: 3
+              _cell_conductor: nova-cell0-conductor-0

--- a/examples/dt/bgp_dt05/README.md
+++ b/examples/dt/bgp_dt05/README.md
@@ -1,0 +1,149 @@
+# RHOSO Deployed Topology - BGP DT05 - EVPN with hybrid iBGP/eBGP
+
+This document describes BGP Deployed Topology DT05, used to test L2VPN EVPN
+with a hybrid BGP fabric on Red Hat OpenStack Services on OpenShift (RHOSO).
+
+The CRs included within this DT should be applied on an environment where EDPM
+and OCP nodes are connected through a spine/leaf network. The BGP protocol
+should be enabled on those spine and leaf routers.
+
+## Purpose
+
+This BGP DT (DT05) reuses the bgp_dt01 rack topology and tests EVPN-oriented
+BGP configuration:
+
+* Neutron API configured with the `evpn` service_plugin at the control plane
+* FRR on dataplane nodes as AS **65000** with `remote-as internal` (iBGP to leafs)
+* L2VPN EVPN address-family enabled on FRR (`advertise-all-vni`)
+* OVN Agent configured with the `ovn-evpn` extension on computes and networkers
+* MetalLB BGP peers using `myASN`/`peerASN` **65000** (iBGP to leaf routers)
+
+### BGP ASN layout
+
+| Role | ASN | Session type |
+| ---- | --- | ------------ |
+| EDPM compute / networker FRR | 65000 | iBGP to leafs |
+| MetalLB speakers (OCP workers) | 65000 | iBGP to leafs |
+| Leaf routers | 65000 | iBGP to EDPM/OCP; eBGP to spines |
+| Spine routers | 64999 | eBGP to leafs; iBGP to router-0 |
+| External router (router-0) | 64999 | iBGP to spines |
+
+Leaf↔EDPM and leaf↔MetalLB stay iBGP on AS **65000**. Spine↔leaf is **eBGP**
+so uplink and downlink routes are different BGP path types (avoids double
+route-reflector ECMP loops in a single-AS fabric).
+
+In CI, leaf/spine/router-0 FRR is rendered by ci-framework
+`prepare-bgp-spines-leaves` using `cifmw_bgp_*` vars from the
+`ci-framework-jobs` `bgp_dt05` scenario. When changing ASN layout, open
+linked PRs and use `Depends-On:` so Zuul tests architecture and jobs together.
+
+Compared to [bgp_dt01](../bgp_dt01/), which uses `ovn-bgp` and dataplane ASN
+64999, DT05 targets the EVPN agent path where neutron-ovn-agent dynamically
+extends `router bgp 65000` for EVPN advertisement.
+
+The OCP cluster consists of the following nodes:
+
+* 3 OCP master nodes
+* 3 OCP worker nodes
+* 1 OCP worker node with special configuration (OCP tester node)
+
+This DT creates an OCP cluster that includes both master and worker nodes,
+instead of the usual master/worker combo nodes. The reason for this is to run
+disruptive tests only on the OCP workers, which host the OpenStack Control
+Plane services, avoiding potential issues when OCP master nodes are disrupted
+that would not be relevant when testing RHOSO high availability scenarios.
+
+The extra OCP worker (OCP tester) is needed to run tests from it because:
+
+* disruptive tests can be run from this worker on the other workers without
+  affecting the test execution
+* this worker is connected to the spine/leaf routers with a special routing
+  configuration, so that it can reach the OpenStack provider network
+
+The OCP tester is configured so that only test pods (created by the
+OpenStack test-operator) run on it.
+
+This DT configures both compute and networker EDPM nodes. Networker
+nodes are needed when BGP is used on RHOSO, in order to expose routes to SNAT
+traffic (OVN Gateway IPs). In other words, when RHOSO is used with BGP, the OCP
+workers cannot be configured as OVN Gateways.
+
+The OCP and EDPM nodes deployed with this DT are distributed into three
+different racks. Each rack is connected to two leaves.
+Hence, the distribution of the nodes in the racks is the following one:
+
+* rack0: r0-compute-0, r0-networker-0, ocp-master-0, ocp-worker-0, leaf-0, leaf-1
+* rack1: r1-compute-0, r1-networker-0, ocp-master-1, ocp-worker-1, leaf-2, leaf-3
+* rack2: r2-compute-0, r2-networker-0, ocp-master-2, ocp-worker-2, leaf-4, leaf-5
+
+The OCP tester (ocp-worker-3) is not included into any rack. It is not
+connected to any leaves, but to a router connected to the spines, due to the
+reasons described before (it needs special connectivity to reach the provider
+network).
+
+## Node topology
+
+| Node role               | bm/vm | amount |
+| ----------------------- | ----- | ------ |
+| Openshift master nodes  | vm    | 3      |
+| Openshift worker nodes  | vm    | 4      |
+| Openstack Computes      | vm    | 3      |
+| Openstack Networker     | vm    | 3      |
+| Leaf routers            | vm    | 6      |
+| Spine routers           | vm    | 2      |
+| External routers        | vm    | 1      |
+| Ansible Controller      | vm    | 1      |
+
+### Networks
+
+| Name                     | Type     | CIDR             |
+| ------------------------ | -------- | ---------------- |
+| Controlplane rack0       | untagged | 192.168.122.0/24 |
+| Controlplane rack1       | untagged | 192.168.123.0/24 |
+| Controlplane rack2       | untagged | 192.168.124.0/24 |
+| Provider network         | untagged | 192.168.133.0/24 |
+| RH OSP                   | untagged | 192.168.111.0/24 |
+| edpm/ocp to left leaves  | untagged | 100.64.x.y/30    |
+| edpm/ocp to right leaves | untagged | 100.65.x.y/30    |
+
+## Services, enabled features and configurations
+
+| Service          | configuration    | Lock-in coverage?  |
+| ---------------- | ---------------- | ------------------ |
+| Glance           | Swift            | Must have          |
+| Swift            | (default)        | Must have          |
+| Heat             | (default)        | Must have          |
+| frr              | dataplane (iBGP AS 65000 to leafs, L2VPN EVPN) | Must have |
+| neutron-ovn      | dataplane (`ovn-evpn`) | Must have    |
+
+## Considerations/Constraints
+
+1. Virtual networks should be created to connect the nodes to the routers.
+2. Lab routers must match the hybrid ASN layout: leafs AS **65000**;
+   spines and router-0 AS **64999**, with eBGP on spine↔leaf links. In CI this
+   is set via `cifmw_bgp_*` in the `ci-framework-jobs` `bgp_dt05` scenario.
+3. The spine/leaf topology separates the nodes into different L2
+   network segments, called racks. Each rack includes two leaves, some OCP
+   nodes and some EDPM nodes.
+4. The OpenStack services running on the EDPM nodes are installed using the BGP
+   network, i.e. the OpenStack services running on OCP nodes connect to the
+   OpenStack services running on EDPM nodes using BGP. There is no direct L2
+   network connectivity between them. OCP version 4.18 or higher is required
+   because the OpenStack Operators use the frr-k8s feature for this and frr-k8s
+   is not available in OCP 4.16.
+5. Once OpenStack is installed on them, both dataplane and controlplane
+   connections are achieved using the BGP protocol.
+6. Tests are executed from the OCP worker to verify external connectivity.
+
+## Stages
+
+All stages must be executed in the order listed below. Everything is required
+unless otherwise indicated.
+
+1. [Configure taints on the OCP worker](../bgp_dt01/configure-taints.md)
+2. [Disable RP filters on OCP nodes](../bgp_dt01/disable-rp-filters.md)
+3. [Install the OpenStack K8S operators and their dependencies](../../../common/)
+4. [Apply metallb customization required to run a speaker pod on the OCP tester node](metallb/)
+5. [Configuring networking and deploy the OpenStack control plane](control-plane.md)
+6. [Create BGPConfiguration after controlplane is deployed](../bgp_dt01/bgp-configuration.md)
+7. [Configure and deploy the dataplane - networker and compute nodes](data-plane.md)

--- a/examples/dt/bgp_dt05/control-plane.md
+++ b/examples/dt/bgp_dt05/control-plane.md
@@ -1,0 +1,68 @@
+# Configuring networking and deploy the OpenStack control plane
+
+## Assumptions
+
+- A storage class called `local-storage` should already exist.
+- An infrastructure of spine/leaf routers exists, is properly connected to the
+  OCP nodes. Leaf routers use ASN **65000** (iBGP with MetalLB/EDPM); spines
+  and router-0 use ASN **64999** with eBGP on spine↔leaf links (see README).
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the bgp_dt05/control-plane directory
+```
+cd architecture/examples/dt/bgp_dt05/control-plane
+```
+Edit the [networking/nncp/values.yaml](control-plane/networking/nncp/values.yaml) and
+[service-values.yaml](control-plane/service-values.yaml) files to suit
+your environment.
+```
+vi networking/nncp/values.yaml
+vi service-values.yaml
+```
+
+## Apply node network configuration
+
+Generate the node network configuration
+```
+kustomize build networking/nncp > nncp.yaml
+```
+Apply the NNCP CRs
+```
+oc apply -f nncp.yaml
+```
+Wait for NNCPs to be available
+```
+oc wait nncp -l osp/nncm-config-type=standard --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured --timeout=300s
+```
+
+## Apply networking configuration
+
+Generate the remaining networking configuration
+```
+kustomize build networking > networking.yaml
+```
+Apply the networking CRs
+```
+oc apply -f networking.yaml
+```
+
+## Apply control-plane configuration
+
+Generate the control-plane CRs
+```
+kustomize build > control-plane.yaml
+```
+Apply the CRs
+```
+oc apply -f control-plane.yaml
+```
+
+Wait for control plane to be available
+```
+oc wait osctlplane controlplane --for condition=Ready --timeout=600s
+```

--- a/examples/dt/bgp_dt05/control-plane/kustomization.yaml
+++ b/examples/dt/bgp_dt05/control-plane/kustomization.yaml
@@ -1,0 +1,208 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../dt/bgp/
+
+resources:
+  - networking/nncp/values.yaml
+  - service-values.yaml
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+patches:
+  # with BGP, ovnController has to be disabled from OCP nodes
+  - target:
+      kind: OpenStackControlPlane
+      name: controlplane
+    patch: |-
+      - op: remove
+        path: /spec/ovn/template/ovnController
+
+replacements:
+  # BGP peer IP addresses
+  # node3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-3-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-3-1
+        fieldPaths:
+          - spec.peerAddress
+  # node4
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-4-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-4-1
+        fieldPaths:
+          - spec.peerAddress
+  # node5
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-5-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-5-1
+        fieldPaths:
+          - spec.peerAddress
+  # node6
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-6-0
+        fieldPaths:
+          - spec.peerAddress
+  # BGP NetworkAttachmentDefinition customization
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node6
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-worker-3
+        fieldPaths:
+          - spec.config
+  # configure neutron customServiceConfig
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.neutron.customServiceConfig
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.neutron.template.customServiceConfig
+        options:
+          create: true
+
+  # configure octavia nodeSelector
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.octavia.nodeSelector
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.octavia.template.nodeSelector
+        options:
+          create: true
+
+  # configure designate
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate-redis.replicas
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.redis.templates.designate-redis.replicas
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate-redis.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.redis.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.designate.enabled
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate.bind9Services
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.designate.template.designateBackendbind9.override
+        options:
+          create: true
+
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.designate.nsRecords
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.designate.template.nsRecords
+        options:
+          create: true

--- a/examples/dt/bgp_dt05/control-plane/networking/designateext_metallb.yaml
+++ b/examples/dt/bgp_dt05/control-plane/networking/designateext_metallb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: designateext
+  labels:
+    osp/lb-addresses-type: standard
+spec:
+  addresses:
+    - __replaced__

--- a/examples/dt/bgp_dt05/control-plane/networking/kustomization.yaml
+++ b/examples/dt/bgp_dt05/control-plane/networking/kustomization.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bgp/networking
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+      - path: metadata/name
+        kind: Namespace
+        create: true
+
+resources:
+  - nncp/values.yaml
+  - metallb_bgppeers.yaml
+  - ocp_networks_netattach.yaml
+  # designate IPAddressPool not needed until OSPRH-26878 is fixed
+  # - designateext_metallb.yaml
+
+patches:
+  # Add BGPPeer to BGPAdvertisement
+  - target:
+      kind: BGPAdvertisement
+    patch: |-
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-3-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-3-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-4-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-4-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-5-0
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-5-1
+      - op: add
+        path: /spec/peers/-
+        value: bgp-peer-node-6-0
+  - target:
+      kind: NetworkAttachmentDefinition
+      labelSelector: "osp/net-attach-def-type=bgp"
+    path: ocp_network_template.yaml
+  # All L2Advertisements are removed
+  - target:
+      kind: L2Advertisement
+    patch: |-
+      kind: L2Advertisement
+      metadata:
+        name: .*
+      $patch: delete
+  # designate IPAddressPool not needed until OSPRH-26878 is fixed
+  # Add designateext to BGPAdvertisement
+  # - target:
+  #     kind: BGPAdvertisement
+  #   patch: |-
+  #     - op: add
+  #       path: /spec/ipAddressPools/-
+  #       value: designateext
+
+  # tenant IPAddressPool removed
+  - target:
+      kind: IPAddressPool
+      name: tenant
+    patch: |-
+      kind: IPAddressPool
+      metadata:
+        name: tenant
+      $patch: delete
+
+replacements:
+  # BGP peer IP addresses
+  # node3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-3-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-3-1
+        fieldPaths:
+          - spec.peerAddress
+  # node4
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-4-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-4-1
+        fieldPaths:
+          - spec.peerAddress
+  # node5
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-5-0
+        fieldPaths:
+          - spec.peerAddress
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_peers.1
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-5-1
+        fieldPaths:
+          - spec.peerAddress
+  # node6
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_peers.0
+    targets:
+      - select:
+          kind: BGPPeer
+          name: bgp-peer-node-6-0
+        fieldPaths:
+          - spec.peerAddress
+  # BGP NetworkAttachmentDefinition customization
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.net-attach-def.node6
+    targets:
+      - select:
+          kind: NetworkAttachmentDefinition
+          name: bgpnet-worker-3
+        fieldPaths:
+          - spec.config
+  # yamllint disable rule:comments-indentation
+  # designate NAD and IPAddressPool not needed until OSPRH-26878 is fixed
+  # Designate NAD
+  # - source:
+  #     kind: ConfigMap
+  #     name: network-values
+  #     fieldPath: data.designate.net-attach-def
+  #   targets:
+  #     - select:
+  #         kind: NetworkAttachmentDefinition
+  #         name: designate
+  #       fieldPaths:
+  #         - spec.config
+  # DesignateExt LB addresses
+  # - source:
+  #     kind: ConfigMap
+  #     name: network-values
+  #     fieldPath: data.designateext.lb_addresses
+  #   targets:
+  #     - select:
+  #         kind: IPAddressPool
+  #         name: designateext
+  #       fieldPaths:
+  #         - spec.addresses

--- a/examples/dt/bgp_dt05/control-plane/networking/metallb_bgppeers.yaml
+++ b/examples/dt/bgp_dt05/control-plane/networking/metallb_bgppeers.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-3-0
+  namespace: metallb-system
+spec:
+  myASN: 65000
+  peerASN: 65000
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-0"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-3-1
+  namespace: metallb-system
+spec:
+  myASN: 65000
+  peerASN: 65000
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-0"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-4-0
+  namespace: metallb-system
+spec:
+  myASN: 65000
+  peerASN: 65000
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-1"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-4-1
+  namespace: metallb-system
+spec:
+  myASN: 65000
+  peerASN: 65000
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-1"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-5-0
+  namespace: metallb-system
+spec:
+  myASN: 65000
+  peerASN: 65000
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-2"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-5-1
+  namespace: metallb-system
+spec:
+  myASN: 65000
+  peerASN: 65000
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-2"]
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-node-6-0
+  namespace: metallb-system
+spec:
+  myASN: 65000
+  peerASN: 65000
+  peerAddress: _replaced_
+  password: f00barZ
+  nodeSelectors:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: ["worker-3"]  # worker-3 has only one bgp-peer

--- a/examples/dt/bgp_dt05/control-plane/networking/nncp/.gitignore
+++ b/examples/dt/bgp_dt05/control-plane/networking/nncp/.gitignore
@@ -1,0 +1,1 @@
+nncp.yaml

--- a/examples/dt/bgp_dt05/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/dt/bgp_dt05/control-plane/networking/nncp/kustomization.yaml
@@ -1,0 +1,724 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+  # Set namespace to OpenStack on all namespaced objects without a namespace
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: _ignored_
+      namespace: openstack
+    setRoleBindingSubjects: none
+    unsetOnly: true
+    fieldSpecs:
+    - path: metadata/name
+      kind: Namespace
+      create: true
+
+components:
+  - ../../../../../../lib/nncp-l3
+
+resources:
+  - values.yaml
+  - ocp_worker_nodes_nncp.yaml
+
+patches:
+  # Add BGP, octavia and designate interfaces
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 1
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+      name: "node-[3-5]"  # node-6 does not need a second BGP interface
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: BGP interface 2
+          ipv4:
+            address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            enabled: false
+          mtu: 1500
+          name: _replaced_
+          state: up
+          type: ethernet
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: loopback interface
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          ipv6:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+            dhcp: false
+          name: _replaced_
+          mtu: 65536
+          state: up
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Octavia bridge
+          mtu: 1500
+          name: octavia
+          type: linux-bridge
+          state: up
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+  - target:
+      kind: NodeNetworkConfigurationPolicy
+    patch: |-
+      - op: add
+        path: /spec/desiredState/interfaces/-
+        value:
+          description: Designate bridge
+          mtu: 1500
+          name: designate
+          type: linux-bridge
+          state: up
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
+
+replacements:
+  # Node names (workers)
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-3
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-4
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-5
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.name
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: node-6
+        fieldPaths:
+          - metadata.name
+          - spec.nodeSelector.[kubernetes.io/hostname]
+
+  # configure ctlplane interfaces
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.iface
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.[type=ethernet].name
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.2.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.2.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.2.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.ctlplane_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.2.ipv4.address.0.ip
+
+  # ctlplane prefix-lengths
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.ctlplane.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.2.ipv4.address.0.prefix-length
+
+  # BGP worker-0/node-3 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-1/node-4 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-2/node-5 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.bgp_ip.1
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.ip
+  # BGP worker-3/node-6 IPs
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.bgp_ip.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.loopback_ip
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.ip
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.loopback_ipv6
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv6.address.0.ip
+
+  # BGP values
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.ifaces.0
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.4.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.ifaces.1
+    targets:  # target all nodes except worker-3 (regexs do not seem to work on select.name value)
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.iface
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.name
+      - select:  # in case of worker-3, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.name
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.prefix-length
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.bgp.prefix-length-worker-3
+    targets:
+      - select:  # in case of worker-3, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.4.ipv4.address.0.prefix-length
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.prefix-length
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+      - select:  # in case of worker-3, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv4.address.0.prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.loopback.prefix-length-ipv6
+    targets:  # regexs do not seem to work on select.name value
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv6.address.0.prefix-length
+      - select:  # in case of worker-3, there is one less interfaces
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.5.ipv6.address.0.prefix-length
+  # Overwrite worker-3 base routes
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_6.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.routes
+
+  # NEW L3 ROUTES
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_3.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_4.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.routes
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.node_5.routes
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.routes
+
+  # internalapi bridge gateway IP and prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.0.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.0.ipv4.address.0.prefix-length
+
+  # storage bridge gateway IP and prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.1.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.1.ipv4.address.0.prefix-length
+
+  # octavia bridge gateway IP and prefix-length
+  # octavia is at index 7 for workers 0-2 (which have 2 BGP ifaces) and index 6 for worker-3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+
+  # designate bridge gateway IP and prefix-length
+  # designate is at index 8 for workers 0-2 and index 7 for worker-3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length

--- a/examples/dt/bgp_dt05/control-plane/networking/nncp/ocp_worker_nodes_nncp.yaml
+++ b/examples/dt/bgp_dt05/control-plane/networking/nncp/ocp_worker_nodes_nncp.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-3
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-4
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-5
+  labels:
+    osp/nncm-config-type: standard
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: node-6
+  labels:
+    osp/nncm-config-type: standard

--- a/examples/dt/bgp_dt05/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/bgp_dt05/control-plane/networking/nncp/values.yaml
@@ -1,0 +1,624 @@
+---
+# local-config: referenced, but not emitted by kustomize
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # nodes
+  node_3:
+    name: worker-0
+    internalapi_ip: 172.17.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+    bgp_ip:
+      - 100.64.0.10
+      - 100.65.0.10
+    bgp_peers:
+      - 100.64.0.9
+      - 100.65.0.9
+    loopback_ip: 99.99.0.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:13
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.0.9
+          next-hop-interface: enp8s0
+          weight: 200
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.0.9
+          next-hop-interface: enp9s0
+          weight: 200
+        # routes to octavia mgmt network
+        - destination: 172.24.0.0/16
+          next-hop-address: 100.64.0.9
+          next-hop-interface: enp8s0
+          weight: 200
+        - destination: 172.24.0.0/16
+          next-hop-address: 100.65.0.9
+          next-hop-interface: enp9s0
+          weight: 200
+  node_4:
+    name: worker-1
+    internalapi_ip: 172.17.0.6
+    ctlplane_ip: 192.168.122.11
+    storage_ip: 172.18.0.6
+    bgp_ip:
+      - 100.64.1.10
+      - 100.65.1.10
+    bgp_peers:
+      - 100.64.1.9
+      - 100.65.1.9
+    loopback_ip: 99.99.1.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:23
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.1.9
+          next-hop-interface: enp8s0
+          weight: 200
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.1.9
+          next-hop-interface: enp9s0
+          weight: 200
+        # routes to octavia mgmt network
+        - destination: 172.24.0.0/16
+          next-hop-address: 100.64.1.9
+          next-hop-interface: enp8s0
+          weight: 200
+        - destination: 172.24.0.0/16
+          next-hop-address: 100.65.1.9
+          next-hop-interface: enp9s0
+          weight: 200
+  node_5:
+    name: worker-2
+    internalapi_ip: 172.17.0.7
+    ctlplane_ip: 192.168.122.12
+    storage_ip: 172.18.0.7
+    bgp_ip:
+      - 100.64.2.10
+      - 100.65.2.10
+    bgp_peers:
+      - 100.64.2.9
+      - 100.65.2.9
+    loopback_ip: 99.99.2.3
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:33
+    routes:
+      config:
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.64.2.9
+          next-hop-interface: enp8s0
+          weight: 200
+        - destination: 99.99.0.0/16
+          next-hop-address: 100.65.2.9
+          next-hop-interface: enp9s0
+          weight: 200
+        # routes to octavia mgmt network
+        - destination: 172.24.0.0/16
+          next-hop-address: 100.64.2.9
+          next-hop-interface: enp8s0
+          weight: 200
+        - destination: 172.24.0.0/16
+          next-hop-address: 100.65.2.9
+          next-hop-interface: enp9s0
+          weight: 200
+  node_6:
+    name: worker-3
+    internalapi_ip: 172.17.0.8
+    ctlplane_ip: 192.168.122.13
+    storage_ip: 172.18.0.8
+    bgp_ip:
+      - 100.64.10.2
+    bgp_peers:
+      - 100.64.10.1
+    loopback_ip: 99.99.10.2
+    loopback_ipv6: f00d:f00d:f00d:f00d:f00d:f00d:f00d:43
+    base_if: enp7s0
+    routes:
+      config:
+        - destination: 192.168.133.0/24
+          next-hop-address: 100.64.10.1
+          next-hop-interface: enp8s0
+        # routes to octavia mgmt network
+        - destination: 172.24.0.0/16
+          next-hop-address: 100.64.10.1
+          next-hop-interface: enp8s0
+        # routes to designateext network
+        - destination: 172.34.0.0/16
+          next-hop-address: 100.64.10.1
+          next-hop-interface: enp8s0
+
+  # networks
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet0
+        routes:
+          - destination: 192.168.123.0/24
+            nexthop: 192.168.122.1
+          - destination: 192.168.124.0/24
+            nexthop: 192.168.122.1
+      - allocationRanges:
+          - end: 192.168.123.120
+            start: 192.168.123.100
+          - end: 192.168.123.170
+            start: 192.168.123.150
+        cidr: 192.168.123.0/24
+        gateway: 192.168.123.1
+        name: subnet1
+        routes:
+          - destination: 192.168.122.0/24
+            nexthop: 192.168.123.1
+          - destination: 192.168.124.0/24
+            nexthop: 192.168.123.1
+      - allocationRanges:
+          - end: 192.168.124.120
+            start: 192.168.124.100
+          - end: 192.168.124.170
+            start: 192.168.124.150
+        cidr: 192.168.124.0/24
+        gateway: 192.168.124.1
+        name: subnet2
+        routes:
+          - destination: 192.168.122.0/24
+            nexthop: 192.168.124.1
+          - destination: 192.168.123.0/24
+            nexthop: 192.168.124.1
+    prefix-length: 24
+    iface: enp7s0
+    mtu: 1500
+    lb_addresses:
+      - 192.168.125.80-192.168.125.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.125.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "bridge",
+        "bridge": "ctlplane",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.125.0/24",
+          "range_start": "192.168.125.30",
+          "range_end": "192.168.125.70"
+        }
+      }
+
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    gateway: 172.17.0.1
+    iface: internalapi
+    vlan: 20
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "bridge",
+        "bridge": "internalapi",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 1500
+    prefix-length: 24
+    gateway: 172.18.0.1
+    iface: storage
+    vlan: 21
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "bridge",
+        "bridge": "storage",
+        "isDefaultGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+  octavia:
+    dnsDomain: octavia.openstack.lab
+    subnets:
+      - allocationRanges:
+          - end: 172.23.0.250
+            start: 172.23.0.100
+        cidr: 172.23.0.0/24
+        name: subnet1
+        vlan: 23
+    mtu: 1500
+    prefix-length: 24
+    gateway: 172.23.0.1
+    vlan: 23
+    base_iface: enp7s0
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "octavia",
+        "type": "bridge",
+        "isDefaultGateway": true,
+        "isGateway": true,
+        "forceAddress": false,
+        "ipMasq": false,
+        "hairpinMode": true,
+        "bridge": "octavia",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.23.0.0/24",
+          "routes": [{
+               "dst": "172.24.0.0/16",
+               "gw": "172.23.0.1"
+          }],
+          "range_start": "172.23.0.30",
+          "range_end": "172.23.0.70",
+          "gateway": "172.23.0.1"
+        }
+      }
+
+  designate:
+    # only NAD is used for designate
+    prefix-length: 24
+    gateway: 172.26.0.1
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "designate",
+        "type": "macvlan",
+        "master": "designate",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.26.0.0/24",
+          "range_start": "172.26.0.30",
+          "range_end": "172.26.0.70"
+        }
+      }
+
+  designateext:
+    # only lb_addresses for the IPAddressPool are needed
+    lb_addresses:
+      - 172.34.0.80-172.34.0.90
+
+  bgp:
+    prefix-length: 30
+    prefix-length-worker-3: 24
+    ifaces:
+      - enp8s0
+      - enp9s0
+    asn: 65000
+    peer_asn: 65000
+    subnets:
+      bgpnet0:
+        - name: subnet0
+          allocationRanges:
+            - end: 100.64.0.6
+              start: 100.64.0.1
+          cidr: 100.64.0.0/29
+          gateway: 100.64.0.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.0.1
+        - name: subnet1
+          allocationRanges:
+            - end: 100.64.1.6
+              start: 100.64.1.1
+          cidr: 100.64.1.0/29
+          gateway: 100.64.1.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.1.1
+        - name: subnet2
+          allocationRanges:
+            - end: 100.64.2.6
+              start: 100.64.2.1
+          cidr: 100.64.2.0/29
+          gateway: 100.64.2.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.64.2.1
+      bgpnet1:
+        - name: subnet0
+          allocationRanges:
+            - end: 100.65.0.6
+              start: 100.65.0.1
+          cidr: 100.65.0.0/29
+          gateway: 100.65.0.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.0.1
+        - name: subnet1
+          allocationRanges:
+            - end: 100.65.1.6
+              start: 100.65.1.1
+          cidr: 100.65.1.0/29
+          gateway: 100.65.1.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.1.1
+        - name: subnet2
+          allocationRanges:
+            - end: 100.65.2.6
+              start: 100.65.2.1
+          cidr: 100.65.2.0/29
+          gateway: 100.65.2.1
+          routes:
+            - destination: 0.0.0.0/0
+              nexthop: 100.65.2.1
+      bgpmainnet:
+        - name: subnet0
+          cidr: 99.99.0.0/28
+          allocationRanges:
+            - end: 99.99.0.14
+              start: 99.99.0.2
+        - name: subnet1
+          cidr: 99.99.1.0/28
+          allocationRanges:
+            - end: 99.99.1.14
+              start: 99.99.1.2
+        - name: subnet2
+          cidr: 99.99.2.0/28
+          allocationRanges:
+            - end: 99.99.2.14
+              start: 99.99.2.2
+        - name: subnet10
+          cidr: 99.99.10.0/28
+          allocationRanges:
+            - end: 99.99.10.14
+              start: 99.99.10.2
+      bgpmainnetv6:
+        - name: subnet0
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0010/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:001e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
+        - name: subnet1
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0020/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:002e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0022
+        - name: subnet2
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0030/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:003e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0032
+        - name: subnet3
+          cidr: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0040/124
+          allocationRanges:
+            - end: f00d:f00d:f00d:f00d:f00d:f00d:f00d:004e
+              start: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0042
+    bgpdefs:
+      node3:
+        bgpnet0:
+          bgp_peer: 100.64.0.9
+          bgp_ip: 100.64.0.10
+        bgpnet1:
+          bgp_peer: 100.65.0.9
+          bgp_ip: 100.65.0.10
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.0.9
+              next-hop-interface: enp8s0
+              weight: 200
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.0.9
+              next-hop-interface: enp9s0
+              weight: 200
+            # ctlplane routes
+            - destination: 192.168.122.0/24
+              next-hop-address: 192.168.125.1
+              next-hop-interface: enp7s0
+            - destination: 192.168.123.0/24
+              next-hop-address: 192.168.125.1
+              next-hop-interface: enp7s0
+            - destination: 192.168.124.0/24
+              next-hop-address: 192.168.125.1
+              next-hop-interface: enp7s0
+            # routes to octavia mgmt network
+            - destination: 172.24.0.0/16
+              next-hop-address: 100.64.0.9
+              next-hop-interface: enp8s0
+              weight: 200
+            - destination: 172.24.0.0/16
+              next-hop-address: 100.65.0.9
+              next-hop-interface: enp9s0
+              weight: 200
+      node4:
+        bgpnet0:
+          bgp_peer: 100.64.1.9
+          bgp_ip: 100.64.1.10
+        bgpnet1:
+          bgp_peer: 100.65.1.9
+          bgp_ip: 100.65.1.10
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.1.9
+              next-hop-interface: enp8s0
+              weight: 200
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.1.9
+              next-hop-interface: enp9s0
+              weight: 200
+            # ctlplane routes
+            - destination: 192.168.122.0/24
+              next-hop-address: 192.168.125.1
+              next-hop-interface: enp7s0
+            - destination: 192.168.123.0/24
+              next-hop-address: 192.168.125.1
+              next-hop-interface: enp7s0
+            - destination: 192.168.124.0/24
+              next-hop-address: 192.168.125.1
+              next-hop-interface: enp7s0
+            # routes to octavia mgmt network
+            - destination: 172.24.0.0/16
+              next-hop-address: 100.64.1.9
+              next-hop-interface: enp8s0
+              weight: 200
+            - destination: 172.24.0.0/16
+              next-hop-address: 100.65.1.9
+              next-hop-interface: enp9s0
+              weight: 200
+      node5:
+        bgpnet0:
+          bgp_peer: 100.64.2.9
+          bgp_ip: 100.64.2.10
+        bgpnet1:
+          bgp_peer: 100.65.2.9
+          bgp_ip: 100.65.2.10
+        routes:
+          config:
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.64.2.9
+              next-hop-interface: enp8s0
+              weight: 200
+            - destination: 99.99.0.0/16
+              next-hop-address: 100.65.2.9
+              next-hop-interface: enp9s0
+              weight: 200
+            # ctlplane routes
+            - destination: 192.168.122.0/24
+              next-hop-address: 192.168.125.1
+              next-hop-interface: enp7s0
+            - destination: 192.168.123.0/24
+              next-hop-address: 192.168.125.1
+              next-hop-interface: enp7s0
+            - destination: 192.168.124.0/24
+              next-hop-address: 192.168.125.1
+              next-hop-interface: enp7s0
+            # routes to octavia mgmt network
+            - destination: 172.24.0.0/16
+              next-hop-address: 100.64.2.9
+              next-hop-interface: enp8s0
+              weight: 200
+            - destination: 172.24.0.0/16
+              next-hop-address: 100.65.2.9
+              next-hop-interface: enp9s0
+              weight: 200
+      node6:
+        bgpnet0:
+          bgp_peer: 100.64.10.1
+          bgp_ip: 100.64.10.2
+        routes:
+          config:
+            - destination: 192.168.133.0/24
+              next-hop-address: 100.64.10.1
+              next-hop-interface: enp8s0
+            # routes to octavia mgmt network
+            - destination: 172.24.0.0/16
+              next-hop-address: 100.64.10.1
+              next-hop-interface: enp8s0
+            # routes to designateext network
+            - destination: 172.34.0.0/16
+              next-hop-address: 100.64.10.1
+              next-hop-interface: enp8s0
+    net-attach-def:
+      node6: |
+        {
+          "cniVersion": "0.3.1",
+          "name": "bgpnet-worker-3",
+          "type": "macvlan",
+          "master": "enp8s0",
+          "ipam": {
+            "type": "whereabouts",
+            "range": "100.64.10.0/24",
+            "range_start": "100.64.10.10",
+            "range_end": "100.64.10.19",
+            "routes": [{
+              "dst": "192.168.133.0/24",
+              "gw": "100.64.10.1"
+            }, {
+              "dst": "172.24.0.0/16",
+              "gw": "100.64.10.1"
+            }, {
+              "dst": "172.34.0.0/16",
+              "gw": "100.64.10.1"
+            }]
+          }
+        }
+
+  loopback:
+    prefix-length: 32
+    prefix-length-ipv6: 128
+    iface: lo
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.125.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.125.1
+
+  routes:
+    config: []
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr

--- a/examples/dt/bgp_dt05/control-plane/networking/ocp_network_template.yaml
+++ b/examples/dt/bgp_dt05/control-plane/networking/ocp_network_template.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: nmstate.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: _ignored_
+spec:
+  config: |
+    _replaced_

--- a/examples/dt/bgp_dt05/control-plane/networking/ocp_networks_netattach.yaml
+++ b/examples/dt/bgp_dt05/control-plane/networking/ocp_networks_netattach.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgpnet-worker-3
+  labels:
+    osp/net: bgpnet-worker-3
+    osp/net-attach-def-type: bgp
+# designate NAD not needed until OSPRH-26878 is fixed
+# ---
+# apiVersion: k8s.cni.cncf.io/v1
+# kind: NetworkAttachmentDefinition
+# metadata:
+#   name: designate
+#   labels:
+#     osp/net: designate
+#     osp/net-attach-def-type: standard

--- a/examples/dt/bgp_dt05/control-plane/service-values.yaml
+++ b/examples/dt/bgp_dt05/control-plane/service-values.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # --- Fields required by lib/control-plane ---
+  preserveJobs: false
+  notificationsBus:
+    cluster: rabbitmq
+  tls:
+    caBundleSecretName: ""
+
+  # --- Below are VA/DT-specific data ---
+  glance:
+    customServiceConfig: |
+      [DEFAULT]
+      enabled_backends = default_backend:swift
+      [glance_store]
+      default_backend = default_backend
+      [default_backend]
+      swift_store_create_container_on_put = True
+      swift_store_auth_version = 3
+      swift_store_auth_address = {{ .KeystoneInternalURL }}
+      swift_store_endpoint_type = internalURL
+      swift_store_user = service:glance
+      swift_store_key = {{ .ServicePassword }}
+    default:
+      replicas: 1
+
+  swift:
+    enabled: true
+
+  octavia:
+    # octavia is disabled due to limitation with Native OVN BGP:
+    # with this feature, only one provider network can be configured, while
+    # octavia needs its own provider network.
+    enabled: false
+    amphoraImageContainerImage: quay.io/gthiemonge/octavia-amphora-image
+    apacheContainerImage: registry.redhat.io/ubi9/httpd-24:latest
+    octaviaAPI:
+      networkAttachments:
+        - internalapi
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+    octaviaHousekeeping:
+      networkAttachments:
+        - octavia
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+    octaviaHealthManager:
+      networkAttachments:
+        - octavia
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+    octaviaWorker:
+      networkAttachments:
+        - octavia
+      customServiceConfig: |
+        [controller_worker]
+        loadbalancer_topology=ACTIVE_STANDBY
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""
+
+  # designate disabled and designate parameters commented out due to OSPRH-26878
+  neutron:
+    customServiceConfig: |
+      [DEFAULT]
+      service_plugins = qos,ovn-router,trunk,segments,port_forwarding,log,placement,evpn
+      vlan_transparent = true
+      debug = true
+      dns_domain = example.org.
+      # external_dns_driver = designate
+      [ovs]
+      igmp_snooping_enable = true
+      # [designate]
+      # url = https://designate-internal.openstack.svc:9001/v2
+      # auth_type = password
+      # auth_url = {{ .KeystoneInternalURL }}
+      # username = {{ .ServiceUser }}
+      # password = {{ .ServicePassword }}
+      # project_name = service
+      # project_domain_name = Default
+      # user_domain_name = Default
+      # allow_reverse_dns_lookup = True
+      # ipv4_ptr_zone_prefix_size = 24
+      # ipv6_ptr_zone_prefix_size = 116
+      # ptr_zone_email = admin@example.org
+
+  designate-redis:
+    enabled: false
+    replicas: 1
+
+  designate:
+    enabled: false
+    nsRecords:
+      - hostname: ns1.example.org.
+        priority: 1
+      - hostname: ns2.example.org.
+        priority: 2
+    bind9Services:
+      services:
+        - metadata:
+            annotations:
+              metallb.universe.tf/address-pool: designateext
+              metallb.universe.tf/allow-shared-ip: designateext
+              metallb.universe.tf/LoadBalancerIPs: 172.34.0.80
+          spec:
+            type: LoadBalancer
+        - metadata:
+            annotations:
+              metallb.universe.tf/address-pool: designateext
+              metallb.universe.tf/allow-shared-ip: designateext
+              metallb.universe.tf/LoadBalancerIPs: 172.34.0.81
+          spec:
+            type: LoadBalancer
+        - metadata:
+            annotations:
+              metallb.universe.tf/address-pool: designateext
+              metallb.universe.tf/allow-shared-ip: designateext
+              metallb.universe.tf/LoadBalancerIPs: 172.34.0.82
+          spec:
+            type: LoadBalancer

--- a/examples/dt/bgp_dt05/data-plane.md
+++ b/examples/dt/bgp_dt05/data-plane.md
@@ -1,0 +1,101 @@
+# Configuring and deploying the dataplane - networker and compute nodes
+
+## Assumptions
+
+- The [control plane](control-plane.md) has been created and successfully deployed
+- An infrastructure of spine/leaf routers exists, is properly connected to the
+  pre-provisioned EDPM nodes. Leaf routers use ASN **65000** (iBGP with EDPM);
+  spines and router-0 use ASN **64999** with eBGP on spine↔leaf links
+  (see [README](README.md)).
+
+## Initialize
+
+Switch to the "openstack" namespace
+```
+oc project openstack
+```
+Change to the bgp_dt05/ directory
+```
+cd architecture/examples/dt/bgp_dt05/
+```
+Edit the networker values.yaml files corresponding to each rack (r0, r1 and r2)
+to suit your environment:
+
+- [edpm/networkers/r0/values.yaml](edpm/networkers/r0/values.yaml)
+- [edpm/networkers/r1/values.yaml](edpm/networkers/r1/values.yaml)
+- [edpm/networkers/r2/values.yaml](edpm/networkers/r2/values.yaml)
+
+```
+vi values.yaml
+```
+
+Edit the compute values.yaml files corresponding to each rack (r0, r1 and r2)
+to suit your environment:
+
+- [edpm/computes/r0/values.yaml](edpm/computes/r0/values.yaml)
+- [edpm/computes/r1/values.yaml](edpm/computes/r1/values.yaml)
+- [edpm/computes/r2/values.yaml](edpm/computes/r2/values.yaml)
+
+```
+vi values.yaml
+```
+
+## Create Networker and Compute Nodeset CRs
+
+Generate the networkers dataplane nodeset CRs for each rack.
+```
+kustomize build edpm/networkers/r0 > edpm-r0-networker-nodeset.yaml
+kustomize build edpm/networkers/r1 > edpm-r1-networker-nodeset.yaml
+kustomize build edpm/networkers/r2 > edpm-r2-networker-nodeset.yaml
+```
+Generate the computes dataplane nodeset CRs for each rack.
+```
+kustomize build edpm/computes/r0 > edpm-r0-compute-nodeset.yaml
+kustomize build edpm/computes/r1 > edpm-r1-compute-nodeset.yaml
+kustomize build edpm/computes/r2 > edpm-r2-compute-nodeset.yaml
+```
+
+## Create EDPM  Deployment CR
+
+Generate the dataplane deployment CR.
+```
+kustomize build edpm/deployment > edpm-deployment.yaml
+```
+
+## Apply the Nodeset CRs
+
+Apply the Networker nodeset CRs
+```
+oc apply -f edpm/networkers/r0/edpm-r0-networker-nodeset.yaml
+oc apply -f edpm/networkers/r1/edpm-r1-networker-nodeset.yaml
+oc apply -f edpm/networkers/r2/edpm-r2-networker-nodeset.yaml
+```
+Wait for Networker dataplane nodesets setup to finish
+```
+oc wait osdpns r0-networker-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r1-networker-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r2-networker-nodes --for condition=SetupReady --timeout=600s
+```
+Apply the Compute nodeset CRs
+```
+oc apply -f edpm/computes/r0/edpm-r0-compute-nodeset.yaml
+oc apply -f edpm/computes/r1/edpm-r1-compute-nodeset.yaml
+oc apply -f edpm/computes/r2/edpm-r2-compute-nodeset.yaml
+```
+Wait for Compute dataplane nodesets setup to finish
+```
+oc wait osdpns r0-compute-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r1-compute-nodes --for condition=SetupReady --timeout=600s
+oc wait osdpns r2-compute-nodes --for condition=SetupReady --timeout=600s
+```
+
+## Apply the deployment
+
+Start the deployment
+```
+oc apply -f edpm/deployment/edpm-deployment.yaml
+```
+Wait for dataplane deployment to finish
+```
+oc wait osdpd edpm-deployment --for condition=Ready --timeout=2400s
+```

--- a/examples/dt/bgp_dt05/edpm/computes/r0/kustomization.yaml
+++ b/examples/dt/bgp_dt05/edpm/computes/r0/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r0-compute-nodes

--- a/examples/dt/bgp_dt05/edpm/computes/r0/values.yaml
+++ b/examples/dt/bgp_dt05/edpm/computes/r0/values.yaml
@@ -1,0 +1,192 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ bgpmainnet_ip }}"
+        edpm_ovn_bridge_mappings:
+          - "datacentre:br-ex"
+          # commented out due to OSPRH-30907 - "octavia:br-octavia"
+        edpm_frr_bgp_asn: 65000
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks_scope: internal
+        edpm_frr_bgp_l2vpn: true
+        edpm_frr_bgp_l2vpn_uplink_activate: true
+        # TODO: empty list is a required workaround — edpm_frr role default
+        # peers create an empty evpn-peer group (frr.conf.j2 never emits
+        # neighbor entries from edpm_frr_bgp_l2vpn_peers). Fix in edpm_frr:
+        # emit neighbors from that list and/or default it to [].
+        edpm_frr_bgp_l2vpn_peers: []
+        bgp_bridges:
+          - br-bgp-0
+          - br-bgp-1
+        edpm_neutron_ovn_agent_bgp_peer_bridges: "{{ bgp_bridges | join(',') }}"
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 65000
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
+        edpm_neutron_ovn_agent_ovn_evpn_child_vxlan_port: 60010
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r0-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+          # commented out due to OSPRH-30907
+          # - type: ovs_bridge
+          #   name: br-octavia
+          #   use_dhcp: false
+          #   use_dhcpv6: true  # needed to enable IPv6 on bridges
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: ovs_bridge
+            name: {{ bgp_bridges[0] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet0_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic3
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: ovs_bridge
+            name: {{ bgp_bridges[1] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet1_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic4
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ bgpmainnet_ip }}/32
+            - ip_netmask: {{ bgpmainnetv6_ip }}/128
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r0-compute-0:
+        hostName: edpm-r0-compute-0
+        ansible:
+          ansibleHost: 192.168.122.100
+          ansibleVars:
+            edpm_frr_bgp_peers:
+              - 100.64.0.1
+              - 100.65.0.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.0.2
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.0.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.0.2
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
+    services:
+      - bootstrap
+      - download-cache
+      - install-os
+      - configure-os
+      - configure-network
+      - frr
+      - validate-network
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-ovn
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp_dt05/edpm/computes/r1/kustomization.yaml
+++ b/examples/dt/bgp_dt05/edpm/computes/r1/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r1-compute-nodes

--- a/examples/dt/bgp_dt05/edpm/computes/r1/values.yaml
+++ b/examples/dt/bgp_dt05/edpm/computes/r1/values.yaml
@@ -1,0 +1,192 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ bgpmainnet_ip }}"
+        edpm_ovn_bridge_mappings:
+          - "datacentre:br-ex"
+          # commented out due to OSPRH-30907 - "octavia:br-octavia"
+        edpm_frr_bgp_asn: 65000
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks_scope: internal
+        edpm_frr_bgp_l2vpn: true
+        edpm_frr_bgp_l2vpn_uplink_activate: true
+        # TODO: empty list is a required workaround — edpm_frr role default
+        # peers create an empty evpn-peer group (frr.conf.j2 never emits
+        # neighbor entries from edpm_frr_bgp_l2vpn_peers). Fix in edpm_frr:
+        # emit neighbors from that list and/or default it to [].
+        edpm_frr_bgp_l2vpn_peers: []
+        bgp_bridges:
+          - br-bgp-0
+          - br-bgp-1
+        edpm_neutron_ovn_agent_bgp_peer_bridges: "{{ bgp_bridges | join(',') }}"
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 65000
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
+        edpm_neutron_ovn_agent_ovn_evpn_child_vxlan_port: 60010
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r1-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+          # commented out due to OSPRH-30907
+          # - type: ovs_bridge
+          #   name: br-octavia
+          #   use_dhcp: false
+          #   use_dhcpv6: true  # needed to enable IPv6 on bridges
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: ovs_bridge
+            name: {{ bgp_bridges[0] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet0_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic3
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: ovs_bridge
+            name: {{ bgp_bridges[1] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet1_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic4
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ bgpmainnet_ip }}/32
+            - ip_netmask: {{ bgpmainnetv6_ip }}/128
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r1-compute-0:
+        hostName: edpm-r1-compute-0
+        ansible:
+          ansibleHost: 192.168.123.100
+          ansibleVars:
+            edpm_frr_bgp_peers:
+              - 100.64.1.1
+              - 100.65.1.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.123.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.1.2
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.1.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.1.2
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
+    services:
+      - bootstrap
+      - download-cache
+      - install-os
+      - configure-os
+      - configure-network
+      - frr
+      - validate-network
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-ovn
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp_dt05/edpm/computes/r2/kustomization.yaml
+++ b/examples/dt/bgp_dt05/edpm/computes/r2/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r2-compute-nodes

--- a/examples/dt/bgp_dt05/edpm/computes/r2/values.yaml
+++ b/examples/dt/bgp_dt05/edpm/computes/r2/values.yaml
@@ -1,0 +1,192 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ bgpmainnet_ip }}"
+        edpm_ovn_bridge_mappings:
+          - "datacentre:br-ex"
+          # commented out due to OSPRH-30907 - "octavia:br-octavia"
+        edpm_frr_bgp_asn: 65000
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks_scope: internal
+        edpm_frr_bgp_l2vpn: true
+        edpm_frr_bgp_l2vpn_uplink_activate: true
+        # TODO: empty list is a required workaround — edpm_frr role default
+        # peers create an empty evpn-peer group (frr.conf.j2 never emits
+        # neighbor entries from edpm_frr_bgp_l2vpn_peers). Fix in edpm_frr:
+        # emit neighbors from that list and/or default it to [].
+        edpm_frr_bgp_l2vpn_peers: []
+        bgp_bridges:
+          - br-bgp-0
+          - br-bgp-1
+        edpm_neutron_ovn_agent_bgp_peer_bridges: "{{ bgp_bridges | join(',') }}"
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 65000
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
+        edpm_neutron_ovn_agent_ovn_evpn_child_vxlan_port: 60010
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r2-compute-0:
+            nic2: 6a:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+          # commented out due to OSPRH-30907
+          # - type: ovs_bridge
+          #   name: br-octavia
+          #   use_dhcp: false
+          #   use_dhcpv6: true  # needed to enable IPv6 on bridges
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: ovs_bridge
+            name: {{ bgp_bridges[0] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet0_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic3
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: ovs_bridge
+            name: {{ bgp_bridges[1] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet1_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic4
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ bgpmainnet_ip }}/32
+            - ip_netmask: {{ bgpmainnetv6_ip }}/128
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r2-compute-0:
+        hostName: edpm-r2-compute-0
+        ansible:
+          ansibleHost: 192.168.124.100
+          ansibleVars:
+            edpm_frr_bgp_peers:
+              - 100.64.2.1
+              - 100.65.2.1
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.124.100
+            name: CtlPlane
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet2
+            fixedIP: 100.64.2.2
+          - name: Bgpnet1
+            subnetName: subnet2
+            fixedIP: 100.65.2.2
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.2.2
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033
+    services:
+      - bootstrap
+      - download-cache
+      - install-os
+      - configure-os
+      - configure-network
+      - frr
+      - validate-network
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-ovn
+      - libvirt
+      - nova
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp_dt05/edpm/deployment/kustomization.yaml
+++ b/examples/dt/bgp_dt05/edpm/deployment/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../dt/bgp/edpm/deployment
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/deployment/ with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: edpm-deployment-values
+      fieldPath: data.nodeSets
+    targets:
+      - select:
+          kind: OpenStackDataPlaneDeployment
+        fieldPaths:
+          - spec.nodeSets

--- a/examples/dt/bgp_dt05/edpm/deployment/values.yaml
+++ b/examples/dt/bgp_dt05/edpm/deployment/values.yaml
@@ -1,0 +1,16 @@
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeSets:
+    - r0-networker-nodes
+    - r1-networker-nodes
+    - r2-networker-nodes
+    - r0-compute-nodes
+    - r1-compute-nodes
+    - r2-compute-nodes

--- a/examples/dt/bgp_dt05/edpm/networkers/r0/kustomization.yaml
+++ b/examples/dt/bgp_dt05/edpm/networkers/r0/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r0-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/bgp_dt05/edpm/networkers/r0/values.yaml
+++ b/examples/dt/bgp_dt05/edpm/networkers/r0/values.yaml
@@ -1,0 +1,192 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ bgpmainnet_ip }}"
+        edpm_ovn_bridge_mappings:
+          - "datacentre:br-ex"
+          # commented out due to OSPRH-30907 - "octavia:br-octavia"
+        edpm_frr_bgp_asn: 65000
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks_scope: internal
+        edpm_frr_bgp_l2vpn: true
+        edpm_frr_bgp_l2vpn_uplink_activate: true
+        # TODO: empty list is a required workaround — edpm_frr role default
+        # peers create an empty evpn-peer group (frr.conf.j2 never emits
+        # neighbor entries from edpm_frr_bgp_l2vpn_peers). Fix in edpm_frr:
+        # emit neighbors from that list and/or default it to [].
+        edpm_frr_bgp_l2vpn_peers: []
+        bgp_bridges:
+          - br-bgp-0
+          - br-bgp-1
+        edpm_neutron_ovn_agent_bgp_peer_bridges: "{{ bgp_bridges | join(',') }}"
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 65000
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
+        edpm_neutron_ovn_agent_ovn_evpn_child_vxlan_port: 60010
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r0-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+          # commented out due to OSPRH-30907
+          # - type: ovs_bridge
+          #   name: br-octavia
+          #   use_dhcp: false
+          #   use_dhcpv6: true  # needed to enable IPv6 on bridges
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: ovs_bridge
+            name: {{ bgp_bridges[0] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet0_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic3
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: ovs_bridge
+            name: {{ bgp_bridges[1] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet1_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic4
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ bgpmainnet_ip }}/32
+            - ip_netmask: {{ bgpmainnetv6_ip }}/128
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r0-networker-0:
+        hostName: edpm-r0-networker-0
+        ansible:
+          ansibleHost: 192.168.122.200
+          ansibleVars:
+            edpm_frr_bgp_peers:
+              - 100.64.0.5
+              - 100.65.0.5
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.122.200
+            name: CtlPlane
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet0
+            fixedIP: 100.64.0.6
+          - name: Bgpnet1
+            subnetName: subnet0
+            fixedIP: 100.65.0.6
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.0.3
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0013
+    services:
+      - bootstrap
+      - download-cache
+      - install-os
+      - configure-os
+      - configure-network
+      - frr
+      - validate-network
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-ovn
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp_dt05/edpm/networkers/r1/kustomization.yaml
+++ b/examples/dt/bgp_dt05/edpm/networkers/r1/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r1-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/bgp_dt05/edpm/networkers/r1/values.yaml
+++ b/examples/dt/bgp_dt05/edpm/networkers/r1/values.yaml
@@ -1,0 +1,192 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ bgpmainnet_ip }}"
+        edpm_ovn_bridge_mappings:
+          - "datacentre:br-ex"
+          # commented out due to OSPRH-30907 - "octavia:br-octavia"
+        edpm_frr_bgp_asn: 65000
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks_scope: internal
+        edpm_frr_bgp_l2vpn: true
+        edpm_frr_bgp_l2vpn_uplink_activate: true
+        # TODO: empty list is a required workaround — edpm_frr role default
+        # peers create an empty evpn-peer group (frr.conf.j2 never emits
+        # neighbor entries from edpm_frr_bgp_l2vpn_peers). Fix in edpm_frr:
+        # emit neighbors from that list and/or default it to [].
+        edpm_frr_bgp_l2vpn_peers: []
+        bgp_bridges:
+          - br-bgp-0
+          - br-bgp-1
+        edpm_neutron_ovn_agent_bgp_peer_bridges: "{{ bgp_bridges | join(',') }}"
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 65000
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
+        edpm_neutron_ovn_agent_ovn_evpn_child_vxlan_port: 60010
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r1-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+          # commented out due to OSPRH-30907
+          # - type: ovs_bridge
+          #   name: br-octavia
+          #   use_dhcp: false
+          #   use_dhcpv6: true  # needed to enable IPv6 on bridges
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: ovs_bridge
+            name: {{ bgp_bridges[0] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet0_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic3
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: ovs_bridge
+            name: {{ bgp_bridges[1] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet1_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic4
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ bgpmainnet_ip }}/32
+            - ip_netmask: {{ bgpmainnetv6_ip }}/128
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r1-networker-0:
+        hostName: edpm-r1-networker-0
+        ansible:
+          ansibleHost: 192.168.123.200
+          ansibleVars:
+            edpm_frr_bgp_peers:
+              - 100.64.1.5
+              - 100.65.1.5
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.123.200
+            name: CtlPlane
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet1
+            fixedIP: 100.64.1.6
+          - name: Bgpnet1
+            subnetName: subnet1
+            fixedIP: 100.65.1.6
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.1.3
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0023
+    services:
+      - bootstrap
+      - download-cache
+      - install-os
+      - configure-os
+      - configure-network
+      - frr
+      - validate-network
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-ovn
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp_dt05/edpm/networkers/r2/kustomization.yaml
+++ b/examples/dt/bgp_dt05/edpm/networkers/r2/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../../dt/bgp/edpm/nodeset
+  ## It's possible to replace ../../../../../../dt/bgp/edpm/nodeset with a git checkout URL as per:
+  ## https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
+
+resources:
+  - values.yaml
+
+patches:
+  - target:
+      kind: OpenStackDataPlaneNodeSet
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: r2-networker-nodes
+
+  - target:
+      kind: Secret
+      name: nova-migration-ssh-key
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          config.kubernetes.io/local-config: true

--- a/examples/dt/bgp_dt05/edpm/networkers/r2/values.yaml
+++ b/examples/dt/bgp_dt05/edpm/networkers/r2/values.yaml
@@ -1,0 +1,192 @@
+# yamllint disable rule:line-length
+# local-config: referenced, but not emitted by kustomize
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: CHANGEME
+    # The private key that will have access to the dataplane computes via SSH
+    private: CHANGEME2
+    # The public key that will have access to the dataplane computes via SSH
+    public: CHANGEME3
+  nodeset:
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+        edpm_ovn_encap_ip: "{{ bgpmainnet_ip }}"
+        edpm_ovn_bridge_mappings:
+          - "datacentre:br-ex"
+          # commented out due to OSPRH-30907 - "octavia:br-octavia"
+        edpm_frr_bgp_asn: 65000
+        edpm_frr_bgp_ipv4_src_network: bgpmainnet
+        edpm_frr_bgp_ipv6_src_network: bgpmainnetv6
+        edpm_frr_bgp_neighbor_password: f00barZ
+        edpm_frr_bgp_uplinks_scope: internal
+        edpm_frr_bgp_l2vpn: true
+        edpm_frr_bgp_l2vpn_uplink_activate: true
+        # TODO: empty list is a required workaround — edpm_frr role default
+        # peers create an empty evpn-peer group (frr.conf.j2 never emits
+        # neighbor entries from edpm_frr_bgp_l2vpn_peers). Fix in edpm_frr:
+        # emit neighbors from that list and/or default it to [].
+        edpm_frr_bgp_l2vpn_peers: []
+        bgp_bridges:
+          - br-bgp-0
+          - br-bgp-1
+        edpm_neutron_ovn_agent_bgp_peer_bridges: "{{ bgp_bridges | join(',') }}"
+        edpm_neutron_ovn_agent_agent_extensions: "metadata,ovn-evpn"
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_as: 65000
+        edpm_neutron_ovn_agent_ovn_evpn_bgp_local_interface: br-bgp-0
+        edpm_neutron_ovn_agent_ovn_evpn_child_vxlan_port: 60010
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
+        # conntrack is necessary for some tobiko tests
+        edpm_bootstrap_command: |
+          dnf -y install conntrack-tools
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+          edpm-r2-networker-0:
+            nic2: 6d:fe:54:3f:8a:02  # CHANGEME
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+          # commented out due to OSPRH-30907
+          # - type: ovs_bridge
+          #   name: br-octavia
+          #   use_dhcp: false
+          #   use_dhcpv6: true  # needed to enable IPv6 on bridges
+          - type: interface
+            name: nic1
+            use_dhcp: true
+            defroute: false
+          - type: interface
+            name: nic2
+            use_dhcp: false
+            defroute: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+          - type: ovs_bridge
+            name: {{ bgp_bridges[0] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet0_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic3
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: ovs_bridge
+            name: {{ bgp_bridges[1] }}
+            use_dhcp: false
+            use_dhcpv6: true  # needed to enable IPv6 on bridges
+            addresses:
+              - ip_netmask: {{ bgpnet1_ip }}/30
+            defroute: false
+            members:
+              - type: interface
+                name: nic4
+                # force the MAC address of the bridge to this interface
+                primary: true
+          - type: interface
+            name: lo
+            addresses:
+            - ip_netmask: {{ bgpmainnet_ip }}/32
+            - ip_netmask: {{ bgpmainnetv6_ip }}/128
+        edpm_enable_chassis_gw: true
+        edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+        neutron_physical_bridge_name: br-ex
+    networks:
+      - defaultRoute: true
+        name: CtlPlane
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet0
+      - name: BgpNet1
+        subnetName: subnet0
+      - name: BgpMainNet
+        subnetName: subnet0
+      - name: BgpMainNetV6
+        subnetName: subnet0
+      - name: BgpNet0
+        subnetName: subnet1
+      - name: BgpNet1
+        subnetName: subnet1
+      - name: BgpMainNet
+        subnetName: subnet1
+      - name: BgpMainNetV6
+        subnetName: subnet1
+      - name: BgpNet0
+        subnetName: subnet2
+      - name: BgpNet1
+        subnetName: subnet2
+      - name: BgpMainNet
+        subnetName: subnet2
+      - name: BgpMainNetV6
+        subnetName: subnet2
+    nodes:
+      edpm-r2-networker-0:
+        hostName: edpm-r2-networker-0
+        ansible:
+          ansibleHost: 192.168.124.200
+          ansibleVars:
+            edpm_frr_bgp_peers:
+              - 100.64.2.5
+              - 100.65.2.5
+        networks:
+          - defaultRoute: true
+            fixedIP: 192.168.124.200
+            name: CtlPlane
+            subnetName: subnet1
+          - name: Bgpnet0
+            subnetName: subnet2
+            fixedIP: 100.64.2.6
+          - name: Bgpnet1
+            subnetName: subnet2
+            fixedIP: 100.65.2.6
+          - name: Bgpmainnet
+            subnetName: subnet1
+            fixedIP: 99.99.2.3
+          - name: BgpmainnetV6
+            subnetName: subnet1
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0033
+    services:
+      - bootstrap
+      - download-cache
+      - install-os
+      - configure-os
+      - configure-network
+      - frr
+      - validate-network
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ovn
+      - neutron-ovn
+  nova:
+    migration:
+      ssh_keys:
+        private: CHANGEME4
+        public: CHANGEME5

--- a/examples/dt/bgp_dt05/metallb/README.md
+++ b/examples/dt/bgp_dt05/metallb/README.md
@@ -1,0 +1,16 @@
+# MetalLB
+
+Observe CRs which will be generated.
+```
+kustomize build examples/dt/bgp_dt05/metallb/
+```
+
+Apply the metallb kustomization from this directory.
+```
+oc apply -k examples/dt/bgp_dt05/metallb/
+```
+
+Then, check that a speaker is running on the OCP tester node.
+```
+oc -n metallb-system wait pod -l component=speaker --field-selector=spec.host=worker-3 --for condition=Ready --timeout=300s
+```

--- a/examples/dt/bgp_dt05/metallb/kustomization.yaml
+++ b/examples/dt/bgp_dt05/metallb/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../lib/metallb
+
+patches:
+  - target:
+      kind: MetalLB
+      name: metallb
+      namespace: metallb-system
+    patch: |-
+      - op: add
+        path: /spec/speakerTolerations
+        value:
+          - key: "testOperator"
+            value: "true"
+            effect: "NoSchedule"
+          - key: "testOperator"
+            value: "true"
+            effect: "NoExecute"

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,6 +7,7 @@
       - rhoso-architecture-validate-bgp_dt01
       - rhoso-architecture-validate-bgp_dt02
       - rhoso-architecture-validate-bgp_dt04_ipv6
+      - rhoso-architecture-validate-bgp_dt05
       - rhoso-architecture-validate-bmo01
       - rhoso-architecture-validate-dcn
       - rhoso-architecture-validate-dt-sharded

--- a/zuul.d/validations.yaml
+++ b/zuul.d/validations.yaml
@@ -82,6 +82,24 @@
       cifmw_architecture_scenario: bgp_dt04_ipv6
 - job:
     files:
+    - automation/mocks/bgp_dt05.yaml
+    - examples/dt/bgp_dt05/control-plane
+    - examples/dt/bgp_dt05/control-plane/networking
+    - examples/dt/bgp_dt05/control-plane/networking/nncp
+    - examples/dt/bgp_dt05/edpm/computes/r0
+    - examples/dt/bgp_dt05/edpm/computes/r1
+    - examples/dt/bgp_dt05/edpm/computes/r2
+    - examples/dt/bgp_dt05/edpm/deployment
+    - examples/dt/bgp_dt05/edpm/networkers/r0
+    - examples/dt/bgp_dt05/edpm/networkers/r1
+    - examples/dt/bgp_dt05/edpm/networkers/r2
+    - lib
+    name: rhoso-architecture-validate-bgp_dt05
+    parent: rhoso-architecture-base-job
+    vars:
+      cifmw_architecture_scenario: bgp_dt05
+- job:
+    files:
     - automation/mocks/bmo01.yaml
     - automation/net-env/bmo01.yaml
     - dt/bmo01


### PR DESCRIPTION
A new bgp_dt05 example based on bgp_dt01. In this deployment all leafs and edpm nodes are on the same ASN. The number of nodes has not changed from bgp_dt01. 
The control plane is using BGP to advertise control plane IPs. This topology will be used for testing BGP EVPN advertising where dataplane traffic will establish VXLAN tunnels for dataplane traffic

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4055

Related: [OSPRH-32310](https://redhat.atlassian.net/browse/OSPRH-32310)
Assisted-By: Claude Code