### PR TITLE
[DNM] Add per-zone Nova cells (cell1/cell2/cell3) to dz-storage DT

### DIFF
--- a/examples/dt/dz-storage/control-plane/service-values.yaml
+++ b/examples/dt/dz-storage/control-plane/service-values.yaml
@@ -440,17 +440,16 @@ data:
       [DEFAULT]
       default_schedule_zone=az0
     metadataServiceTemplate:
-      enabled: true
-      # if cells per zone, set false
-      # enabled: false
+      # Set to true only when not deploying cells per zone
+      # enabled: true
+      enabled: false
     cellTemplates:
       cell0:
         cellDatabaseAccount: nova-cell0
         hasAPIAccess: true
-      # if cells per zone, uncomment topologyRef
       cell1:
-        # topologyRef:
-        #   name: azone-node-affinity
+        topologyRef:
+          name: azone-node-affinity
         cellDatabaseInstance: openstack-cell1
         cellDatabaseAccount: nova-cell1
         messagingBus:
@@ -458,37 +457,35 @@ data:
         conductorServiceTemplate:
           replicas: 1
         hasAPIAccess: true
-        # if cells per zone, uncomment to deploy metadataService per zone
-        # metadataServiceTemplate:
-        #   enabled: true
-        #   replicas: 3
-        # if cells per zone, uncomment cell2 and cell3
-        # cell2:
-        #   topologyRef:
-        #     name: bzone-node-affinity
-        #   cellDatabaseInstance: openstack-cell2
-        #   cellDatabaseAccount: nova-cell2
-        #   messagingBus:
-        #     cluster: rabbitmq-cell2
-        #   conductorServiceTemplate:
-        #     replicas: 1
-        #   hasAPIAccess: true
-        #   metadataServiceTemplate:
-        #     enabled: true
-        #     replicas: 3
-        # cell3:
-        #   topologyRef:
-        #     name: czone-node-affinity
-        #   cellDatabaseInstance: openstack-cell3
-        #   cellDatabaseAccount: nova-cell3
-        #   messagingBus:
-        #     cluster: rabbitmq-cell3
-        #   conductorServiceTemplate:
-        #     replicas: 1
-        #   hasAPIAccess: true
-        #   metadataServiceTemplate:
-        #     enabled: true
-        #     replicas: 3
+        metadataServiceTemplate:
+          enabled: true
+          replicas: 3
+      cell2:
+        topologyRef:
+          name: bzone-node-affinity
+        cellDatabaseInstance: openstack-cell2
+        cellDatabaseAccount: nova-cell2
+        messagingBus:
+          cluster: rabbitmq-cell2
+        conductorServiceTemplate:
+          replicas: 1
+        hasAPIAccess: true
+        metadataServiceTemplate:
+          enabled: true
+          replicas: 3
+      cell3:
+        topologyRef:
+          name: czone-node-affinity
+        cellDatabaseInstance: openstack-cell3
+        cellDatabaseAccount: nova-cell3
+        messagingBus:
+          cluster: rabbitmq-cell3
+        conductorServiceTemplate:
+          replicas: 1
+        hasAPIAccess: true
+        metadataServiceTemplate:
+          enabled: true
+          replicas: 3
   rabbitmq:
     templates:
       rabbitmq:
@@ -511,34 +508,32 @@ data:
             spec:
               type: LoadBalancer
         replicas: 3
-        # if cells per zone, uncomment topologyRef
-        # topologyRef:
-        #   name: azone-node-affinity
-        # if cells per zone, uncomment cell2 and cell2
-        # rabbitmq-cell2:
-        #   override:
-        #     service:
-        #       metadata:
-        #         annotations:
-        #           metallb.universe.tf/address-pool: internalapi
-        #           metallb.universe.tf/loadBalancerIPs: 172.17.0.87
-        #       spec:
-        #         type: LoadBalancer
-        #   replicas: 3
-        #   topologyRef:
-        #     name: bzone-node-affinity
-        # rabbitmq-cell3:
-        #   override:
-        #     service:
-        #       metadata:
-        #         annotations:
-        #           metallb.universe.tf/address-pool: internalapi
-        #           metallb.universe.tf/loadBalancerIPs: 172.17.0.88
-        #       spec:
-        #         type: LoadBalancer
-        #   replicas: 3
-        #   topologyRef:
-        #     name: czone-node-affinity
+        topologyRef:
+          name: azone-node-affinity
+      rabbitmq-cell2:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.87
+            spec:
+              type: LoadBalancer
+        replicas: 3
+        topologyRef:
+          name: bzone-node-affinity
+      rabbitmq-cell3:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.88
+            spec:
+              type: LoadBalancer
+        replicas: 3
+        topologyRef:
+          name: czone-node-affinity
   galera:
     templates:
       openstack:
@@ -549,15 +544,14 @@ data:
         replicas: 3
         secret: osp-secret
         storageRequest: 5Gi
-        # if cells per zone, uncomment cell1 and cell3
-        # openstack-cell2:
-        #   replicas: 3
-        #   secret: osp-secret
-        #   storageRequest: 5Gi
-        # openstack-cell3:
-        #   replicas: 3
-        #   secret: osp-secret
-        #   storageRequest: 5Gi
+      openstack-cell2:
+        replicas: 3
+        secret: osp-secret
+        storageRequest: 5Gi
+      openstack-cell3:
+        replicas: 3
+        secret: osp-secret
+        storageRequest: 5Gi
 
   # Cinder volume secrets
   cinder-volume-secrets-az0: |

--- a/examples/dt/dz-storage/edpm/computes/r0/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r0/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - values.yaml
   - nova-extra-config-az0.yaml
   - nova-custom-az0.yaml
+  - neutron-metadata-az0.yaml
 
 patches:
   - target:

--- a/examples/dt/dz-storage/edpm/computes/r0/neutron-metadata-az0.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r0/neutron-metadata-az0.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: neutron-metadata-az0
+spec:
+  addCertMounts: false
+  caCerts: combined-ca-bundle
+  containerImageFields:
+    - EdpmNeutronMetadataAgentImage
+  dataSources:
+    - secretRef:
+        name: neutron-ovn-metadata-agent-neutron-config
+    - secretRef:
+        name: nova-cell1-metadata-neutron-config
+  edpmServiceType: neutron-metadata
+  playbook: osp.edpm.neutron_metadata
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      issuer: osp-rootca-issuer-ovn
+      keyUsages:
+        - digital signature
+        - key encipherment
+        - client auth
+      networks:
+        - ctlplane

--- a/examples/dt/dz-storage/edpm/computes/r0/values.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r0/values.yaml
@@ -179,7 +179,7 @@ data:
       - reboot-os
       - install-certs
       - ovn
-      - neutron-metadata
+      - neutron-metadata-az0
       - ovn-bgp-agent
       - libvirt
       - nova-custom-az0

--- a/examples/dt/dz-storage/edpm/computes/r1/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r1/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - values.yaml
   - nova-extra-config-az1.yaml
   - nova-custom-az1.yaml
+  - neutron-metadata-az1.yaml
 
 patches:
   - target:

--- a/examples/dt/dz-storage/edpm/computes/r1/neutron-metadata-az1.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r1/neutron-metadata-az1.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: neutron-metadata-az1
+spec:
+  addCertMounts: false
+  caCerts: combined-ca-bundle
+  containerImageFields:
+    - EdpmNeutronMetadataAgentImage
+  dataSources:
+    - secretRef:
+        name: neutron-ovn-metadata-agent-neutron-config
+    - secretRef:
+        name: nova-cell2-metadata-neutron-config
+  edpmServiceType: neutron-metadata
+  playbook: osp.edpm.neutron_metadata
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      issuer: osp-rootca-issuer-ovn
+      keyUsages:
+        - digital signature
+        - key encipherment
+        - client auth
+      networks:
+        - ctlplane

--- a/examples/dt/dz-storage/edpm/computes/r1/nova-custom-az1.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r1/nova-custom-az1.yaml
@@ -14,7 +14,7 @@ spec:
     - secretRef:
         name: nova-migration-ssh-key
     - secretRef:
-        name: nova-cell1-compute-config
+        name: nova-cell2-compute-config
   tlsCerts:
     default:
       contents:

--- a/examples/dt/dz-storage/edpm/computes/r1/values.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r1/values.yaml
@@ -179,7 +179,7 @@ data:
       - reboot-os
       - install-certs
       - ovn
-      - neutron-metadata
+      - neutron-metadata-az1
       - ovn-bgp-agent
       - libvirt
       - nova-custom-az1

--- a/examples/dt/dz-storage/edpm/computes/r2/kustomization.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r2/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - values.yaml
   - nova-extra-config-az2.yaml
   - nova-custom-az2.yaml
+  - neutron-metadata-az2.yaml
 
 patches:
   - target:

--- a/examples/dt/dz-storage/edpm/computes/r2/neutron-metadata-az2.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r2/neutron-metadata-az2.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: neutron-metadata-az2
+spec:
+  addCertMounts: false
+  caCerts: combined-ca-bundle
+  containerImageFields:
+    - EdpmNeutronMetadataAgentImage
+  dataSources:
+    - secretRef:
+        name: neutron-ovn-metadata-agent-neutron-config
+    - secretRef:
+        name: nova-cell3-metadata-neutron-config
+  edpmServiceType: neutron-metadata
+  playbook: osp.edpm.neutron_metadata
+  tlsCerts:
+    default:
+      contents:
+        - dnsnames
+        - ips
+      issuer: osp-rootca-issuer-ovn
+      keyUsages:
+        - digital signature
+        - key encipherment
+        - client auth
+      networks:
+        - ctlplane

--- a/examples/dt/dz-storage/edpm/computes/r2/nova-custom-az2.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r2/nova-custom-az2.yaml
@@ -14,7 +14,7 @@ spec:
     - secretRef:
         name: nova-migration-ssh-key
     - secretRef:
-        name: nova-cell1-compute-config
+        name: nova-cell3-compute-config
   tlsCerts:
     default:
       contents:

--- a/examples/dt/dz-storage/edpm/computes/r2/values.yaml
+++ b/examples/dt/dz-storage/edpm/computes/r2/values.yaml
@@ -179,7 +179,7 @@ data:
       - reboot-os
       - install-certs
       - ovn
-      - neutron-metadata
+      - neutron-metadata-az2
       - ovn-bgp-agent
       - libvirt
       - nova-custom-az2


### PR DESCRIPTION
Introduce Nova cells to dz-storage, making each availability zone 
its own cell with its own conductor, Galera database, and RabbitMQ cluster, 
and point each AZ's compute nodeset at its own 
cell's nova-cell[N]-compute-config secret so hosts land in the correct cell.

Signed-off-by: Gais Ameer <gameer@redhat.com>