### PR TITLE
Replace hardcoded bare-metal root password with CHANGEME placeholder

### DIFF
--- a/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset/baremetalset-password-secret.yaml
+++ b/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset/baremetalset-password.env
+++ b/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset/kustomization.yaml
+++ b/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset/kustomization.yaml
@@ -17,27 +17,21 @@ transformers:
       kind: Namespace
       create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
   - nova_ovs_dpdk_sriov.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-
   # Nova compute CPU pinning customization
   - source:
       kind: ConfigMap

--- a/dt/nova/nova01alpha/edpm/nodeset/baremetalset-password-secret.yaml
+++ b/dt/nova/nova01alpha/edpm/nodeset/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/dt/nova/nova01alpha/edpm/nodeset/baremetalset-password.env
+++ b/dt/nova/nova01alpha/edpm/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/dt/nova/nova01alpha/edpm/nodeset/kustomization.yaml
+++ b/dt/nova/nova01alpha/edpm/nodeset/kustomization.yaml
@@ -17,27 +17,21 @@ transformers:
       kind: Namespace
       create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
   - nova_sriov.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-
   # Nova compute CPU pinning customization
   - source:
       kind: ConfigMap

--- a/dt/nova/nova02beta/edpm/nodeset/baremetalset-password-secret.yaml
+++ b/dt/nova/nova02beta/edpm/nodeset/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/dt/nova/nova02beta/edpm/nodeset/baremetalset-password.env
+++ b/dt/nova/nova02beta/edpm/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/dt/nova/nova02beta/edpm/nodeset/kustomization.yaml
+++ b/dt/nova/nova02beta/edpm/nodeset/kustomization.yaml
@@ -17,27 +17,21 @@ transformers:
       kind: Namespace
       create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
   - nova_sriov.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-
   # Nova compute CPU pinning customization
   - source:
       kind: ConfigMap

--- a/dt/nova/nova02beta/edpm/nodeset2/baremetalset-password-secret.yaml
+++ b/dt/nova/nova02beta/edpm/nodeset2/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/dt/nova/nova02beta/edpm/nodeset2/baremetalset-password.env
+++ b/dt/nova/nova02beta/edpm/nodeset2/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/dt/nova/nova02beta/edpm/nodeset2/kustomization.yaml
+++ b/dt/nova/nova02beta/edpm/nodeset2/kustomization.yaml
@@ -17,27 +17,21 @@ transformers:
       kind: Namespace
       create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
   - nova_sriov.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-
   # Nova compute CPU pinning customization
   - source:
       kind: ConfigMap

--- a/dt/nova/nova04delta/edpm/nodeset/baremetalset-password.env
+++ b/dt/nova/nova04delta/edpm/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/dt/nova/nova04delta/edpm/nodeset/kustomization.yaml
+++ b/dt/nova/nova04delta/edpm/nodeset/kustomization.yaml
@@ -20,8 +20,8 @@ transformers:
 secretGenerator:
   - name: baremetalset-password-secret
     behavior: create
-    literals:
-      - NodeRootPassword=redhat
+    envs:
+      - baremetalset-password.env
     options:
       disableNameSuffixHash: true
 
@@ -81,19 +81,6 @@ replacements:
           name: openstack-edpm
         fieldPaths:
           - spec.baremetalSetTemplate
-        options:
-          create: true
-  # BMO root password for provisioned host
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
         options:
           create: true
   # BMO networkData for provisioned host

--- a/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/baremetalset-password.env
+++ b/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/kustomization.yaml
+++ b/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/kustomization.yaml
@@ -20,8 +20,8 @@ transformers:
 secretGenerator:
   - name: baremetalset-password-secret
     behavior: create
-    literals:
-      - NodeRootPassword=redhat
+    envs:
+      - baremetalset-password.env
     options:
       disableNameSuffixHash: true
 
@@ -90,19 +90,6 @@ replacements:
           kind: OpenStackDataPlaneNodeSet
         fieldPaths:
           - spec.baremetalSetTemplate
-        options:
-          create: true
-  # BMO root password for provisioned host
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
         options:
           create: true
   # BMO networkData for provisioned host

--- a/dt/perfscale/scalelab/edpm/nodeset/baremetalset-password.env
+++ b/dt/perfscale/scalelab/edpm/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/dt/perfscale/scalelab/edpm/nodeset/kustomization.yaml
+++ b/dt/perfscale/scalelab/edpm/nodeset/kustomization.yaml
@@ -17,6 +17,14 @@ transformers:
         kind: Namespace
         create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/nodeset
 
@@ -27,17 +35,3 @@ patches:
     patch: |
       - op: remove
         path: /data/authorized_keys
-
-replacements:
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset/values.yaml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset2/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset2/values.yaml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset/values.yaml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/dataplane.md
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/dataplane.md
@@ -17,6 +17,11 @@ Change to the `nfv/nfv-ovs-dpdk-sriov-networker/edpm directory:
 cd examples/dt/nfv/nfv-ovs-dpdk-sriov-networker
 ```
 
+Modify the [baremetalset-password.env](../../../../va/nfv/ovs-dpdk-sriov/edpm/nodeset/baremetalset-password.env) and [baremetalset-password.env](../../../../va/nfv/ovs-dpdk-sriov/edpm/networker-nodeset/baremetalset-password.env) with a secure root password for bare-metal provisioning:
+```
+NodeRootPassword=YourSecurePasswordHere
+```
+
 Edit the [edpm/computes/values.yaml](edpm/computes/values.yaml), 
 [edpm/networkers/values.yaml](edpm/networkers/values.yaml) and
 [edpm/deployment/values.yaml](edpm/deployment/values.yaml) files to suit your

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/computes/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/computes/values.yaml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/networkers/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/networkers/values.yaml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/dt/nova/nova01alpha/dataplane.md
+++ b/examples/dt/nova/nova01alpha/dataplane.md
@@ -14,6 +14,12 @@ Change to the nova/nova01alpha/edpm directory
 ```
 cd architecture/examples/dt/nova/nova01alpha/edpm/
 ```
+
+Modify the [baremetalset-password.env](../../../../dt/nova/nova01alpha/edpm/nodeset/baremetalset-password.env) with a secure root password for bare-metal provisioning:
+```
+NodeRootPassword=YourSecurePasswordHere
+```
+
 Edit the [nodeset/values.yaml](edpm/nodeset/values.yaml) and [deployment/values.yaml](edpm/deployment/values.yaml) files to suit 
 your environment.
 ```

--- a/examples/dt/nova/nova01alpha/edpm/nodeset/values.yaml
+++ b/examples/dt/nova/nova01alpha/edpm/nodeset/values.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/dt/nova/nova02beta/dataplane.md
+++ b/examples/dt/nova/nova02beta/dataplane.md
@@ -14,6 +14,12 @@ Change to the nova/nova02beta/edpm directory
 ```
 cd architecture/examples/dt/nova/nova02beta/edpm/
 ```
+
+Modify the [baremetalset-password.env](../../../../dt/nova/nova02beta/edpm/nodeset/baremetalset-password.env) and [baremetalset-password.env](../../../../dt/nova/nova02beta/edpm/nodeset2/baremetalset-password.env) with a secure root password for bare-metal provisioning:
+```
+NodeRootPassword=YourSecurePasswordHere
+```
+
 Edit the [nodeset/values.yaml](edpm/nodeset/values.yaml), the [nodeset2/values.yaml](edpm/nodeset2/values.yaml), 
 and [deployment/values.yaml](edpm/deployment/values.yaml) files to suit 
 your environment.

--- a/examples/dt/nova/nova02beta/edpm/nodeset/values.yaml
+++ b/examples/dt/nova/nova02beta/edpm/nodeset/values.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/dt/nova/nova02beta/edpm/nodeset2/values.yaml
+++ b/examples/dt/nova/nova02beta/edpm/nodeset2/values.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/dt/nova/nova04delta/data-plane.md
+++ b/examples/dt/nova/nova04delta/data-plane.md
@@ -14,6 +14,12 @@ Change to the nova/nova04delta directory
 ```
 cd architecture/examples/dt/nova/nova04delta
 ```
+
+Modify the [baremetalset-password.env](../../../../dt/nova/nova04delta/edpm/nodeset/baremetalset-password.env) with a secure root password for bare-metal provisioning:
+```
+NodeRootPassword=YourSecurePasswordHere
+```
+
 Edit the [edpm/nodeset/values.yaml](edpm/nodeset/values.yaml)
 file to suit your environment.
 ```

--- a/examples/dt/nova/nova04delta/edpm/nodeset/values.yaml
+++ b/examples/dt/nova/nova04delta/edpm/nodeset/values.yaml
@@ -8,8 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  # Mapped in dt/nova/nova04delta/edpm/nodeset/kustomization.yaml to baremetalset-password-secret.data.NodeRootPassword
-  root_password: cmVkaGF0Cg==
   # Mapped in dt/nova/nova04delta/edpm/nodeset/kustomization.yaml to OpenStackDataPlaneNodeSet.spec.preProvisioned
   preProvisioned: false
   # Mapped in dt/nova/nova04delta/edpm/nodeset/kustomization.yaml to edpm-compute-0-network-data Secret

--- a/examples/dt/nova/nova05epsilon/dataplane-pre-ceph.md
+++ b/examples/dt/nova/nova05epsilon/dataplane-pre-ceph.md
@@ -18,6 +18,11 @@ Change to the nova05epsilon directory
 cd architecture/examples/dt/nova/nova05epsilon
 ```
 
+Modify the [baremetalset-password.env](../../../../dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/baremetalset-password.env) with a secure root password for bare-metal provisioning:
+```
+NodeRootPassword=YourSecurePasswordHere
+```
+
 Edit the [edpm-pre-ceph/nodeset/values.yaml](edpm-pre-ceph/nodeset/values.yaml)
 file to suit your environment.
 

--- a/examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/nova/nova05epsilon/edpm-pre-ceph/nodeset/values.yaml
@@ -14,7 +14,6 @@ metadata:
     config.kubernetes.io/local-config: "true"
 data:
   nodeset_name: gpu-computes-edpm
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalHostsNetworkData:
     edpm-compute-0:

--- a/examples/dt/perfscale/scalelab/edpm/nodeset/values.yaml
+++ b/examples/dt/perfscale/scalelab/edpm/nodeset/values.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: true
   ssh_keys:
     # Authorized keys that will have access to the dataplane computes via SSH

--- a/examples/va/nfv/ovs-dpdk-networker/dataplane.md
+++ b/examples/va/nfv/ovs-dpdk-networker/dataplane.md
@@ -14,6 +14,12 @@ Change to the nfv/ovs-dpdk-networker/networker directory
 ```
 cd architecture/examples/va/nfv/ovs-dpdk-networker/networker
 ```
+
+Modify the [baremetalset-password.env](../../../../va/nfv/ovs-dpdk-networker/networker/nodeset/baremetalset-password.env) with a secure root password for bare-metal provisioning:
+```
+NodeRootPassword=YourSecurePasswordHere
+```
+
 Edit the [nodeset/values.yaml](networker/nodeset/values.yaml) file to suit
 your environment.
 ```

--- a/examples/va/nfv/ovs-dpdk-networker/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-networker/edpm/nodeset/values.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/va/nfv/ovs-dpdk-networker/networker/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-networker/networker/nodeset/values.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/va/nfv/ovs-dpdk-sriov/dataplane.md
+++ b/examples/va/nfv/ovs-dpdk-sriov/dataplane.md
@@ -14,6 +14,12 @@ Change to the nfv/ovs-dpdk-sriov/edpm directory
 ```
 cd architecture/examples/va/nfv/ovs-dpdk-sriov/edpm
 ```
+
+Modify the [baremetalset-password.env](../../../../va/nfv/ovs-dpdk-sriov/edpm/nodeset/baremetalset-password.env) with a secure root password for bare-metal provisioning:
+```
+NodeRootPassword=YourSecurePasswordHere
+```
+
 Edit the [nodeset/values.yaml](nodeset/values.yaml) and [deployment/values.yaml](deployment/values.yaml) files to suit 
 your environment.
 ```

--- a/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/va/nfv/ovs-dpdk/dataplane.md
+++ b/examples/va/nfv/ovs-dpdk/dataplane.md
@@ -14,6 +14,12 @@ Change to the nfv/ovs-dpdk/edpm directory
 ```
 cd architecture/examples/va/nfv/ovs-dpdk/edpm
 ```
+
+Modify the [baremetalset-password.env](../../../../va/nfv/ovs-dpdk/edpm/nodeset/baremetalset-password.env) with a secure root password for bare-metal provisioning:
+```
+NodeRootPassword=YourSecurePasswordHere
+```
+
 Edit the [nodeset/values.yaml](edpm/nodeset/values.yaml) and [deployment/values.yaml](edpm/deployment/values.yaml) files to suit
 your environment.
 ```

--- a/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/va/nfv/sriov/dataplane.md
+++ b/examples/va/nfv/sriov/dataplane.md
@@ -14,6 +14,12 @@ Change to the nfv/sriov/edpm directory
 ```
 cd architecture/examples/va/nfv/sriov/edpm
 ```
+
+Modify the [baremetalset-password.env](../../../../va/nfv/sriov/edpm/nodeset/baremetalset-password.env) with a secure root password for bare-metal provisioning:
+```
+NodeRootPassword=YourSecurePasswordHere
+```
+
 Edit the [nodeset/values.yaml](nodeset/values.yaml) and [deployment/values.yaml](deployment/values.yaml) files to suit 
 your environment.
 ```

--- a/examples/va/nfv/sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/sriov/edpm/nodeset/values.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/va/nvidia-mdev/edpm-pre.md
+++ b/examples/va/nvidia-mdev/edpm-pre.md
@@ -14,6 +14,12 @@ Change to the nvidia-mdev/edpm directory
 ```
 cd architecture/examples/va/nvidia-mdev/edpm
 ```
+
+Modify the [baremetalset-password.env](../../../va/nvidia-mdev/edpm/nodeset/baremetalset-password.env) with a secure root password for bare-metal provisioning:
+```
+NodeRootPassword=YourSecurePasswordHere
+```
+
 Edit the [nodeset/values.yaml](edpm/nodeset/values.yaml) and [deployment/values.yaml](edpm/deployment/values.yaml) files to suit your environment.
 ```
 vi nodeset/values.yaml

--- a/examples/va/nvidia-mdev/edpm/nodeset/kustomization.yaml
+++ b/examples/va/nvidia-mdev/edpm/nodeset/kustomization.yaml
@@ -15,18 +15,6 @@ replacements:
   - source:
       kind: ConfigMap
       name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
       fieldPath: data.preProvisioned
     targets:
       - select:

--- a/examples/va/nvidia-mdev/edpm/nodeset/values.yaml
+++ b/examples/va/nvidia-mdev/edpm/nodeset/values.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  root_password: cmVkaGF0Cg==
   preProvisioned: false
   baremetalSetTemplate:
     ctlplaneInterface: eno2  # CHANGEME

--- a/examples/va/nvidia-vfio-passthrough/edpm/nodeset/values.yaml
+++ b/examples/va/nvidia-vfio-passthrough/edpm/nodeset/values.yaml
@@ -8,8 +8,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  # Mapped in va/nvidia-vfio-passthrough/edpm/nodeset/kustomization.yaml to baremetalset-password-secret.data.NodeRootPassword
-  root_password: cmVkaGF0Cg==
   # Mapped in va/nvidia-vfio-passthrough/edpm/nodeset/kustomization.yaml to OpenStackDataPlaneNodeSet.spec.preProvisioned
   preProvisioned: false
   # Mapped in va/nvidia-vfio-passthrough/edpm/nodeset/kustomization.yaml to edpm-compute-0-network-data Secret

--- a/va/nfv/ovs-dpdk-networker/edpm/nodeset/baremetalset-password-secret.yaml
+++ b/va/nfv/ovs-dpdk-networker/edpm/nodeset/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/va/nfv/ovs-dpdk-networker/edpm/nodeset/baremetalset-password.env
+++ b/va/nfv/ovs-dpdk-networker/edpm/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/va/nfv/ovs-dpdk-networker/edpm/nodeset/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-networker/edpm/nodeset/kustomization.yaml
@@ -17,27 +17,21 @@ transformers:
         kind: Namespace
         create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
   - nova_ovs_dpdk.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-
   # Nova compute CPU pinning customization
   - source:
       kind: ConfigMap

--- a/va/nfv/ovs-dpdk-networker/networker/nodeset/baremetalset-password-secret.yaml
+++ b/va/nfv/ovs-dpdk-networker/networker/nodeset/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/va/nfv/ovs-dpdk-networker/networker/nodeset/baremetalset-password.env
+++ b/va/nfv/ovs-dpdk-networker/networker/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/va/nfv/ovs-dpdk-networker/networker/nodeset/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-networker/networker/nodeset/kustomization.yaml
@@ -17,26 +17,20 @@ transformers:
         kind: Namespace
         create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/networker-nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: networker-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-
   - source:
       kind: ConfigMap
       name: networker-nodeset-values

--- a/va/nfv/ovs-dpdk-sriov/edpm/networker-nodeset/baremetalset-password-secret.yaml
+++ b/va/nfv/ovs-dpdk-sriov/edpm/networker-nodeset/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/va/nfv/ovs-dpdk-sriov/edpm/networker-nodeset/baremetalset-password.env
+++ b/va/nfv/ovs-dpdk-sriov/edpm/networker-nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/va/nfv/ovs-dpdk-sriov/edpm/networker-nodeset/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-sriov/edpm/networker-nodeset/kustomization.yaml
@@ -17,26 +17,20 @@ transformers:
       kind: Namespace
       create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/networker-nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: networker-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-
   - source:
       kind: ConfigMap
       name: networker-nodeset-values

--- a/va/nfv/ovs-dpdk-sriov/edpm/nodeset/baremetalset-password-secret.yaml
+++ b/va/nfv/ovs-dpdk-sriov/edpm/nodeset/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/va/nfv/ovs-dpdk-sriov/edpm/nodeset/baremetalset-password.env
+++ b/va/nfv/ovs-dpdk-sriov/edpm/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/va/nfv/ovs-dpdk-sriov/edpm/nodeset/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-sriov/edpm/nodeset/kustomization.yaml
@@ -17,27 +17,21 @@ transformers:
       kind: Namespace
       create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
   - nova_ovs_dpdk_sriov.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-
   # Nova compute CPU pinning customization
   - source:
       kind: ConfigMap

--- a/va/nfv/ovs-dpdk/edpm/nodeset/baremetalset-password-secret.yaml
+++ b/va/nfv/ovs-dpdk/edpm/nodeset/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/va/nfv/ovs-dpdk/edpm/nodeset/baremetalset-password.env
+++ b/va/nfv/ovs-dpdk/edpm/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/va/nfv/ovs-dpdk/edpm/nodeset/kustomization.yaml
+++ b/va/nfv/ovs-dpdk/edpm/nodeset/kustomization.yaml
@@ -17,27 +17,21 @@ transformers:
         kind: Namespace
         create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
   - nova_ovs_dpdk.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-
   # Nova compute CPU pinning customization
   - source:
       kind: ConfigMap

--- a/va/nfv/sriov/edpm/nodeset/baremetalset-password-secret.yaml
+++ b/va/nfv/sriov/edpm/nodeset/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/va/nfv/sriov/edpm/nodeset/baremetalset-password.env
+++ b/va/nfv/sriov/edpm/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/va/nfv/sriov/edpm/nodeset/kustomization.yaml
+++ b/va/nfv/sriov/edpm/nodeset/kustomization.yaml
@@ -17,27 +17,21 @@ transformers:
       kind: Namespace
       create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../../lib/dataplane/nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
   - nova_sriov.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
-
   # Nova compute CPU pinning customization
   - source:
       kind: ConfigMap

--- a/va/nvidia-mdev/edpm/nodeset/baremetalset-password-secret.yaml
+++ b/va/nvidia-mdev/edpm/nodeset/baremetalset-password-secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-data:
-  NodeRootPassword: _replaced_
-kind: Secret
-metadata:
-  name: baremetalset-password-secret
-  namespace: openstack
-type: Opaque

--- a/va/nvidia-mdev/edpm/nodeset/baremetalset-password.env
+++ b/va/nvidia-mdev/edpm/nodeset/baremetalset-password.env
@@ -1,0 +1,1 @@
+NodeRootPassword=CHANGEME

--- a/va/nvidia-mdev/edpm/nodeset/kustomization.yaml
+++ b/va/nvidia-mdev/edpm/nodeset/kustomization.yaml
@@ -17,26 +17,21 @@ transformers:
       kind: Namespace
       create: true
 
+secretGenerator:
+  - name: baremetalset-password-secret
+    behavior: create
+    envs:
+      - baremetalset-password.env
+    options:
+      disableNameSuffixHash: true
+
 components:
   - ../../../../lib/dataplane/nodeset
 
 resources:
-  - baremetalset-password-secret.yaml
   - nova_sriov.yaml
 
 replacements:
-  - source:
-      kind: ConfigMap
-      name: edpm-nodeset-values
-      fieldPath: data.root_password
-    targets:
-      - select:
-          kind: Secret
-          name: baremetalset-password-secret
-        fieldPaths:
-          - data.NodeRootPassword
-        options:
-          create: true
   - source:
       kind: ConfigMap
       name: edpm-nodeset-values


### PR DESCRIPTION
Removed hardcoded redhat password (CWE-798) from 18 values.yaml files and converted to .env file pattern following bmo01 approach. Operators must now set a secure password in baremetalset-password.env before deployment. Updated 10 deployment docs to document the new requirement.

Closes: [OSPRH-33539](https://redhat.atlassian.net/browse/OSPRH-33539)