### PR TITLE
docs: fix remaining typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenStack K8S Operators Architectures
 
-This repository contains templates used a a part of the validated architecture
+This repository contains templates used as part of the validated architecture
 (VA) and deployment topology (DT) effort.
 
 Validated architectures and deployment topologies are represented as kustomize


### PR DESCRIPTION
Changed 'used a part' to 'used as part'. 
This was left out of the earlier one  `docs: fixed typos in README.md - #798`