### PR TITLE
NFV: add metricStorage kustomize replacements for full config

### DIFF
--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/service-values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/service-values.yaml
@@ -64,7 +64,16 @@ data:
       ceilometer:
         enabled: true
       metricStorage:
+        dashboardsEnabled: true
         enabled: true
+        monitoringStack:
+          alertingEnabled: true
+          scrapeInterval: 30s
+          storage:
+            strategy: persistent
+            retention: 24h
+            persistent:
+              pvcStorageRequest: 20G
   extraMounts:
     - name: v1
       region: r1

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-ipv6-2nodesets/service-values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-ipv6-2nodesets/service-values.yaml
@@ -64,7 +64,16 @@ data:
       ceilometer:
         enabled: true
       metricStorage:
+        dashboardsEnabled: true
         enabled: true
+        monitoringStack:
+          alertingEnabled: true
+          scrapeInterval: 30s
+          storage:
+            strategy: persistent
+            retention: 24h
+            persistent:
+              pvcStorageRequest: 20G
   extraMounts:
     - name: v1
       region: r1

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/service-values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/service-values.yaml
@@ -66,7 +66,16 @@ data:
       ceilometer:
         enabled: true
       metricStorage:
+        dashboardsEnabled: true
         enabled: true
+        monitoringStack:
+          alertingEnabled: true
+          scrapeInterval: 30s
+          storage:
+            strategy: persistent
+            retention: 24h
+            persistent:
+              pvcStorageRequest: 20G
   extraMounts:
     - name: v1
       region: r1

--- a/examples/va/nfv/ovs-dpdk-networker/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-networker/service-values.yaml
@@ -54,6 +54,17 @@ data:
     template:
       ceilometer:
         enabled: true
+      metricStorage:
+        dashboardsEnabled: true
+        enabled: true
+        monitoringStack:
+          alertingEnabled: true
+          scrapeInterval: 30s
+          storage:
+            strategy: persistent
+            retention: 24h
+            persistent:
+              pvcStorageRequest: 20G
   nova:
     schedulerServiceTemplate:
       customServiceConfig: |

--- a/examples/va/nfv/ovs-dpdk-sriov-ipv6/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov-ipv6/service-values.yaml
@@ -64,7 +64,16 @@ data:
       ceilometer:
         enabled: true
       metricStorage:
+        dashboardsEnabled: true
         enabled: true
+        monitoringStack:
+          alertingEnabled: true
+          scrapeInterval: 30s
+          storage:
+            strategy: persistent
+            retention: 24h
+            persistent:
+              pvcStorageRequest: 20G
   extraMounts:
     - name: v1
       region: r1

--- a/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/service-values.yaml
@@ -64,7 +64,16 @@ data:
       ceilometer:
         enabled: true
       metricStorage:
+        dashboardsEnabled: true
         enabled: true
+        monitoringStack:
+          alertingEnabled: true
+          scrapeInterval: 30s
+          storage:
+            strategy: persistent
+            retention: 24h
+            persistent:
+              pvcStorageRequest: 20G
   extraMounts:
     - name: v1
       region: r1

--- a/examples/va/nfv/ovs-dpdk/service-values.yaml
+++ b/examples/va/nfv/ovs-dpdk/service-values.yaml
@@ -60,6 +60,17 @@ data:
     template:
       ceilometer:
         enabled: true
+      metricStorage:
+        dashboardsEnabled: true
+        enabled: true
+        monitoringStack:
+          alertingEnabled: true
+          scrapeInterval: 30s
+          storage:
+            strategy: persistent
+            retention: 24h
+            persistent:
+              pvcStorageRequest: 20G
   nova:
     schedulerServiceTemplate:
       customServiceConfig: |

--- a/examples/va/nfv/sriov/service-values.yaml
+++ b/examples/va/nfv/sriov/service-values.yaml
@@ -42,6 +42,22 @@ data:
       replicas: 1
   swift:
     enabled: true
+  telemetry:
+    enabled: true
+    template:
+      ceilometer:
+        enabled: true
+      metricStorage:
+        dashboardsEnabled: true
+        enabled: true
+        monitoringStack:
+          alertingEnabled: true
+          scrapeInterval: 30s
+          storage:
+            strategy: persistent
+            retention: 24h
+            persistent:
+              pvcStorageRequest: 20G
   nova:
     schedulerServiceTemplate:
       customServiceConfig: |

--- a/va/nfv/ovs-dpdk-networker/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-networker/kustomization.yaml
@@ -102,3 +102,81 @@ replacements:
           - spec.nova.template.schedulerServiceTemplate.customServiceConfig
         options:
           create: true
+  # Telemetry metric storage for NFV deployments
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.dashboardsEnabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.dashboardsEnabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.alertingEnabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.alertingEnabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.scrapeInterval
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.scrapeInterval
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.strategy
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.strategy
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.retention
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.retention
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageRequest
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageRequest
+        options:
+          create: true

--- a/va/nfv/ovs-dpdk-sriov/kustomization.yaml
+++ b/va/nfv/ovs-dpdk-sriov/kustomization.yaml
@@ -128,7 +128,7 @@ replacements:
           - spec.nova.template.schedulerServiceTemplate.customServiceConfig
         options:
           create: true
-  # Telemetry metric storage toggle for NFV deployments
+  # Telemetry metric storage for NFV deployments
   - source:
       kind: ConfigMap
       name: service-values
@@ -138,5 +138,71 @@ replacements:
           kind: OpenStackControlPlane
         fieldPaths:
           - spec.telemetry.template.metricStorage.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.dashboardsEnabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.dashboardsEnabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.alertingEnabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.alertingEnabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.scrapeInterval
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.scrapeInterval
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.strategy
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.strategy
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.retention
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.retention
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageRequest
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageRequest
         options:
           create: true

--- a/va/nfv/ovs-dpdk/kustomization.yaml
+++ b/va/nfv/ovs-dpdk/kustomization.yaml
@@ -114,3 +114,81 @@ replacements:
           - spec.nova.template.schedulerServiceTemplate.customServiceConfig
         options:
           create: true
+  # Telemetry metric storage for NFV deployments
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.dashboardsEnabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.dashboardsEnabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.alertingEnabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.alertingEnabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.scrapeInterval
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.scrapeInterval
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.strategy
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.strategy
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.retention
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.retention
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageRequest
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageRequest
+        options:
+          create: true

--- a/va/nfv/sriov/kustomization.yaml
+++ b/va/nfv/sriov/kustomization.yaml
@@ -92,3 +92,81 @@ replacements:
           - spec.nova.template.schedulerServiceTemplate.customServiceConfig
         options:
           create: true
+  # Telemetry metric storage for NFV deployments
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.enabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.enabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.dashboardsEnabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.dashboardsEnabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.alertingEnabled
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.alertingEnabled
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.scrapeInterval
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.scrapeInterval
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.strategy
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.strategy
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.retention
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.retention
+        options:
+          create: true
+  - source:
+      kind: ConfigMap
+      name: service-values
+      fieldPath: data.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageRequest
+    targets:
+      - select:
+          kind: OpenStackControlPlane
+        fieldPaths:
+          - spec.telemetry.template.metricStorage.monitoringStack.storage.persistent.pvcStorageRequest
+        options:
+          create: true


### PR DESCRIPTION
The NFV kustomizations only mapped metricStorage.enabled from the service-values ConfigMap to the OpenStackControlPlane CR. The remaining fields (dashboardsEnabled, monitoringStack with alerting, scrape interval, and persistent storage) were not mapped, so they were silently ignored during deployment.

This forced NFV CI jobs to use a post-deploy oc-patch hook to configure metricStorage, which caused a race condition: the patch triggered an OpenStackClient operator reconciliation that killed the openstackclient pod while os_net_setup was using it for oc exec.

Add kustomize replacements for all metricStorage fields across all four NFV VA scenarios (ovs-dpdk-sriov, ovs-dpdk, sriov, ovs-dpdk-networker) so the full configuration is applied at deploy time via the service-values ConfigMap.