### PR TITLE
Remove commented edpm_bootstrap_command examples from edpm values

### DIFF
--- a/examples/dt/dcn/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/dcn/edpm-pre-ceph/nodeset/values.yaml
@@ -23,11 +23,6 @@ data:
       ansibleVars:
         timesync_ntp_servers:
           - hostname: clock.redhat.com
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
           edpm-compute-0:

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset/values.yaml
@@ -32,11 +32,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset2/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-2nodesets/edpm/nodeset2/values.yaml
@@ -32,11 +32,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/edpm-pre-ceph/nodeset/values.yaml
@@ -32,11 +32,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: clock.redhat.com
         # CPU pinning settings

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/computes/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/computes/values.yaml
@@ -32,11 +32,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/networkers/values.yaml
+++ b/examples/dt/nfv/nfv-ovs-dpdk-sriov-networker/edpm/networkers/values.yaml
@@ -33,11 +33,6 @@ data:
       ansiblePort: 22
       ansibleVars:
         edpm_enable_chassis_gw: true
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # edpm_network_config

--- a/examples/dt/nova/nova01alpha/edpm/nodeset/values.yaml
+++ b/examples/dt/nova/nova01alpha/edpm/nodeset/values.yaml
@@ -31,10 +31,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/dt/nova/nova02beta/edpm/nodeset/values.yaml
+++ b/examples/dt/nova/nova02beta/edpm/nodeset/values.yaml
@@ -31,10 +31,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/dt/nova/nova02beta/edpm/nodeset2/values.yaml
+++ b/examples/dt/nova/nova02beta/edpm/nodeset2/values.yaml
@@ -31,10 +31,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/dt/osasinfra-ipv6/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/osasinfra-ipv6/edpm-pre-ceph/nodeset/values.yaml
@@ -22,11 +22,6 @@ data:
       ansibleVars:
         timesync_ntp_servers:
           - hostname: pool.ntp.org
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
           edpm-compute-0:

--- a/examples/dt/osasinfra/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/osasinfra/edpm-pre-ceph/nodeset/values.yaml
@@ -22,11 +22,6 @@ data:
       ansibleVars:
         timesync_ntp_servers:
           - hostname: pool.ntp.org
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
           edpm-compute-0:

--- a/examples/dt/perfscale/scalelab/edpm/nodeset/values.yaml
+++ b/examples/dt/perfscale/scalelab/edpm/nodeset/values.yaml
@@ -22,11 +22,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # edpm_network_config

--- a/examples/dt/pidone/edpm/nodeset/values.yaml
+++ b/examples/dt/pidone/edpm/nodeset/values.yaml
@@ -22,11 +22,6 @@ data:
       ansibleVars:
         timesync_ntp_servers:
           - hostname: pool.ntp.org
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
           edpm-compute-0:

--- a/examples/dt/uni04delta-ipv6/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni04delta-ipv6/edpm-pre-ceph/nodeset/values.yaml
@@ -22,11 +22,6 @@ data:
       ansibleVars:
         timesync_ntp_servers:
           - hostname: pool.ntp.org
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
           ---

--- a/examples/dt/uni04delta/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/uni04delta/edpm-pre-ceph/nodeset/values.yaml
@@ -22,11 +22,6 @@ data:
       ansibleVars:
         timesync_ntp_servers:
           - hostname: pool.ntp.org
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
           ---

--- a/examples/dt/vhosts-compact/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/dt/vhosts-compact/edpm-pre-ceph/nodeset/values.yaml
@@ -22,11 +22,6 @@ data:
       ansibleVars:
         timesync_ntp_servers:
           - hostname: pool.ntp.org
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
           edpm-compute-0:

--- a/examples/va/hci-ironic/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/va/hci-ironic/edpm-pre-ceph/nodeset/values.yaml
@@ -35,11 +35,6 @@ data:
       ansibleVars:
         timesync_ntp_servers:
           - hostname: pool.ntp.org
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
           edpm-compute-0:

--- a/examples/va/hci/edpm-pre-ceph/nodeset/values.yaml
+++ b/examples/va/hci/edpm-pre-ceph/nodeset/values.yaml
@@ -22,11 +22,6 @@ data:
       ansibleVars:
         timesync_ntp_servers:
           - hostname: pool.ntp.org
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_os_net_config_mappings:
           edpm-compute-0:

--- a/examples/va/nfv/ovs-dpdk-networker/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-networker/edpm/nodeset/values.yaml
@@ -31,11 +31,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/va/nfv/ovs-dpdk-networker/networker/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-networker/networker/nodeset/values.yaml
@@ -31,11 +31,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk-sriov/edpm/nodeset/values.yaml
@@ -32,11 +32,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/ovs-dpdk/edpm/nodeset/values.yaml
@@ -31,11 +31,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> \
-        #         --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/va/nfv/sriov/edpm/nodeset/values.yaml
+++ b/examples/va/nfv/sriov/edpm/nodeset/values.yaml
@@ -31,10 +31,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings

--- a/examples/va/nvidia-mdev/edpm/nodeset/values.yaml
+++ b/examples/va/nvidia-mdev/edpm/nodeset/values.yaml
@@ -31,10 +31,6 @@ data:
       ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
-        # CHANGEME -- see https://access.redhat.com/solutions/253273
-        # edpm_bootstrap_command: |
-        #       subscription-manager register --username <subscription_manager_username> --password <subscription_manager_password>
-        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # CPU pinning settings


### PR DESCRIPTION
The commented-out `subscription-manager` and `podman login` placeholder blocks guarded by `"CHANGEME"` comments are misleading and do not represent a recommended bootstrap pattern. Remove them from all VA and DT dataplane nodeset values files.