### PR TITLE
Fix invalid nexthop IP with stray unicode characters

### DIFF
--- a/examples/dt/bgp-l3-xl/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/networking/nncp/values.yaml
@@ -506,7 +506,7 @@ data:
           - destination: 192.168.122.0/24
             nexthop: 192.168.123.1
           - destination: 192.168.124.0/24
-            nexthop: 192.168.123.1ØØ
+            nexthop: 192.168.123.1
       - allocationRanges:
           - end: 192.168.124.120
             start: 192.168.124.100

--- a/examples/dt/bgp_dt01/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/bgp_dt01/control-plane/networking/nncp/values.yaml
@@ -159,7 +159,7 @@ data:
           - destination: 192.168.122.0/24
             nexthop: 192.168.123.1
           - destination: 192.168.124.0/24
-            nexthop: 192.168.123.1ØØ
+            nexthop: 192.168.123.1
       - allocationRanges:
           - end: 192.168.124.120
             start: 192.168.124.100

--- a/examples/dt/dz-storage/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/dz-storage/control-plane/networking/nncp/values.yaml
@@ -264,7 +264,7 @@ data:
           - destination: 192.168.122.0/24
             nexthop: 192.168.123.1
           - destination: 192.168.124.0/24
-            nexthop: 192.168.123.1ØØ
+            nexthop: 192.168.123.1
       - allocationRanges:
           - end: 192.168.124.120
             start: 192.168.124.100


### PR DESCRIPTION
Remove ØØ characters appended to nexthop 192.168.123.1 in subnet1 routes across bgp_dt01, bgp-l3-xl, and dz-storage NNCP values.

Assisted-By: Claude Code