### PR TITLE
Enable volume-based Octavia amphora on uni07eta

### DIFF
--- a/examples/dt/uni07eta/control-plane/service-values.yaml
+++ b/examples/dt/uni07eta/control-plane/service-values.yaml
@@ -84,24 +84,28 @@ data:
       customServiceConfig: |
         [controller_worker]
         loadbalancer_topology=ACTIVE_STANDBY
+        volume_driver=volume_cinder_driver
     octaviaHousekeeping:
       networkAttachments:
         - octavia
       customServiceConfig: |
         [controller_worker]
         loadbalancer_topology=ACTIVE_STANDBY
+        volume_driver=volume_cinder_driver
     octaviaHealthManager:
       networkAttachments:
         - octavia
       customServiceConfig: |
         [controller_worker]
         loadbalancer_topology=ACTIVE_STANDBY
+        volume_driver=volume_cinder_driver
     octaviaWorker:
       networkAttachments:
         - octavia
       customServiceConfig: |
         [controller_worker]
         loadbalancer_topology=ACTIVE_STANDBY
+        volume_driver=volume_cinder_driver
 
   ovn:
     ovnController:


### PR DESCRIPTION
Enable Octavia `volume_cinder_driver` on uni07eta so amphorae boot from Cinder volumes.